### PR TITLE
HDF5 file id type to long int and friend defs in namespace

### DIFF
--- a/src/rshdf5.cpp
+++ b/src/rshdf5.cpp
@@ -94,16 +94,16 @@ void rshdf5::ReadPulseData(const std::string &name, std::complex<rsFloat> **data
 }
 
 ///Open the HDF5 file for writing
-int rshdf5::CreateFile(const std::string& name)
+long int rshdf5::CreateFile(const std::string& name)
 {
   hid_t file = H5Fcreate(name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
   if (file < 0)
     throw std::runtime_error("[ERROR] Could not create HDF5 file "+name+" for export");
-  return static_cast<int>(file);
+  return static_cast<long int>(file);
 }
 
 ///Add a dataset to the HDF5 file
-void rshdf5::AddChunkToFile(int file, std::complex<rsFloat> *data, unsigned int size, rsFloat time, rsFloat rate, rsFloat fullscale, unsigned int count)
+void rshdf5::AddChunkToFile(long int file, std::complex<rsFloat> *data, unsigned int size, rsFloat time, rsFloat rate, rsFloat fullscale, unsigned int count)
 {
   //Create the name of the dataset
   std::ostringstream oss;
@@ -146,7 +146,7 @@ void rshdf5::AddChunkToFile(int file, std::complex<rsFloat> *data, unsigned int 
 }
 
 ///Close the HDF5 file
-void rshdf5::CloseFile(int file) {
+void rshdf5::CloseFile(long int file) {
   if (H5Fclose(static_cast<hid_t>(file)) < 0)
     throw std::runtime_error("[ERROR] Error while closing HDF5 file");
 }

--- a/src/rshdf5.h
+++ b/src/rshdf5.h
@@ -10,13 +10,13 @@
 namespace rshdf5 {
 
 ///Open the HDF5 file for writing
-int CreateFile(const std::string& name);
+long int CreateFile(const std::string& name);
 
 ///Add a dataset to the HDF5 file
-void AddChunkToFile(int file, std::complex<rsFloat> *data, unsigned int size, rsFloat time, rsFloat rate, rsFloat fullscale, unsigned int count);
+void AddChunkToFile(long int file, std::complex<rsFloat> *data, unsigned int size, rsFloat time, rsFloat rate, rsFloat fullscale, unsigned int count);
 
 ///Close the HDF5 file
- void CloseFile(int file);
+ void CloseFile(long int file);
 
 /// Read the pulse data from the specified file
  void ReadPulseData(const std::string &name, std::complex<rsFloat> **data, unsigned int &size, rsFloat &rate);

--- a/src/rspath.h
+++ b/src/rspath.h
@@ -120,7 +120,7 @@ private:
   InterpType type; //!< Type of interpolation
   rsPython::PythonPath *pythonpath; //!< Pointer to the PythonPath object
   /// Create a new path which is a reflection of this one around the given plane
-  friend Path* rs::ReflectPath(const Path *path, const MultipathSurface *surf);
+  friend Path* ReflectPath(const Path *path, const MultipathSurface *surf);
 };
 
   /// Create a new path which is a reflection of this one around the given plane
@@ -153,7 +153,7 @@ protected:
 
   InterpType type; //!< Type of interpolation
   /// Create a new path which is a reflection of this one around the given plane
-  friend RotationPath* rs::ReflectPath(const RotationPath *path, const MultipathSurface *surf);
+  friend RotationPath* ReflectPath(const RotationPath *path, const MultipathSurface *surf);
 };
 
   /// Create a new path which is a reflection of this one around the given plane
@@ -169,6 +169,10 @@ class PathException: public std::runtime_error
   }     
 };
 
+}
+namespace rs {
+  Path* ReflectPath(const Path *path, const MultipathSurface *surf);
+  RotationPath* ReflectPath(const RotationPath *path, const MultipathSurface *surf);
 }
 
 #endif

--- a/src/rsplatform.h
+++ b/src/rsplatform.h
@@ -40,7 +40,7 @@ private:
   std::string name; //!< The name of the platform
   Platform *dual; //!< Multipath dual of this platform
   /// Create a dual of this platform for multipath simulation
-  friend Platform* rs::CreateMultipathDual(const Platform *plat, const MultipathSurface *surf);
+  friend Platform* CreateMultipathDual(const Platform *plat, const MultipathSurface *surf);
 };
 
   /// Create a dual of this platform for multipath simulation
@@ -48,4 +48,7 @@ private:
 
 }
 
+namespace rs { 
+  Platform* CreateMultipathDual(const Platform *plat, const MultipathSurface *surf);
+}
 #endif

--- a/src/rspulserender.cpp
+++ b/src/rspulserender.cpp
@@ -35,9 +35,9 @@ using namespace rs;
 namespace {
 
   ///Open the binary file for response export
-  int OpenHDF5File(const std::string &recv_name)
+  long int OpenHDF5File(const std::string &recv_name)
   {
-    int hdf5_file = 0;
+    long int hdf5_file = 0;
     if (rs::rsParameters::export_binary()) {
       //Build the filename for the binary file
       std::ostringstream b_oss;
@@ -169,7 +169,7 @@ namespace {
     if (responses.empty())
       return;
 
-    int out_bin = OpenHDF5File(recv_name);
+    long int out_bin = OpenHDF5File(recv_name);
 
     // Create a threaded render object, to manage the rendering process
     ThreadedRenderer thr_renderer(&responses, recv, rsParameters::render_threads());

--- a/src/rsworld.h
+++ b/src/rsworld.h
@@ -69,7 +69,7 @@ class MultipathSurface;
     ///Process the scene to add virtual receivers and transmitters
     void ProcessMultipath();
     
-    friend void rs::RunThreadedSim(int thread_limit, World *world);
+    friend void RunThreadedSim(int thread_limit, World *world);
     friend void SimulatePair(const Transmitter *trans, Receiver *recv, const World *world);
 
   protected:    
@@ -86,5 +86,8 @@ class MultipathSurface;
 
 }
 
+namespace rs {
+  void RunThreadedSim(int thread_limit, World *world);
+}
 
 #endif


### PR DESCRIPTION
Proposed a fix for #15 where HDF5 library (at least on Ubuntu 20.04) is looking for a long int and cast to an int was causing some problems.  I also had to change the declarations for the friend functions in the namespace for many of the .h files.