### PR TITLE
improve macOS compatibility and build process

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,8 @@
 # PNPM
 pnpm-lock.yaml
 
+.venv
+
 # Build outputs
 build/
 dist/

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ cmake --preset=release
 cmake --build --preset=release
 ```
 
+> [!TIP]
+> On Linux and macOS, you can install the built `fers-cli` release to your system using
+>
+> `cmake --install --preset=release`
+
 ### 5. Run the UI
 
 The UI build process is completely self-contained. When you run the UI, Cargo will automatically invoke CMake to build the C++ backend in an isolated directory.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can configure and compile the C++ libraries directly using CMake presets. Th
 ```bash
 # From the root FERS directory
 cmake --preset=release
-cmake --build build --preset=release
+cmake --build --preset=release
 ```
 
 ### 5. Run the UI

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ VCPKG_ROOT=/path/to/vcpkg
 
 Navigate to the root of the repository and start the development server:
 
+> [!WARNING]
+> The UI is currently in active development and may be unstable. Expect crashes and incomplete features.
+> In particular, there is a known issue causing WebGL context loss on macOS on launch. See https://github.com/davidbits/FERS/issues/181 for details.
+
 ```bash
 bun ui:dev
 ```

--- a/cmake/FersCompilerWarnings.cmake
+++ b/cmake/FersCompilerWarnings.cmake
@@ -22,12 +22,18 @@ function(apply_fers_warnings TARGET_NAME)
 		-Wdouble-promotion
 		-Wformat=2
 		-Wmisleading-indentation
-		-Wduplicated-cond
-		-Wduplicated-branches
-		-Wlogical-op
 	)
 
 	target_compile_options(${TARGET_NAME} PRIVATE ${FERS_GCC_CLANG_WARNINGS})
+
+	# --- GCC-Specific Warnings ---
+	if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		target_compile_options(${TARGET_NAME} PRIVATE
+							   -Wduplicated-cond
+							   -Wduplicated-branches
+							   -Wlogical-op
+		)
+	endif ()
 
 	# --- Common Flags ---
 	target_compile_options(${TARGET_NAME} PRIVATE

--- a/packages/fers-cli/CMakeLists.txt
+++ b/packages/fers-cli/CMakeLists.txt
@@ -8,17 +8,29 @@ apply_fers_warnings(fers-cli)
 
 # Add its own source files
 target_sources(fers-cli PRIVATE
-	src/main.cpp
-	src/arg_parser.cpp
+			   src/main.cpp
+			   src/arg_parser.cpp
 )
 
 # Add include directory for its own headers (arg_parser.h)
 target_include_directories(fers-cli PRIVATE
-	${CMAKE_CURRENT_SOURCE_DIR}/src
+						   ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-# Link against libfers. CMake handles transitive dependencies and include paths.
-target_link_libraries(fers-cli PRIVATE libfers)
+# Link against libfers.
+target_link_libraries(fers-cli PRIVATE fers::fers_static)
+
+# --- Cross-Platform Relocatable RPATH ---
+set_target_properties(fers-cli PROPERTIES
+					  BUILD_WITH_INSTALL_RPATH FALSE
+					  INSTALL_RPATH_USE_LINK_PATH TRUE
+)
+
+if (APPLE)
+	set_target_properties(fers-cli PROPERTIES INSTALL_RPATH "@executable_path/../lib")
+elseif (UNIX)
+	set_target_properties(fers-cli PROPERTIES INSTALL_RPATH "$ORIGIN/../lib")
+endif ()
 
 # Install the executable
 install(TARGETS fers-cli DESTINATION bin)

--- a/packages/fers-ui/src-tauri/build.rs
+++ b/packages/fers-ui/src-tauri/build.rs
@@ -62,6 +62,7 @@ fn main() {
     // for static libraries often omit transitive dependencies like szip and libaec.
     // Order is critical here: Dependents must appear BEFORE their dependencies.
     let vcpkg_libs = [
+        "Geographic",
         "GeographicLib",
         "hdf5_hl_cpp",
         "hdf5_cpp",
@@ -100,9 +101,13 @@ fn main() {
 
     println!("cargo:rerun-if-changed={}", header_path.display());
     println!("cargo:rerun-if-env-changed=VCPKG_ROOT");
+    println!("cargo:rerun-if-changed={}", repo_root.join("vcpkg.json").display());
     println!("cargo:rerun-if-changed={}", repo_root.join("packages/libfers/src").display());
     println!("cargo:rerun-if-changed={}", repo_root.join("packages/libfers/include").display());
-    println!("cargo:rerun-if-changed={}", repo_root.join("packages/libfers/CMakeLists.txt").display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        repo_root.join("packages/libfers/CMakeLists.txt").display()
+    );
 
     let bindings = bindgen::Builder::default()
         .header(header_path.to_str().unwrap())

--- a/packages/libfers/CMakeLists.txt
+++ b/packages/libfers/CMakeLists.txt
@@ -39,8 +39,8 @@ function(fers_configure_library_target target_name)
 	target_compile_definitions(${target_name} PRIVATE HAVE_LIBHDF5)
 
 	set_target_properties(${target_name} PROPERTIES
-		SOVERSION ${PROJECT_VERSION_MAJOR}
-		VERSION ${PROJECT_VERSION}
+		SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
+		VERSION ${CMAKE_PROJECT_VERSION}
 	)
 endfunction()
 

--- a/packages/libfers/src/simulation/channel_model.h
+++ b/packages/libfers/src/simulation/channel_model.h
@@ -21,6 +21,7 @@
 #include <chrono>
 #include <exception>
 #include <memory>
+#include <vector>
 
 #include "core/config.h"
 #include "core/sim_id.h"

--- a/packages/libfers/tests/noise/test_falpha_branch.cpp
+++ b/packages/libfers/tests/noise/test_falpha_branch.cpp
@@ -58,7 +58,7 @@ TEST_CASE("FAlphaBranch non-last branch matches upsampled pre-offset buffer", "[
 {
 	constexpr unsigned fint = 0;
 	constexpr RealType ffrac = 0.0;
-	constexpr RealType upsample_scale = std::pow(10.0, ffrac + fint + 0.5);
+	const RealType upsample_scale = std::pow(10.0, ffrac + fint + 0.5);
 
 	std::mt19937 rng_branch(77);
 	std::mt19937 rng_manual(77);


### PR DESCRIPTION
This pull request addresses several issues discovered while building and installing `fers-cli` on macOS. The changes improve compiler compatibility, fix the runtime behavior of the installed executable, and update documentation to reflect the current state of the project on this platform.

### Key Changes

**1. Build System Improvements for `fers-cli`**

To ensure the `fers-cli` executable is relocatable and can find its libraries after installation, the build process has been updated:
-   **Static Linking:** The CLI now links against the static version of `libfers` (`fers::fers_static`).
-   **Relocatable RPATH:** A cross-platform relative RPATH is now set for the installed executable (`@executable_path/../lib` on macOS, `$ORIGIN/../lib` on Linux), allowing it to locate shared libraries in a standard install layout.

**2. Compiler Compatibility Fixes**

Several adjustments were made to support building with the Clang compiler on macOS:
-   **Compiler Warnings:** Warnings that are specific to GCC (`-Wduplicated-cond`, `-Wduplicated-branches`, `-Wlogical-op`) have been moved into a GCC-only block in `FersCompilerWarnings.cmake` to avoid build errors with Clang.
-   **`constexpr` Correction:** A `constexpr` variable initialized with a call to `std::pow` (which is not a `constexpr` function) has been corrected to `const`.

**3. Documentation Updates**

The `README.md` has been updated with two important notes:
-   A tip has been added explaining how to install the built binaries to the system using `cmake --install`.
-   A warning has been added regarding the current instability of `fers-ui` on macOS, specifically noting the known WebGL context loss issue and linking to issue https://github.com/davidbits/FERS/issues/181 for tracking.