### PR TITLE
Update rspulserender.cpp

### DIFF
--- a/src/rspulserender.cpp
+++ b/src/rspulserender.cpp
@@ -123,7 +123,7 @@ namespace {
       for (unsigned int i = 0; i < wsize; i++) {
 	noise[i] = timing->NextNoiseSample();        
       }
-      std::printf("%g\n", noise[0]);
+      //std::printf("%g\n", noise[0]);
       //Calculate the number of samples to skip
       if (timing->GetSyncOnPulse()) {
 	timing->Reset();


### PR DESCRIPTION
Commented out printf() function for displaying each generated noise value. Presumably was used during debugging.