### PR TITLE
Update rssim.cpp

### DIFF
--- a/src/rssim.cpp
+++ b/src/rssim.cpp
@@ -93,7 +93,7 @@ void SolveRE(const Transmitter *trans, const Receiver *recv, const Target *targ,
   //See "Bistatic Doppler Equation" in doc/equations/equations.tex
   rsFloat V_r = (Rr_end-Rr)/length;
   rsFloat V_t = (Rt_end-Rt)/length;
-  results.doppler = std::sqrt((1-V_r/rsParameters::c())/(1+V_r/rsParameters::c()))*std::sqrt((1-V_t/rsParameters::c())/(1+V_t/rsParameters::c()));
+  results.doppler = std::sqrt((1+V_r/rsParameters::c())/(1-V_r/rsParameters::c()))*std::sqrt((1+V_t/rsParameters::c())/(1-V_t/rsParameters::c()));
   //Step 5, calculate system noise temperature
   //We only use the receive antenna noise temperature for now
   results.noise_temperature = recv->GetNoiseTemperature(recv->GetRotation(time+results.delay));


### PR DESCRIPTION
Based on the Equations document (as well as textbooks I've checked), I believe signs inside the square roots of the Doppler equation should be swapped? I.e. Addition in the numerator and subtraction in the numerator? This form is also seen in the SolveREDirect function, so I assume it's a mistake in SolveRE?

When testing the current version using a monostatic setup, the Doppler shift is computed as negative for an approaching target. This cannot be correct as it implies a negative target velocity towards the radar. So either the signs need to be swapped in the equation above, or (Fc - Fr) in "rsresponse.cpp" should be changed to (Fr - Fc) such that the Doppler is correct.