### PR TITLE
build: overhaul build system and fix HDF5 thread-safety

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,20 +32,13 @@ jobs:
 
             - uses: lukka/get-cmake@latest
 
-            - uses: lukka/run-vcpkg@v11
-              with:
-                  runVcpkgInstall: false
-
             - name: Install build tools
               run: |
                   sudo apt-get update
-                  sudo apt-get install -y \
-                    doxygen \
-                    graphviz \
-                    xxd
+                  sudo apt-get install -y doxygen graphviz
 
             - name: Configure CMake
-              run: cmake --preset release -DFERS_BUILD_DOCS=ON
+              run: cmake --preset release -DFERS_BUILD_DOCS=ON -DFERS_DOCS_ONLY=ON
 
             - name: Build documentation
               run: cmake --build --preset release --target doc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,51 +1,100 @@
 cmake_minimum_required(VERSION 3.22)
 
-project(FERS
-	VERSION 1.0.0
-	DESCRIPTION "The Flexible Extensible Radar Simulator"
-	LANGUAGES CXX)
-
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-
-# --- Project-wide Settings ---
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON) # For simpler DLL exports
 
 # --- Options and Build Type ---
 include(FersOptions)
 
-# --- Compiler Warnings and Flags ---
-include(FersCompilerWarnings)
+if (NOT FERS_DOCS_ONLY)
+	# Auto-detect vcpkg toolchain before project() so dependency resolution works in CLion and CLI.
+	if (NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+		set(_fers_vcpkg_candidates)
 
-# --- Testing ---
-if (FERS_BUILD_TESTS)
-	enable_testing()
-endif()
+		if (DEFINED ENV{VCPKG_ROOT})
+			list(APPEND _fers_vcpkg_candidates "$ENV{VCPKG_ROOT}")
+		endif ()
 
-if(FERS_ENABLE_COVERAGE)
-	if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-		message(STATUS "Enabling Code Coverage")
-		add_compile_options(-fprofile-arcs -ftest-coverage)
-		add_link_options(--coverage)
-	else()
-		message(WARNING "Code coverage is only supported for GCC and Clang")
-	endif()
-endif()
+		if (DEFINED ENV{HOME})
+			list(APPEND _fers_vcpkg_candidates "$ENV{HOME}/vcpkg")
+		endif ()
 
-# --- macOS Specific Configuration ---
-if (APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-	message(STATUS "macOS with a modern toolchain (e.g., Homebrew LLVM) is recommended.")
-	message(STATUS "If you are not using the system compiler, please configure with:")
-	message(STATUS "  CC=/path/to/clang CXX=/path/to/clang++ cmake ..")
-	# link_directories(/usr/local/opt/llvm/lib/c++)
+		list(APPEND _fers_vcpkg_candidates
+			 "${CMAKE_SOURCE_DIR}/vcpkg"
+			 "${CMAKE_SOURCE_DIR}/../vcpkg")
+
+		find_program(_fers_vcpkg_exe NAMES vcpkg)
+		if (_fers_vcpkg_exe)
+			cmake_path(GET _fers_vcpkg_exe PARENT_PATH _fers_vcpkg_bin_dir)
+			cmake_path(GET _fers_vcpkg_bin_dir PARENT_PATH _fers_vcpkg_root_from_path)
+			list(APPEND _fers_vcpkg_candidates "${_fers_vcpkg_root_from_path}")
+		endif ()
+
+		list(REMOVE_DUPLICATES _fers_vcpkg_candidates)
+		foreach (_fers_vcpkg_root IN LISTS _fers_vcpkg_candidates)
+			set(_fers_vcpkg_toolchain "${_fers_vcpkg_root}/scripts/buildsystems/vcpkg.cmake")
+			if (EXISTS "${_fers_vcpkg_toolchain}")
+				set(CMAKE_TOOLCHAIN_FILE "${_fers_vcpkg_toolchain}" CACHE FILEPATH "vcpkg toolchain")
+				message(STATUS "Using vcpkg toolchain: ${CMAKE_TOOLCHAIN_FILE}")
+				break()
+			endif ()
+		endforeach ()
+
+		unset(_fers_vcpkg_candidates)
+		unset(_fers_vcpkg_exe)
+		unset(_fers_vcpkg_bin_dir)
+		unset(_fers_vcpkg_root_from_path)
+		unset(_fers_vcpkg_root)
+		unset(_fers_vcpkg_toolchain)
+	endif ()
+
+	if (NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+		message(FATAL_ERROR
+				"Could not locate vcpkg toolchain file. Set VCPKG_ROOT or CMAKE_TOOLCHAIN_FILE before configuring.")
+	endif ()
 endif ()
 
-# Add the subdirectory containing the C++ packages.
-add_subdirectory(packages)
+project(FERS
+		VERSION 1.0.0
+		DESCRIPTION "The Flexible Extensible Radar Simulator"
+		LANGUAGES CXX)
+
+if (NOT FERS_DOCS_ONLY)
+	# --- Project-wide Settings ---
+	set(CMAKE_CXX_STANDARD 23)
+	set(CMAKE_CXX_STANDARD_REQUIRED ON)
+	set(CMAKE_CXX_EXTENSIONS OFF)
+	set(CMAKE_VERBOSE_MAKEFILE ON)
+	set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+	set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON) # For simpler DLL exports
+
+	# --- Compiler Warnings and Flags ---
+	include(FersCompilerWarnings)
+
+	# --- Testing ---
+	if (FERS_BUILD_TESTS)
+		enable_testing()
+	endif ()
+
+	if (FERS_ENABLE_COVERAGE)
+		if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+			message(STATUS "Enabling Code Coverage")
+			add_compile_options(-fprofile-arcs -ftest-coverage)
+			add_link_options(--coverage)
+		else ()
+			message(WARNING "Code coverage is only supported for GCC and Clang")
+		endif ()
+	endif ()
+
+	# --- macOS Specific Configuration ---
+	if (APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+		message(STATUS "macOS with a modern toolchain (e.g., Homebrew LLVM) is recommended.")
+		message(STATUS "If you are not using the system compiler, please configure with:")
+		message(STATUS "  CC=/path/to/clang CXX=/path/to/clang++ cmake ..")
+	endif ()
+
+	# Add the subdirectory containing the C++ packages.
+	add_subdirectory(packages)
+endif ()
 
 # --- Documentation ---
 add_subdirectory(docs)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,54 +7,44 @@
     },
     "configurePresets": [
         {
-            "name": "base",
-            "hidden": true,
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build/${presetName}",
+            "name": "debug",
+            "displayName": "Debug (Make)",
+            "description": "Standard Debug build using Unix Makefiles",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build/debug",
             "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
             }
         },
         {
-            "name": "vcpkg",
-            "hidden": true,
-            "inherits": "base",
-            "cacheVariables": {
-                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-            }
-        },
-        {
-            "name": "debug",
-            "displayName": "Debug",
-            "description": "Standard Debug build",
-            "inherits": "vcpkg",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug"
-            }
-        },
-        {
             "name": "release",
-            "displayName": "Release",
-            "description": "Standard Release build (-O2 -s)",
-            "inherits": "vcpkg",
+            "displayName": "Release (Make)",
+            "description": "Standard Release build (-O2 -s) using Unix Makefiles",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build/release",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release"
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
             }
         },
         {
             "name": "relwithdebinfo",
-            "displayName": "RelWithDebInfo",
-            "description": "Release build with Debug symbols",
-            "inherits": "vcpkg",
+            "displayName": "RelWithDebInfo (Make)",
+            "description": "Release build with debug symbols using Unix Makefiles",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build/relwithdebinfo",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
             }
         },
         {
             "name": "asan",
-            "displayName": "AddressSanitizer",
-            "description": "Debug build with AddressSanitizer enabled",
+            "displayName": "AddressSanitizer (Make)",
+            "description": "Debug build with AddressSanitizer enabled using Unix Makefiles",
             "inherits": "debug",
+            "binaryDir": "${sourceDir}/build/asan",
             "cacheVariables": {
                 "CMAKE_C_FLAGS": "-fsanitize=address -fno-omit-frame-pointer",
                 "CMAKE_CXX_FLAGS": "-fsanitize=address -fno-omit-frame-pointer"
@@ -62,9 +52,10 @@
         },
         {
             "name": "tsan",
-            "displayName": "ThreadSanitizer",
-            "description": "Debug build with ThreadSanitizer enabled",
+            "displayName": "ThreadSanitizer (Make)",
+            "description": "Debug build with ThreadSanitizer enabled using Unix Makefiles",
             "inherits": "debug",
+            "binaryDir": "${sourceDir}/build/tsan",
             "cacheVariables": {
                 "CMAKE_C_FLAGS": "-fsanitize=thread",
                 "CMAKE_CXX_FLAGS": "-fsanitize=thread"
@@ -72,9 +63,10 @@
         },
         {
             "name": "coverage",
-            "displayName": "Code Coverage",
-            "description": "Debug build with coverage generation enabled",
+            "displayName": "Code Coverage (Make)",
+            "description": "Debug build with coverage generation enabled using Unix Makefiles",
             "inherits": "debug",
+            "binaryDir": "${sourceDir}/build/coverage",
             "cacheVariables": {
                 "FERS_ENABLE_COVERAGE": "ON"
             }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,12 +845,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,7 +1002,6 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "cmake",
- "dotenv",
  "pkg-config",
  "serde",
  "tauri",

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Ensure you have the following tools installed on your system:
 - A C++23 compatible compiler (e.g., GCC 11+, Clang 14+) and **CMake** (3.22+).
 - [**vcpkg**](https://vcpkg.io/en/getting-started.html) (for C++ dependencies). Ensure `VCPKG_ROOT` is set in your environment, or create a `.env` file at `packages/fers-ui/src-tauri/.env` containing `VCPKG_ROOT=/path/to/vcpkg`.
 - [**Bun**](https://bun.sh/).
-- [**Ninja**](https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages) (recommended for faster builds).
 - The [**Rust toolchain**](https://www.rust-lang.org/tools/install).
 - [**Tauri prerequisites**](https://tauri.app/start/prerequisites/) for your operating system.
 - [**clang-format**](https://clang.llvm.org/docs/ClangFormat.html) (for code formatting).

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Follow these steps to set up a development environment for building the C++ core
 Ensure you have the following tools installed on your system:
 
 - A C++23 compatible compiler (e.g., GCC 11+, Clang 14+) and **CMake** (3.22+).
-- [**vcpkg**](https://vcpkg.io/en/getting-started.html) (for C++ dependencies). Ensure `VCPKG_ROOT` is set in your environment, or create a `.env` file at `packages/fers-ui/src-tauri/.env` containing `VCPKG_ROOT=/path/to/vcpkg`.
+- [**vcpkg**](https://vcpkg.io/en/getting-started.html) (for C++ dependencies). Ensure `VCPKG_ROOT` is set in your environment.
 - [**Bun**](https://bun.sh/).
 - The [**Rust toolchain**](https://www.rust-lang.org/tools/install).
 - [**Tauri prerequisites**](https://tauri.app/start/prerequisites/) for your operating system.
 - [**clang-format**](https://clang.llvm.org/docs/ClangFormat.html) (for code formatting).
-- **Other notable dependencies (for linux):** `build-essential` and `pkg-config`
+- **Other notable dependencies (for linux):** `build-essential`, `pkg-config`, and `xxd`.
 
 ### 2. Clone the Repository
 
@@ -100,10 +100,11 @@ cmake --build --preset=release
 
 The UI build process is completely self-contained. When you run the UI, Cargo will automatically invoke CMake to build the C++ backend in an isolated directory.
 
-**Important:** You must have `vcpkg` installed and the `VCPKG_ROOT` environment variable set in `PATH`. You can set this globally in your shell, or create a `.env` file at `src-tauri/.env` with the path to your vcpkg installation:
+**Important:** You must have `vcpkg` installed and the `VCPKG_ROOT` environment variable set in `PATH`.
 
 ```env
-VCPKG_ROOT=/path/to/vcpkg
+export VCPKG_ROOT=/path/to/vcpkg
+export PATH=$VCPKG_ROOT:$PATH
 ```
 
 Navigate to the root of the repository and start the development server:

--- a/cmake/FersCompilerWarnings.cmake
+++ b/cmake/FersCompilerWarnings.cmake
@@ -37,24 +37,8 @@ function(apply_fers_warnings TARGET_NAME)
 
 	# --- Common Flags ---
 	target_compile_options(${TARGET_NAME} PRIVATE
-						   -pthread
-						   -ffast-math
 						   -fno-finite-math-only
 	)
-
-	if (UNIX)
-		target_compile_definitions(${TARGET_NAME} PRIVATE _REENTRANT)
-	endif ()
-
-	# --- Build-Type Specific Flags ---
-	if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-		target_compile_options(${TARGET_NAME} PRIVATE -g -O0)
-	elseif (CMAKE_BUILD_TYPE STREQUAL "Release")
-		target_compile_options(${TARGET_NAME} PRIVATE -O2)
-		target_link_options(${TARGET_NAME} PRIVATE -s)
-	elseif (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-		target_compile_options(${TARGET_NAME} PRIVATE -O2 -g)
-	endif ()
 
 	# --- Sanitizer Detection ---
 	if (CMAKE_CXX_FLAGS MATCHES ".*-fsanitize=address.*")

--- a/cmake/FersOptions.cmake
+++ b/cmake/FersOptions.cmake
@@ -18,6 +18,7 @@ endif ()
 option(FERS_BUILD_SHARED_LIBS "Build the shared (.so/.dll) library" ON)
 option(FERS_BUILD_STATIC_LIBS "Build the static (.a) library" ON)
 option(FERS_BUILD_DOCS "Enable building Doxygen documentation" OFF)
+option(FERS_DOCS_ONLY "Configure only for documentation generation" OFF)
 option(FERS_BUILD_TESTS "Build unit tests" ON)
 option(FERS_ENABLE_COVERAGE "Enable code coverage generation" OFF)
 

--- a/packages/fers-cli/CMakeLists.txt
+++ b/packages/fers-cli/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(fers-cli PRIVATE
 )
 
 # Link against libfers.
-target_link_libraries(fers-cli PRIVATE fers::fers_static)
+target_link_libraries(fers-cli PRIVATE fers::fers)
 
 # --- Cross-Platform Relocatable RPATH ---
 set_target_properties(fers-cli PROPERTIES

--- a/packages/fers-cli/README.md
+++ b/packages/fers-cli/README.md
@@ -28,8 +28,8 @@ After a successful build, the executable can be found at `build/release/packages
 Run the simulator from the command line, providing the path to a scenario XML file and any desired options.
 
 ```bash
-# From the build/release/packages/ directory
-./fers-cli/fers-cli path/to/your/scenario.fersxml [options]
+# From the project root
+./build/release/packages/fers-cli/fers-cli path/to/your/scenario.fersxml [options]
 ```
 
 ### Options
@@ -47,6 +47,6 @@ Run the simulator from the command line, providing the path to a scenario XML fi
 ### Example
 
 ```bash
-# From the build/packages directory
-./fers-cli/fers-cli example.fersxml --log-level=DEBUG -n=8
+# From the project root
+./build/release/packages/fers-cli/fers-cli example.fersxml --log-level=DEBUG -n=8
 ```

--- a/packages/fers-ui/README.md
+++ b/packages/fers-ui/README.md
@@ -55,10 +55,11 @@ This application is part of a monorepo that includes the core C++ `libfers` libr
 
 To set up the complete development environment, please follow the unified **[Development Setup guide in the root README.md](https://github.com/stpaine/FERS/blob/master/README.md)**.
 
-**Important:** You must have `vcpkg` installed and the `VCPKG_ROOT` environment variable set. You can set this globally in your shell, or create a `.env` file at `src-tauri/.env` with the path to your vcpkg installation:
+**Important:** You must have `vcpkg` installed and the `VCPKG_ROOT` environment variable set.
 
 ```env
-VCPKG_ROOT=/path/to/vcpkg
+export VCPKG_ROOT=/path/to/vcpkg
+export PATH=$VCPKG_ROOT:$PATH
 ```
 
 Once the environment is set up, you can run the UI from the **repository root** with:

--- a/packages/fers-ui/README.md
+++ b/packages/fers-ui/README.md
@@ -66,3 +66,7 @@ Once the environment is set up, you can run the UI from the **repository root** 
 ```bash
 bun ui:dev
 ```
+
+> [!WARNING]
+> The UI is currently in active development and may be unstable. Expect crashes and incomplete features.
+> In particular, there is a known issue causing WebGL context loss on macOS on launch. See https://github.com/davidbits/FERS/issues/181 for details.

--- a/packages/fers-ui/src-tauri/.env.example
+++ b/packages/fers-ui/src-tauri/.env.example
@@ -1,1 +1,0 @@
-VCPKG_ROOT=

--- a/packages/fers-ui/src-tauri/Cargo.toml
+++ b/packages/fers-ui/src-tauri/Cargo.toml
@@ -20,7 +20,6 @@ tauri-build = { version = "2", features = [] }
 bindgen = "0.72"
 pkg-config = "0.3"
 cmake = "0.1.57"
-dotenv = "0.15.0"
 
 [dependencies]
 tauri = { version = "2", features = [] }

--- a/packages/fers-ui/src-tauri/build.rs
+++ b/packages/fers-ui/src-tauri/build.rs
@@ -33,7 +33,6 @@ fn main() {
     let vcpkg_toolchain = format!("{}/scripts/buildsystems/vcpkg.cmake", vcpkg_root);
 
     config
-        .generator("Ninja")
         .define("CMAKE_TOOLCHAIN_FILE", &vcpkg_toolchain)
         .define("FERS_BUILD_TESTS", "OFF")
         .define("FERS_BUILD_SHARED_LIBS", "OFF")

--- a/packages/fers-ui/src-tauri/build.rs
+++ b/packages/fers-ui/src-tauri/build.rs
@@ -2,7 +2,6 @@
 // Copyright (c) 2025-present FERS Contributors (see AUTHORS.md).
 
 use std::env;
-use std::fs;
 use std::path::PathBuf;
 
 fn main() {
@@ -14,7 +13,20 @@ fn main() {
 
     // --- 1. Ensure VCPKG_ROOT is set ---
     let vcpkg_root = env::var("VCPKG_ROOT")
-        .expect("VCPKG_ROOT must be set in your environment or in packages/fers-ui/src-tauri/.env");
+        .or_else(|_| {
+            let home = env::var("HOME").unwrap_or_default();
+            let candidates = [
+                repo_root.join("vcpkg"),
+                repo_root.join("../vcpkg"),
+                PathBuf::from(home).join("vcpkg"),
+            ];
+            candidates
+                .into_iter()
+                .find(|p| p.exists())
+                .map(|p| p.to_string_lossy().into_owned())
+                .ok_or("VCPKG_ROOT not found")
+        })
+        .expect("VCPKG_ROOT must be set in your environment...");
 
     // --- 2. Invoke CMake to build libfers ---
     let mut config = cmake::Config::new(&repo_root);
@@ -35,20 +47,9 @@ fn main() {
     // --- 3. Locate vcpkg installed directory ---
     let vcpkg_installed_dir = build_dir.join("vcpkg_installed");
 
-    let mut triplet_dir = None;
-    if vcpkg_installed_dir.exists() {
-        for entry in fs::read_dir(&vcpkg_installed_dir).unwrap() {
-            let entry = entry.unwrap();
-            let path = entry.path();
-            if path.is_dir() && entry.file_name() != "vcpkg" {
-                triplet_dir = Some(path);
-                break;
-            }
-        }
-    }
-
-    let triplet_dir =
-        triplet_dir.expect("Could not find vcpkg triplet directory. Did CMake run successfully?");
+    let target = env::var("TARGET").unwrap();
+    let triplet = if target.contains("apple") { "x64-osx" } else { "x64-linux" };
+    let triplet_dir = vcpkg_installed_dir.join(triplet);
     let vcpkg_lib_dir = triplet_dir.join("lib");
 
     // --- 4. Link the libraries ---
@@ -64,8 +65,6 @@ fn main() {
     let vcpkg_libs = [
         "Geographic",
         "GeographicLib",
-        "hdf5_hl_cpp",
-        "hdf5_cpp",
         "hdf5_hl",
         "hdf5",
         "sz",

--- a/packages/fers-ui/src-tauri/build.rs
+++ b/packages/fers-ui/src-tauri/build.rs
@@ -5,9 +5,6 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    // Load environment variables from .env file if it exists
-    dotenv::dotenv().ok();
-
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let repo_root = manifest_dir.join("../../..");
 

--- a/packages/libfers/CMakeLists.txt
+++ b/packages/libfers/CMakeLists.txt
@@ -7,40 +7,40 @@ function(fers_configure_library_target target_name)
 
 	# --- Source and Header Files ---
 	target_sources(${target_name} PRIVATE
-		${LIBFERS_SOURCES}
-		${LIBFERS_PUBLIC_HEADERS}
-		${LIBFERS_PRIVATE_HEADERS}
+				   ${LIBFERS_SOURCES}
+				   ${LIBFERS_PUBLIC_HEADERS}
+				   ${LIBFERS_PRIVATE_HEADERS}
 	)
 
 	# --- Include Directories ---
 	target_include_directories(${target_name} PUBLIC
-		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-		$<INSTALL_INTERFACE:include>
+							   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+							   $<INSTALL_INTERFACE:include>
 	)
 	target_include_directories(${target_name} PRIVATE
-		${CMAKE_CURRENT_SOURCE_DIR}/src
+							   ${CMAKE_CURRENT_SOURCE_DIR}/src
 	)
 
 	# --- Schema Headers ---
 	add_dependencies(${target_name} generate_schemas)
 	target_include_directories(${target_name} PRIVATE
-		$<BUILD_INTERFACE:${GENERATED_HEADERS_DIR}>
+							   $<BUILD_INTERFACE:${GENERATED_HEADERS_DIR}>
 	)
 
 	# --- Third-Party Dependencies ---
 	target_link_libraries(${target_name} PRIVATE
-		HighFive
-		nlohmann_json::nlohmann_json
-		GeographicLib::GeographicLib
-		LibXml2::LibXml2
-		${HDF5_C_LIBRARIES}
-		${HDF5_HL_LIBRARIES}
+						  HighFive
+						  nlohmann_json::nlohmann_json
+						  GeographicLib::GeographicLib
+						  LibXml2::LibXml2
+						  hdf5::hdf5
+						  hdf5::hdf5_hl
 	)
 	target_compile_definitions(${target_name} PRIVATE HAVE_LIBHDF5)
 
 	set_target_properties(${target_name} PROPERTIES
-		SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
-		VERSION ${CMAKE_PROJECT_VERSION}
+						  SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
+						  VERSION ${CMAKE_PROJECT_VERSION}
 	)
 endfunction()
 
@@ -54,19 +54,19 @@ set(SCHEMA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../schema)
 set(GENERATED_HEADERS_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated_headers)
 
 add_custom_command(
-	OUTPUT ${GENERATED_HEADERS_DIR}/fers_xml_dtd.h ${GENERATED_HEADERS_DIR}/fers_xml_xsd.h
-	COMMAND ${CMAKE_COMMAND} -E make_directory ${GENERATED_HEADERS_DIR}
-	COMMAND ${CMAKE_COMMAND} -E copy ${SCHEMA_DIR}/fers-xml.dtd ${CMAKE_CURRENT_BINARY_DIR}/fers-xml.dtd
-	COMMAND ${CMAKE_COMMAND} -E copy ${SCHEMA_DIR}/fers-xml.xsd ${CMAKE_CURRENT_BINARY_DIR}/fers-xml.xsd
-	COMMAND xxd -i fers-xml.dtd > ${GENERATED_HEADERS_DIR}/fers_xml_dtd.h
-	COMMAND xxd -i fers-xml.xsd > ${GENERATED_HEADERS_DIR}/fers_xml_xsd.h
-	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-	DEPENDS ${SCHEMA_DIR}/fers-xml.dtd ${SCHEMA_DIR}/fers-xml.xsd
-	COMMENT "Converting XML schema files to C headers"
+		OUTPUT ${GENERATED_HEADERS_DIR}/fers_xml_dtd.h ${GENERATED_HEADERS_DIR}/fers_xml_xsd.h
+		COMMAND ${CMAKE_COMMAND} -E make_directory ${GENERATED_HEADERS_DIR}
+		COMMAND ${CMAKE_COMMAND} -E copy ${SCHEMA_DIR}/fers-xml.dtd ${CMAKE_CURRENT_BINARY_DIR}/fers-xml.dtd
+		COMMAND ${CMAKE_COMMAND} -E copy ${SCHEMA_DIR}/fers-xml.xsd ${CMAKE_CURRENT_BINARY_DIR}/fers-xml.xsd
+		COMMAND xxd -i fers-xml.dtd > ${GENERATED_HEADERS_DIR}/fers_xml_dtd.h
+		COMMAND xxd -i fers-xml.xsd > ${GENERATED_HEADERS_DIR}/fers_xml_xsd.h
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+		DEPENDS ${SCHEMA_DIR}/fers-xml.dtd ${SCHEMA_DIR}/fers-xml.xsd
+		COMMENT "Converting XML schema files to C headers"
 )
 add_custom_target(generate_schemas ALL DEPENDS
-	${GENERATED_HEADERS_DIR}/fers_xml_dtd.h
-	${GENERATED_HEADERS_DIR}/fers_xml_xsd.h
+				  ${GENERATED_HEADERS_DIR}/fers_xml_dtd.h
+				  ${GENERATED_HEADERS_DIR}/fers_xml_xsd.h
 )
 
 # --- Third-Party Dependencies (vcpkg) ---
@@ -112,28 +112,28 @@ source_group("Header Files\\Private" FILES ${LIBFERS_PRIVATE_HEADERS})
 # --- Installation ---
 if (FERS_BUILD_STATIC_LIBS)
 	install(TARGETS fers_static
-		EXPORT libfers-targets
-		ARCHIVE DESTINATION lib
+			EXPORT libfers-targets
+			ARCHIVE DESTINATION lib
 	)
 endif ()
 
 if (FERS_BUILD_SHARED_LIBS)
 	install(TARGETS fers_shared
-		EXPORT libfers-targets
-		LIBRARY DESTINATION lib
-		RUNTIME DESTINATION bin
-		ARCHIVE DESTINATION lib
+			EXPORT libfers-targets
+			LIBRARY DESTINATION lib
+			RUNTIME DESTINATION bin
+			ARCHIVE DESTINATION lib
 	)
 endif ()
 
 install(FILES ${LIBFERS_PUBLIC_HEADERS}
-	DESTINATION include/libfers
+		DESTINATION include/libfers
 )
 
 install(EXPORT libfers-targets
-	FILE libfers-config.cmake
-	NAMESPACE fers::
-	DESTINATION lib/cmake/libfers
+		FILE libfers-config.cmake
+		NAMESPACE fers::
+		DESTINATION lib/cmake/libfers
 )
 
 # --- Testing ---

--- a/packages/libfers/CMakeLists.txt
+++ b/packages/libfers/CMakeLists.txt
@@ -33,8 +33,9 @@ function(fers_configure_library_target target_name)
 						  nlohmann_json::nlohmann_json
 						  GeographicLib::GeographicLib
 						  LibXml2::LibXml2
-						  hdf5::hdf5
-						  hdf5::hdf5_hl
+						  # Using this format instead of hdf5::hdf5/hdf5::hdf5_hl due to macOS linking issues
+						  ${HDF5_C_LIBRARIES}
+						  ${HDF5_HL_LIBRARIES}
 	)
 	target_compile_definitions(${target_name} PRIVATE HAVE_LIBHDF5)
 

--- a/packages/libfers/README.md
+++ b/packages/libfers/README.md
@@ -37,7 +37,7 @@ From the root of the repository, use the CMake presets to configure and build th
 ```bash
 # From the root FERS directory
 cmake --preset=release
-cmake --build build --preset=release
+cmake --build --preset=release
 ```
 
 The compiled artifacts will be located in the `build/release/` directory. Libraries (`.a`, `.so`) are in `build/release/packages/libfers/`,

--- a/packages/libfers/src/interpolation/interpolation_filter.cpp
+++ b/packages/libfers/src/interpolation/interpolation_filter.cpp
@@ -143,6 +143,7 @@ namespace interp
 			throw std::runtime_error("Requested delay filter value out of range");
 		}
 
+		// TODO: Investigate if OOB access can occur here
 		const auto filt = static_cast<unsigned>((delay + 1) * (_table_filters / 2.0));
 		return std::span{&_filter_table[filt * _length], static_cast<size_t>(_length)};
 	}

--- a/packages/libfers/src/processing/finalizer.cpp
+++ b/packages/libfers/src/processing/finalizer.cpp
@@ -36,7 +36,13 @@ namespace processing
 		}
 
 		const auto hdf5_filename = std::format("{}_results.h5", receiver->getName());
-		HighFive::File h5_file(hdf5_filename, HighFive::File::Truncate);
+
+		std::unique_ptr<HighFive::File> h5_file;
+		{
+			std::lock_guard<std::mutex> lock(serial::hdf5_global_mutex);
+			h5_file = std::make_unique<HighFive::File>(hdf5_filename, HighFive::File::Truncate);
+		}
+
 		unsigned chunk_index = 0;
 
 		LOG(logging::Level::INFO, "Finalizer thread started for receiver '{}'. Outputting to '{}'.",
@@ -85,7 +91,7 @@ namespace processing
 
 			const RealType fullscale = pipeline::applyDownsamplingAndQuantization(window_buffer);
 
-			serial::addChunkToFile(h5_file, window_buffer, actual_start, fullscale, chunk_index++);
+			serial::addChunkToFile(*h5_file, window_buffer, actual_start, fullscale, chunk_index++);
 
 			if (reporter)
 			{
@@ -97,6 +103,12 @@ namespace processing
 					last_report_time = now;
 				}
 			}
+		}
+
+		{
+			// Safe destruction of the HDF5 object inside a lock
+			std::lock_guard<std::mutex> lock(serial::hdf5_global_mutex);
+			h5_file.reset();
 		}
 
 		if (reporter)

--- a/packages/libfers/src/processing/finalizer_pipeline.cpp
+++ b/packages/libfers/src/processing/finalizer_pipeline.cpp
@@ -17,6 +17,7 @@
 #include "radar/receiver.h"
 #include "radar/target.h"
 #include "radar/transmitter.h"
+#include "serial/hdf5_handler.h"
 #include "serial/response.h"
 #include "signal/dsp_filters.h"
 #include "simulation/channel_model.h"
@@ -121,6 +122,7 @@ namespace processing::pipeline
 	void exportCwToHdf5(const std::string& filename, const std::vector<ComplexType>& iq_buffer,
 						const RealType fullscale, const RealType ref_freq)
 	{
+		std::lock_guard<std::mutex> lock(serial::hdf5_global_mutex);
 		try
 		{
 			HighFive::File file(filename, HighFive::File::Truncate);

--- a/packages/libfers/src/serial/hdf5_handler.cpp
+++ b/packages/libfers/src/serial/hdf5_handler.cpp
@@ -26,8 +26,12 @@ using logging::Level;
 
 namespace serial
 {
+	std::mutex hdf5_global_mutex;
+
 	void readPulseData(const std::string& name, std::vector<ComplexType>& data)
 	{
+		std::lock_guard lock(hdf5_global_mutex);
+
 		if (!std::filesystem::exists(name))
 		{
 			LOG(Level::FATAL, "File '{}' not found", name);
@@ -76,6 +80,8 @@ namespace serial
 	void addChunkToFile(HighFive::File& file, const std::vector<ComplexType>& data, const RealType time,
 						const RealType fullscale, const unsigned count)
 	{
+		std::lock_guard<std::mutex> lock(hdf5_global_mutex);
+
 		const unsigned size = data.size();
 
 		const std::string base_chunk_name = "chunk_" + std::format("{:06}", count);
@@ -126,6 +132,7 @@ namespace serial
 
 	std::vector<std::vector<RealType>> readPattern(const std::string& name, const std::string& datasetName)
 	{
+		std::lock_guard<std::mutex> lock(hdf5_global_mutex);
 		try
 		{
 			LOG(Level::TRACE, "Reading dataset '{}' from file '{}'", datasetName, name);

--- a/packages/libfers/src/serial/hdf5_handler.h
+++ b/packages/libfers/src/serial/hdf5_handler.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -24,6 +25,11 @@ namespace HighFive
 
 namespace serial
 {
+	/**
+	 * @brief Global mutex to protect all HDF5 C-library calls, which are not thread-safe.
+	 */
+	extern std::mutex hdf5_global_mutex;
+
 	/**
 	 * @brief Adds a chunk of data to an HDF5 file.
 	 *

--- a/packages/libfers/tests/CMakeLists.txt
+++ b/packages/libfers/tests/CMakeLists.txt
@@ -57,10 +57,17 @@ add_executable(libfers_tests
 )
 
 target_include_directories(libfers_tests PRIVATE
-						  ${CMAKE_CURRENT_SOURCE_DIR}/../src
-						  ${HDF5_INCLUDE_DIRS})
+						   ${CMAKE_CURRENT_SOURCE_DIR}/../src
+						   ${HDF5_INCLUDE_DIRS})
 
-target_link_libraries(libfers_tests PRIVATE Catch2::Catch2WithMain fers::fers LibXml2::LibXml2 ${HDF5_C_LIBRARIES} ${HDF5_HL_LIBRARIES})
+target_link_libraries(libfers_tests PRIVATE
+					  Catch2::Catch2WithMain
+					  fers::fers
+					  LibXml2::LibXml2
+					  # Using this format instead of hdf5::hdf5/hdf5::hdf5_hl due to macOS linking issues
+					  ${HDF5_C_LIBRARIES}
+					  ${HDF5_HL_LIBRARIES}
+)
 
 if (COMMAND apply_fers_warnings)
 	apply_fers_warnings(libfers_tests)

--- a/packages/libfers/tests/CMakeLists.txt
+++ b/packages/libfers/tests/CMakeLists.txt
@@ -66,4 +66,6 @@ if (COMMAND apply_fers_warnings)
 	apply_fers_warnings(libfers_tests)
 endif ()
 
-catch_discover_tests(libfers_tests)
+catch_discover_tests(libfers_tests
+					 DISCOVERY_MODE PRE_TEST
+)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,7 +9,7 @@
         "highfive",
         {
             "name": "hdf5",
-            "features": ["cpp", "hl"]
+            "features": ["hl"]
         },
         "libxml2",
         "nlohmann-json"


### PR DESCRIPTION
This pull request introduces a significant overhaul of the CMake and Rust build systems to improve usability, cross-platform compatibility, and robustness. It also resolves a critical race condition in HDF5 file operations and addresses several build issues, particularly on macOS.

### Key Changes

**1. Build System and Dependency Management Overhaul**

The build process has been redesigned to be more automated and less dependent on specific local configurations.
-   **Vcpkg Auto-Detection:** The root `CMakeLists.txt` and the Tauri `build.rs` script now automatically search for and use a local vcpkg installation. This removes the need to manually configure `CMAKE_TOOLCHAIN_FILE` or use `.env` files, simplifying the initial project setup. The `dotenv` dependency has been removed accordingly.
-   **Simplified Presets:** The `CMakePresets.json` file has been streamlined. The dependency on Ninja has been removed in favor of standard makefiles, and the presets now rely on CMake's default handling of build-type flags.
-   **Documentation-Only Build:** A new `FERS_DOCS_ONLY` CMake option allows for building documentation without configuring the entire C++ project or its dependencies. This streamlines the documentation CI workflow.

**2. HDF5 Thread-Safety Fix**

A critical concurrency bug that caused heap corruption and intermittent crashes has been resolved.
-   **Global Mutex:** A global `std::mutex` has been introduced to serialize all calls to the HDF5 library. The underlying HDF5 C-library is not thread-safe and was susceptible to race conditions on its internal global state when multiple threads performed file I/O. All HDF5 operations are now protected by this mutex.

**3. macOS Compatibility Improvements**

Several changes were made to resolve linking errors and improve the build experience on macOS.
-   **HDF5 Linking:** The project now links directly against the HDF5 C libraries (`${HDF5_C_LIBRARIES}`) instead of using CMake targets (`hdf5::hdf5`). This works around linking issues observed with the vcpkg-provided HDF5 package on macOS.
-   **Vcpkg Dependency:** The `vcpkg.json` manifest has been updated to request only the `hl` (High-Level) feature from HDF5, removing the unused `cpp` feature which was contributing to build issues.

**4. Documentation and Usability Updates**

-   The main `README.md` and package-specific READMEs have been updated to reflect the new, simplified build process and dependency requirements.
-   A warning has been added to the `fers-ui` README regarding its current instability on macOS, with a link to the relevant tracking issue.