### PR TITLE
refactor build system, resolve compiler warnings, and enhance diagnostic tooling

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,9 +8,9 @@
     "configurePresets": [
         {
             "name": "debug",
-            "displayName": "Debug (Make)",
-            "description": "Standard Debug build using Unix Makefiles",
-            "generator": "Unix Makefiles",
+            "displayName": "Debug",
+            "description": "Standard Debug build using Ninja",
+            "generator": "Ninja",
             "binaryDir": "${sourceDir}/build/debug",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
@@ -19,9 +19,9 @@
         },
         {
             "name": "release",
-            "displayName": "Release (Make)",
-            "description": "Standard Release build (-O2 -s) using Unix Makefiles",
-            "generator": "Unix Makefiles",
+            "displayName": "Release",
+            "description": "Standard Release build (-O2 -s) using Ninja",
+            "generator": "Ninja",
             "binaryDir": "${sourceDir}/build/release",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
@@ -30,9 +30,9 @@
         },
         {
             "name": "relwithdebinfo",
-            "displayName": "RelWithDebInfo (Make)",
-            "description": "Release build with debug symbols using Unix Makefiles",
-            "generator": "Unix Makefiles",
+            "displayName": "RelWithDebInfo",
+            "description": "Release build with debug symbols using Ninja",
+            "generator": "Ninja",
             "binaryDir": "${sourceDir}/build/relwithdebinfo",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
@@ -41,8 +41,8 @@
         },
         {
             "name": "asan",
-            "displayName": "AddressSanitizer (Make)",
-            "description": "Debug build with AddressSanitizer enabled using Unix Makefiles",
+            "displayName": "AddressSanitizer",
+            "description": "Debug build with AddressSanitizer enabled",
             "inherits": "debug",
             "binaryDir": "${sourceDir}/build/asan",
             "cacheVariables": {
@@ -52,8 +52,8 @@
         },
         {
             "name": "tsan",
-            "displayName": "ThreadSanitizer (Make)",
-            "description": "Debug build with ThreadSanitizer enabled using Unix Makefiles",
+            "displayName": "ThreadSanitizer",
+            "description": "Debug build with ThreadSanitizer enabled",
             "inherits": "debug",
             "binaryDir": "${sourceDir}/build/tsan",
             "cacheVariables": {
@@ -63,8 +63,8 @@
         },
         {
             "name": "coverage",
-            "displayName": "Code Coverage (Make)",
-            "description": "Debug build with coverage generation enabled using Unix Makefiles",
+            "displayName": "Code Coverage",
+            "description": "Debug build with coverage generation enabled",
             "inherits": "debug",
             "binaryDir": "${sourceDir}/build/coverage",
             "cacheVariables": {
@@ -74,10 +74,9 @@
         },
         {
             "name": "coverage-ci",
-            "displayName": "Code Coverage (Ninja)",
-            "description": "Debug build with coverage generation enabled using Ninja for CI",
+            "displayName": "Code Coverage (CI)",
+            "description": "Debug build with coverage generation enabled for CI",
             "inherits": "coverage",
-            "generator": "Ninja",
             "binaryDir": "${sourceDir}/build/coverage-ci"
         }
     ],

--- a/README.md
+++ b/README.md
@@ -53,13 +53,17 @@ Follow these steps to set up a development environment for building the C++ core
 
 Ensure you have the following tools installed on your system:
 
-- A C++23 compatible compiler (e.g., GCC 11+, Clang 14+) and **CMake** (3.22+).
+- A C++23 compatible compiler (e.g., GCC 11+, Clang 14+), **CMake** (3.22+), and [**Ninja**](https://ninja-build.org/).
 - [**vcpkg**](https://vcpkg.io/en/getting-started.html) (for C++ dependencies). Ensure `VCPKG_ROOT` is set in your environment.
 - [**Bun**](https://bun.sh/).
 - The [**Rust toolchain**](https://www.rust-lang.org/tools/install).
 - [**Tauri prerequisites**](https://tauri.app/start/prerequisites/) for your operating system.
 - [**clang-format**](https://clang.llvm.org/docs/ClangFormat.html) (for code formatting).
 - **Other notable dependencies (for linux):** `build-essential`, `pkg-config`, and `xxd`.
+
+> [!TIP]
+> Ninja is available in all major package managers: `sudo apt install ninja-build` (Debian/Ubuntu),
+> `brew install ninja` (macOS), or `choco install ninja` (Windows).
 
 ### 2. Clone the Repository
 

--- a/packages/fers-cli/src/arg_parser.cpp
+++ b/packages/fers-cli/src/arg_parser.cpp
@@ -107,12 +107,13 @@ namespace
 	{
 		try
 		{
-			config.num_threads = std::stoi(arg.substr(3));
-			if (config.num_threads == 0)
+			const int requested_threads = std::stoi(arg.substr(3));
+			if (requested_threads <= 0)
 			{
 				return std::unexpected("Number of threads must be greater than 0");
 			}
 
+			config.num_threads = static_cast<unsigned>(requested_threads);
 			if (const unsigned max_threads = std::thread::hardware_concurrency();
 				max_threads > 0 && config.num_threads > max_threads)
 			{

--- a/packages/fers-cli/tests/test_arg_parser.cpp
+++ b/packages/fers-cli/tests/test_arg_parser.cpp
@@ -153,6 +153,14 @@ TEST_CASE("parseArguments rejects a zero thread count", "[fers-cli][arg-parser]"
 	CHECK(result.error() == "Number of threads must be greater than 0");
 }
 
+TEST_CASE("parseArguments rejects a negative thread count", "[fers-cli][arg-parser]")
+{
+	const auto result = parseArgs({"scenario.fersxml", "-n=-4"});
+
+	REQUIRE_FALSE(result);
+	CHECK(result.error() == "Number of threads must be greater than 0");
+}
+
 TEST_CASE("parseArguments requires a script file", "[fers-cli][arg-parser]")
 {
 	const auto result = parseArgs({"--out-dir=results"});

--- a/packages/libfers/CMakeLists.txt
+++ b/packages/libfers/CMakeLists.txt
@@ -220,13 +220,36 @@ set(FERS_NATIVE_LINK_MANIFEST_TARGETS
 )
 
 # --- Create Library Targets ---
+
+# Compile sources exactly once into an OBJECT library.
+# Both static and shared targets consume these objects.
+add_library(fers_objects OBJECT)
+set_target_properties(fers_objects PROPERTIES POSITION_INDEPENDENT_CODE ON)
+fers_configure_library_target(fers_objects)
+target_precompile_headers(fers_objects PRIVATE
+	<nlohmann/json.hpp>
+)
+
 if (FERS_BUILD_STATIC_LIBS)
-	add_library(fers_static STATIC)
+	add_library(fers_static STATIC $<TARGET_OBJECTS:fers_objects>)
 	set_target_properties(fers_static PROPERTIES OUTPUT_NAME "fers")
 	# Ensure the static library is built with Position-Independent Code,
 	# which is required when linking it into a shared library (like the Rust cdylib).
 	set_target_properties(fers_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
-	fers_configure_library_target(fers_static)
+
+	# Include directories and link dependencies must be set on the
+	# final library targets so that consumers inherit them correctly.
+	target_include_directories(fers_static PUBLIC
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+		$<INSTALL_INTERFACE:include>
+	)
+	target_link_libraries(fers_static PRIVATE ${FERS_NATIVE_LINK_DEPENDENCIES})
+	target_compile_definitions(fers_static PRIVATE HAVE_LIBHDF5)
+
+	set_target_properties(fers_static PROPERTIES
+		SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
+		VERSION ${CMAKE_PROJECT_VERSION}
+	)
 	add_library(fers::fers_static ALIAS fers_static)
 
 	set(_fers_native_static_links)
@@ -249,9 +272,20 @@ if (FERS_BUILD_STATIC_LIBS)
 endif ()
 
 if (FERS_BUILD_SHARED_LIBS)
-	add_library(fers_shared SHARED)
+	add_library(fers_shared SHARED $<TARGET_OBJECTS:fers_objects>)
 	set_target_properties(fers_shared PROPERTIES OUTPUT_NAME "fers")
-	fers_configure_library_target(fers_shared)
+
+	target_include_directories(fers_shared PUBLIC
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+		$<INSTALL_INTERFACE:include>
+	)
+	target_link_libraries(fers_shared PRIVATE ${FERS_NATIVE_LINK_DEPENDENCIES})
+	target_compile_definitions(fers_shared PRIVATE HAVE_LIBHDF5)
+
+	set_target_properties(fers_shared PROPERTIES
+		SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
+		VERSION ${CMAKE_PROJECT_VERSION}
+	)
 	add_library(fers::fers_shared ALIAS fers_shared)
 endif ()
 

--- a/packages/libfers/README.md
+++ b/packages/libfers/README.md
@@ -22,7 +22,7 @@ including the official `fers-cli` and `fers-ui` applications.
 ## Dependencies
 
 - A C++23 compatible compiler (e.g., GCC 11+, Clang 14+)
-- **CMake** (3.22+)
+- **CMake** (3.22+) and [**Ninja**](https://ninja-build.org/)
 - **vcpkg** for C++ package management. All third-party libraries (like HDF5, libxml2, etc.) are managed through the `vcpkg.json` manifest at the repository root.
 - **Doxygen** & **Graphviz** (for documentation generation, optional)
 

--- a/packages/libfers/src/antenna/antenna_factory.cpp
+++ b/packages/libfers/src/antenna/antenna_factory.cpp
@@ -422,15 +422,16 @@ namespace antenna
 		const double ex1 = (pattern_angle.azimuth + PI) / two_pi;
 		const double ey1 = (pattern_angle.elevation + PI) / two_pi;
 
-		const auto calc_grid_point = [](const double value, const unsigned size)
+		const auto calc_grid_point = [](const double value, const std::size_t size)
 		{
-			const double x1 = std::floor(value * (size - 1)) / (size - 1);
-			const double x2 = std::min(x1 + 1.0 / size, 1.0);
+			const double grid_size = static_cast<double>(size - 1);
+			const double x1 = std::floor(value * grid_size) / grid_size;
+			const double x2 = std::min(x1 + 1.0 / static_cast<double>(size), 1.0);
 			return std::pair{x1, x2};
 		};
 
-		unsigned size_azi = _pattern.size();
-		unsigned size_elev = _pattern[0].size();
+		const std::size_t size_azi = _pattern.size();
+		const std::size_t size_elev = _pattern[0].size();
 
 		LOG(logging::Level::TRACE, "Size of pattern: {} x {}", size_azi, size_elev);
 
@@ -440,11 +441,11 @@ namespace antenna
 		const double t = (ex1 - x1) / (x2 - x1);
 		const double u = (ey1 - y1) / (y2 - y1);
 
-		const auto calc_array_index = [](const double value, const unsigned size)
-		{ return std::min(static_cast<unsigned>(std::floor(value * size)), size - 1); };
+		const auto calc_array_index = [](const double value, const std::size_t size)
+		{ return std::min(static_cast<std::size_t>(std::floor(value * static_cast<double>(size))), size - 1); };
 
-		const unsigned arr_x = calc_array_index(x1, size_azi);
-		const unsigned arr_y = calc_array_index(y1, size_elev);
+		const std::size_t arr_x = calc_array_index(x1, size_azi);
+		const std::size_t arr_y = calc_array_index(y1, size_elev);
 
 		const RealType interp = (1.0 - t) * (1.0 - u) * _pattern[arr_x][arr_y] +
 			t * (1.0 - u) * _pattern[(arr_x + 1) % size_azi][arr_y] +

--- a/packages/libfers/src/antenna/antenna_factory.cpp
+++ b/packages/libfers/src/antenna/antenna_factory.cpp
@@ -394,8 +394,8 @@ namespace antenna
 			LOG(Level::FATAL, "Could not load antenna description {}", filename.data());
 			throw std::runtime_error("Could not load antenna description");
 		}
-		doc.validateWithDtd(antenna_pattern_dtd);
-		doc.validateWithXsd(antenna_pattern_xsd);
+		(void)doc.validateWithDtd(antenna_pattern_dtd);
+		(void)doc.validateWithXsd(antenna_pattern_xsd);
 
 		const XmlElement root(doc.getRootElement());
 		const AxisLoadResult elev_result = loadAntennaGainAxis(_elev_samples.get(), root.childElement("elevation", 0));

--- a/packages/libfers/src/api.cpp
+++ b/packages/libfers/src/api.cpp
@@ -818,7 +818,7 @@ fers_interpolated_path_t* fers_get_interpolated_motion_path(const fers_motion_wa
 			const math::Vec3 pos = path.getPosition(start_time);
 			for (size_t i = 0; i < num_points; ++i)
 			{
-				result_path->points[i] = {pos.x, pos.y, pos.z};
+				result_path->points[i] = {pos.x, pos.y, pos.z, 0.0, 0.0, 0.0};
 			}
 			return result_path;
 		}

--- a/packages/libfers/src/api.cpp
+++ b/packages/libfers/src/api.cpp
@@ -823,11 +823,12 @@ fers_interpolated_path_t* fers_get_interpolated_motion_path(const fers_motion_wa
 			return result_path;
 		}
 
-		const double time_step = duration / (num_points > 1 ? num_points - 1 : 1);
+		const double time_step =
+			duration / static_cast<double>(num_points > 1 ? num_points - 1 : static_cast<size_t>(1));
 
 		for (size_t i = 0; i < num_points; ++i)
 		{
-			const double t = start_time + i * time_step;
+			const double t = start_time + static_cast<double>(i) * time_step;
 			const math::Vec3 pos = path.getPosition(t);
 			const math::Vec3 vel = path.getVelocity(t);
 			result_path->points[i] = {pos.x, pos.y, pos.z, vel.x, vel.y, vel.z};
@@ -915,11 +916,12 @@ fers_interpolated_rotation_path_t* fers_get_interpolated_rotation_path(const fer
 			return result_path;
 		}
 
-		const double time_step = duration / (num_points > 1 ? num_points - 1 : 1);
+		const double time_step =
+			duration / static_cast<double>(num_points > 1 ? num_points - 1 : static_cast<size_t>(1));
 
 		for (size_t i = 0; i < num_points; ++i)
 		{
-			const double t = start_time + i * time_step;
+			const double t = start_time + static_cast<double>(i) * time_step;
 			const math::SVec3 rot = path.getPosition(t);
 
 			result_path->points[i] = fers_interpolated_rotation_point_t{
@@ -996,14 +998,17 @@ fers_antenna_pattern_data_t* fers_get_antenna_pattern(const fers_context_t* cont
 		const math::SVec3 ref_angle(1.0, 0.0, 0.0);
 		double max_gain = 0.0;
 
+		const RealType az_denominator = static_cast<RealType>(az_samples - 1);
+		const RealType el_denominator = static_cast<RealType>(el_samples - 1);
+
 		for (size_t i = 0; i < el_samples; ++i)
 		{
 			// Elevation from -PI/2 to PI/2
-			const RealType elevation = (static_cast<RealType>(i) / (el_samples - 1)) * PI - (PI / 2.0);
+			const RealType elevation = (static_cast<RealType>(i) / el_denominator) * PI - (PI / 2.0);
 			for (size_t j = 0; j < az_samples; ++j)
 			{
 				// Azimuth from -PI to PI
-				const RealType azimuth = (static_cast<RealType>(j) / (az_samples - 1)) * 2.0 * PI - PI;
+				const RealType azimuth = (static_cast<RealType>(j) / az_denominator) * 2.0 * PI - PI;
 				const math::SVec3 sample_angle(1.0, azimuth, elevation);
 				const RealType gain = ant->getGain(sample_angle, ref_angle, wavelength);
 				data->gains[i * az_samples + j] = gain;

--- a/packages/libfers/src/core/rendering_job.h
+++ b/packages/libfers/src/core/rendering_job.h
@@ -32,15 +32,15 @@ namespace core
 	struct RenderingJob
 	{
 		/// The ideal, jitter-free start time of the receive window.
-		RealType ideal_start_time;
+		RealType ideal_start_time = 0.0;
 
 		/// The duration of the receive window in seconds.
-		RealType duration;
+		RealType duration = 0.0;
 
 		/// A list of all Response objects that overlap with this window.
-		std::vector<std::unique_ptr<serial::Response>> responses;
+		std::vector<std::unique_ptr<serial::Response>> responses{};
 
 		/// A list of all CW transmitters that were active during this window.
-		std::vector<radar::Transmitter*> active_cw_sources;
+		std::vector<radar::Transmitter*> active_cw_sources{};
 	};
 }

--- a/packages/libfers/src/core/sim_threading.cpp
+++ b/packages/libfers/src/core/sim_threading.cpp
@@ -284,7 +284,8 @@ namespace core
 			}
 			else if (receiver_ptr->getMode() == OperationMode::PULSED_MODE)
 			{
-				RenderingJob shutdown_job{.duration = -1.0};
+				RenderingJob shutdown_job{};
+				shutdown_job.duration = -1.0;
 				receiver_ptr->enqueueFinalizerJob(std::move(shutdown_job));
 			}
 		}

--- a/packages/libfers/src/core/sim_threading.cpp
+++ b/packages/libfers/src/core/sim_threading.cpp
@@ -43,8 +43,8 @@ namespace core
 {
 	SimulationEngine::SimulationEngine(World* world, pool::ThreadPool& pool, std::shared_ptr<ProgressReporter> reporter,
 									   std::string output_dir) :
-		_world(world), _pool(pool), _reporter(std::move(reporter)), _output_dir(std::move(output_dir)),
-		_last_report_time(std::chrono::steady_clock::now())
+		_world(world), _pool(pool), _reporter(std::move(reporter)), _last_report_time(std::chrono::steady_clock::now()),
+		_output_dir(std::move(output_dir))
 	{
 	}
 

--- a/packages/libfers/src/core/thread_pool.cpp
+++ b/packages/libfers/src/core/thread_pool.cpp
@@ -11,6 +11,9 @@
 
 #include "thread_pool.h"
 
+#include <limits>
+#include <stdexcept>
+
 #include "logging.h"
 
 namespace pool
@@ -75,7 +78,11 @@ namespace pool
 	{
 		std::unique_lock lock(_queue_mutex);
 		const unsigned active_threads = _pending_tasks;
-		const unsigned total_threads = _workers.size();
+		if (_workers.size() > static_cast<std::size_t>(std::numeric_limits<unsigned>::max()))
+		{
+			throw std::runtime_error("Thread pool size exceeds unsigned range.");
+		}
+		const unsigned total_threads = static_cast<unsigned>(_workers.size());
 		return total_threads > active_threads ? total_threads - active_threads : 0;
 	}
 }

--- a/packages/libfers/src/core/world.cpp
+++ b/packages/libfers/src/core/world.cpp
@@ -13,6 +13,7 @@
 #include "world.h"
 
 #include <iomanip>
+#include <limits>
 #include <sstream>
 
 #include "antenna/antenna_factory.h"
@@ -346,9 +347,14 @@ namespace core
 
 		const std::string separator = "--------------------------------------------------------------------";
 		const std::string title = "| Event Queue Contents (" + std::to_string(_event_queue.size()) + " events)";
+		if (separator.size() > static_cast<std::size_t>(std::numeric_limits<int>::max()))
+		{
+			throw std::runtime_error("Separator width exceeds stream formatting limits.");
+		}
+		const int title_width = static_cast<int>(separator.size()) - 1;
 
 		ss << separator << "\n"
-		   << std::left << std::setw(separator.length() - 1) << title << "|\n"
+		   << std::left << std::setw(title_width) << title << "|\n"
 		   << separator << "\n"
 		   << "| " << std::left << std::setw(12) << "Timestamp" << " | " << std::setw(21) << "Event Type" << " | "
 		   << std::setw(25) << "Source Object" << " |\n"

--- a/packages/libfers/src/interpolation/interpolation_filter.cpp
+++ b/packages/libfers/src/interpolation/interpolation_filter.cpp
@@ -117,10 +117,10 @@ namespace interp
 
 		for (std::ptrdiff_t i = -hfilt; i < hfilt; ++i)
 		{
-			const RealType delay = i / static_cast<RealType>(hfilt);
+			const RealType delay = static_cast<RealType>(i) / static_cast<RealType>(hfilt);
 			for (std::ptrdiff_t j = -alpha_offset; j < alpha_offset; ++j)
 			{
-				if (auto interp = interpFilter(j - delay); interp)
+				if (auto interp = interpFilter(static_cast<RealType>(j) - delay); interp)
 				{
 					const auto filter_index =
 						static_cast<std::size_t>(i + hfilt) * _length + static_cast<std::size_t>(j + alpha_offset);

--- a/packages/libfers/src/interpolation/interpolation_filter.cpp
+++ b/packages/libfers/src/interpolation/interpolation_filter.cpp
@@ -12,6 +12,8 @@
 
 #include "interpolation_filter.h"
 
+#include <algorithm>
+#include <cstddef>
 #include <stdexcept>
 
 #include "core/logging.h"
@@ -93,11 +95,11 @@ namespace interp
 
 	InterpFilter::InterpFilter()
 	{
-		_length = static_cast<int>(params::renderFilterLength());
+		_length = params::renderFilterLength();
 		_table_filters = 1000;
 		_filter_table = std::vector<RealType>(_table_filters * _length);
 
-		_alpha = std::floor(params::renderFilterLength() / 2.0);
+		_alpha = std::floor(static_cast<RealType>(_length) / 2.0);
 		if (auto bessel = besselI0(_beta); bessel)
 		{
 			_bessel_beta = *bessel;
@@ -108,18 +110,21 @@ namespace interp
 			throw std::runtime_error("Bessel function calculation failed");
 		}
 
-		const int hfilt = _table_filters / 2;
+		const auto hfilt = static_cast<std::ptrdiff_t>(_table_filters / 2);
+		const auto alpha_offset = static_cast<std::ptrdiff_t>(_alpha);
 
 		LOG(Level::DEBUG, "Building table of {} filters", _table_filters);
 
-		for (int i = -hfilt; i < hfilt; ++i)
+		for (std::ptrdiff_t i = -hfilt; i < hfilt; ++i)
 		{
 			const RealType delay = i / static_cast<RealType>(hfilt);
-			for (int j = static_cast<int>(-_alpha); j < _alpha; ++j)
+			for (std::ptrdiff_t j = -alpha_offset; j < alpha_offset; ++j)
 			{
 				if (auto interp = interpFilter(j - delay); interp)
 				{
-					_filter_table[(i + hfilt) * _length + j + static_cast<int>(_alpha)] = *interp;
+					const auto filter_index =
+						static_cast<std::size_t>(i + hfilt) * _length + static_cast<std::size_t>(j + alpha_offset);
+					_filter_table[filter_index] = *interp;
 				}
 				else
 				{
@@ -140,8 +145,9 @@ namespace interp
 			throw std::runtime_error("Requested delay filter value out of range");
 		}
 
-		// TODO: Investigate if OOB access can occur here
-		const auto filt = static_cast<unsigned>((delay + 1) * (_table_filters / 2.0));
-		return std::span{&_filter_table[filt * _length], static_cast<size_t>(_length)};
+		const auto filt =
+			std::min(static_cast<std::size_t>((delay + 1.0) * (static_cast<RealType>(_table_filters) / 2.0)),
+					 _table_filters - 1);
+		return std::span{_filter_table.data() + filt * _length, _length};
 	}
 }

--- a/packages/libfers/src/interpolation/interpolation_filter.h
+++ b/packages/libfers/src/interpolation/interpolation_filter.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <expected>
 #include <span>
 #include <vector>
@@ -82,8 +83,8 @@ namespace interp
 		RealType _alpha; ///< The alpha value for the Kaiser window.
 		RealType _beta = 5; ///< The beta value for the Kaiser window.
 		RealType _bessel_beta; ///< The Bessel function value for the Kaiser window.
-		int _length; ///< The length of the filter.
-		int _table_filters; ///< The number of filters in the table.
+		std::size_t _length; ///< The length of the filter.
+		std::size_t _table_filters; ///< The number of filters in the table.
 		std::vector<RealType> _filter_table; ///< The table of precomputed filters.
 	};
 }

--- a/packages/libfers/src/interpolation/interpolation_set.cpp
+++ b/packages/libfers/src/interpolation/interpolation_set.cpp
@@ -29,6 +29,14 @@ namespace interp
 			return std::nullopt;
 		}
 
+		// TODO: RealConcept is broader than the implementation really supports?
+		// std::is_arithmetic_v<T> admits integral types
+		// That may be intended, but for value(T x) it means interpolation with
+		// integer queries returns std::optional<int>, and the final interpolated
+		// double gets truncated by:
+		// return static_cast<T>(...)
+		// If the class is conceptually for real-valued interpolation,
+		// std::floating_point<T> would be a better constraint
 		const RealType x_value = static_cast<RealType>(x);
 		const auto iter = _data.lower_bound(x_value);
 

--- a/packages/libfers/src/interpolation/interpolation_set.cpp
+++ b/packages/libfers/src/interpolation/interpolation_set.cpp
@@ -29,7 +29,8 @@ namespace interp
 			return std::nullopt;
 		}
 
-		const auto iter = _data.lower_bound(static_cast<double>(x));
+		const RealType x_value = static_cast<RealType>(x);
+		const auto iter = _data.lower_bound(x_value);
 
 		if (iter == _data.begin())
 		{
@@ -40,7 +41,7 @@ namespace interp
 			const auto prev = std::prev(iter);
 			return static_cast<T>(prev->second);
 		}
-		if (iter->first == static_cast<double>(x))
+		if (iter->first == x_value)
 		{
 			return static_cast<T>(iter->second);
 		}
@@ -49,7 +50,7 @@ namespace interp
 		const auto [x1, y1] = *prev;
 		const auto [x2, y2] = *iter;
 
-		return static_cast<T>(y2 * (x - x1) / (x2 - x1) + y1 * (x2 - x) / (x2 - x1));
+		return static_cast<T>(y2 * (x_value - x1) / (x2 - x1) + y1 * (x2 - x_value) / (x2 - x1));
 	}
 
 	double InterpSetData::max() const noexcept

--- a/packages/libfers/src/math/geometry_ops.h
+++ b/packages/libfers/src/math/geometry_ops.h
@@ -65,12 +65,13 @@ namespace math
 		/**
 		 * @brief Parameterized constructor for SVec3.
 		 *
-		 * @param length The length or magnitude of the vector.
-		 * @param azimuth The azimuthal angle of the vector.
-		 * @param elevation The elevation angle of the vector.
+		 * @param vector_length The length or magnitude of the vector.
+		 * @param vector_azimuth The azimuthal angle of the vector.
+		 * @param vector_elevation The elevation angle of the vector.
 		 */
-		constexpr SVec3(const RealType length, const RealType azimuth, const RealType elevation) noexcept :
-			length(length), azimuth(azimuth), elevation(elevation)
+		constexpr SVec3(const RealType vector_length, const RealType vector_azimuth,
+						const RealType vector_elevation) noexcept :
+			length(vector_length), azimuth(vector_azimuth), elevation(vector_elevation)
 		{
 		}
 
@@ -118,11 +119,14 @@ namespace math
 		/**
 		 * @brief Parameterized constructor for Vec3.
 		 *
-		 * @param x The x component.
-		 * @param y The y component.
-		 * @param z The z component.
+		 * @param x_value The x component.
+		 * @param y_value The y component.
+		 * @param z_value The z component.
 		 */
-		constexpr Vec3(const RealType x, const RealType y, const RealType z) noexcept : x(x), y(y), z(z) {}
+		constexpr Vec3(const RealType x_value, const RealType y_value, const RealType z_value) noexcept :
+			x(x_value), y(y_value), z(z_value)
+		{
+		}
 
 		/**
 		 * @brief Constructs a rectangular vector from a spherical SVec3.

--- a/packages/libfers/src/math/path.cpp
+++ b/packages/libfers/src/math/path.cpp
@@ -13,6 +13,7 @@
 #include "path.h"
 
 #include <algorithm>
+#include <cstddef>
 
 #include "coord.h"
 #include "core/logging.h"
@@ -77,19 +78,22 @@ namespace math
 		case InterpType::INTERP_LINEAR:
 			{
 				auto xrp = std::ranges::upper_bound(_coords, t, {}, &Coord::t);
-				size_t idx = std::distance(_coords.begin(), xrp);
+				auto idx = std::distance(_coords.begin(), xrp);
 
 				// Clamp to valid segments
-				if (idx == 0)
+				if (idx <= 0)
 					idx = 1;
-				if (idx >= _coords.size())
-					idx = _coords.size() - 1;
+				if (static_cast<std::size_t>(idx) >= _coords.size())
+					idx = static_cast<decltype(idx)>(_coords.size() - 1);
 
-				if (idx < 1)
+				if (idx < 1 || static_cast<std::size_t>(idx) >= _coords.size())
 					return {0, 0, 0}; // Should not happen if size >= 1 and clamp works
 
-				const auto& p1 = _coords[idx - 1];
-				const auto& p2 = _coords[idx];
+				const auto right_idx = static_cast<std::size_t>(idx);
+				const auto left_idx = right_idx - 1;
+
+				const auto& p1 = _coords[left_idx];
+				const auto& p2 = _coords[right_idx];
 				const RealType dt = p2.t - p1.t;
 
 				if (dt <= EPSILON)
@@ -101,25 +105,26 @@ namespace math
 		case InterpType::INTERP_CUBIC:
 			{
 				auto xrp = std::ranges::upper_bound(_coords, t, {}, &Coord::t);
-				size_t xri;
+				std::ptrdiff_t xri;
 				if (xrp == _coords.begin())
 					xri = 1;
 				else if (xrp == _coords.end())
-					xri = _coords.size() - 1;
+					xri = static_cast<std::ptrdiff_t>(_coords.size() - 1);
 				else
 					xri = std::distance(_coords.begin(), xrp);
 
-				if (xri < 1 || xri >= _coords.size())
+				if (xri < 1 || static_cast<std::size_t>(xri) >= _coords.size())
 					return {0, 0, 0};
 
-				size_t xli = xri - 1;
+				const auto right_idx = static_cast<std::size_t>(xri);
+				const auto left_idx = right_idx - 1;
 
-				const RealType h = _coords[xri].t - _coords[xli].t;
+				const RealType h = _coords[right_idx].t - _coords[left_idx].t;
 				if (h <= EPSILON)
 					return {0, 0, 0};
 
-				const RealType a = (_coords[xri].t - t) / h;
-				const RealType b = (t - _coords[xli].t) / h;
+				const RealType a = (_coords[right_idx].t - t) / h;
+				const RealType b = (t - _coords[left_idx].t) / h;
 
 				// Derivative coefficients
 				// da/dt = -1/h
@@ -132,7 +137,8 @@ namespace math
 				const RealType dc = -h / 6.0 * (3.0 * a * a - 1.0);
 				const RealType dd_coeff = h / 6.0 * (3.0 * b * b - 1.0);
 
-				return _coords[xli].pos * da + _coords[xri].pos * db + _dd[xli].pos * dc + _dd[xri].pos * dd_coeff;
+				return _coords[left_idx].pos * da + _coords[right_idx].pos * db + _dd[left_idx].pos * dc +
+					_dd[right_idx].pos * dd_coeff;
 			}
 		}
 		return {0, 0, 0};

--- a/packages/libfers/src/math/path_utils.h
+++ b/packages/libfers/src/math/path_utils.h
@@ -106,14 +106,15 @@ void getPositionLinear(RealType t, T& coord, const std::vector<T>& coords)
 	}
 	else
 	{
-		auto xri = std::distance(coords.begin(), xrp);
-		auto xli = xri - 1;
+		using index_type = typename std::vector<T>::size_type;
+		const auto right_index = static_cast<index_type>(xrp - coords.begin());
+		const auto left_index = right_index - 1;
 
-		const RealType iw = coords[xri].t - coords[xli].t;
-		const RealType rw = (coords[xri].t - t) / iw;
+		const RealType iw = coords[right_index].t - coords[left_index].t;
+		const RealType rw = (coords[right_index].t - t) / iw;
 		const RealType lw = 1 - rw;
 
-		coord = coords[xri] * lw + coords[xli] * rw;
+		coord = coords[right_index] * lw + coords[left_index] * rw;
 	}
 	coord.t = t;
 }
@@ -149,19 +150,20 @@ void getPositionCubic(RealType t, T& coord, const std::vector<T>& coords, const 
 	}
 	else
 	{
-		auto xri = std::distance(coords.begin(), xrp);
-		auto xli = xri - 1;
+		using index_type = typename std::vector<T>::size_type;
+		const auto right_index = static_cast<index_type>(xrp - coords.begin());
+		const auto left_index = right_index - 1;
 
-		const RealType xrd = coords[xri].t - t;
-		const RealType xld = t - coords[xli].t;
-		const RealType iw = coords[xri].t - coords[xli].t;
+		const RealType xrd = coords[right_index].t - t;
+		const RealType xld = t - coords[left_index].t;
+		const RealType iw = coords[right_index].t - coords[left_index].t;
 		const RealType iws = iw * iw / 6.0;
 		const RealType a = xrd / iw;
 		const RealType b = xld / iw;
 		const RealType c = (a * a * a - a) * iws;
 		const RealType d = (b * b * b - b) * iws;
 
-		coord = coords[xli] * a + coords[xri] * b + dd[xli] * c + dd[xri] * d;
+		coord = coords[left_index] * a + coords[right_index] * b + dd[left_index] * c + dd[right_index] * d;
 	}
 	coord.t = t;
 }
@@ -177,7 +179,8 @@ void getPositionCubic(RealType t, T& coord, const std::vector<T>& coords, const 
 template <Interpolatable T>
 void finalizeCubic(const std::vector<T>& coords, std::vector<T>& dd)
 {
-	const int size = static_cast<int>(coords.size());
+	using index_type = typename std::vector<T>::size_type;
+	const index_type size = coords.size();
 	if (size < 2)
 	{
 		throw math::PathException("Not enough points for cubic interpolation");
@@ -189,13 +192,16 @@ void finalizeCubic(const std::vector<T>& coords, std::vector<T>& dd)
 	dd.front() = 0;
 	dd.back() = 0;
 
-	for (int i = 1; i < size - 1; ++i)
+	for (index_type i = 1; i + 1 < size; ++i)
 	{
-		const T yrd = coords[i + 1] - coords[i];
-		const T yld = coords[i] - coords[i - 1];
-		const RealType xrd = coords[i + 1].t - coords[i].t;
-		const RealType xld = coords[i].t - coords[i - 1].t;
-		const RealType iw = coords[i + 1].t - coords[i - 1].t;
+		const index_type next_index = i + 1;
+		const index_type prev_index = i - 1;
+
+		const T yrd = coords[next_index] - coords[i];
+		const T yld = coords[i] - coords[prev_index];
+		const RealType xrd = coords[next_index].t - coords[i].t;
+		const RealType xld = coords[i].t - coords[prev_index].t;
+		const RealType iw = coords[next_index].t - coords[prev_index].t;
 
 		if (iw <= EPSILON)
 		{
@@ -208,12 +214,12 @@ void finalizeCubic(const std::vector<T>& coords, std::vector<T>& dd)
 		const T yld_xld = (xld <= EPSILON) ? (yld * 0.0) : (yld / xld);
 
 		const RealType si = xld / iw;
-		const T p = dd[i - 1] * si + 2.0;
+		const T p = dd[prev_index] * si + 2.0;
 		dd[i] = (si - 1.0) / p;
-		tmp[i] = ((yrd_xrd - yld_xld) * 6.0 / iw - tmp[i - 1] * si) / p;
+		tmp[i] = ((yrd_xrd - yld_xld) * 6.0 / iw - tmp[prev_index] * si) / p;
 	}
 
-	for (int i = size - 2; i >= 0; --i)
+	for (index_type i = size - 1; i-- > 0;)
 	{
 		dd[i] = dd[i] * dd[i + 1] + tmp[i];
 	}

--- a/packages/libfers/src/noise/falpha_branch.cpp
+++ b/packages/libfers/src/noise/falpha_branch.cpp
@@ -59,7 +59,7 @@ namespace noise
 			_highpass = std::make_unique<IirFilter>(hp_den.data(), hp_num.data(), hp_num.size());
 		}
 
-		if (_ffrac == 0.5f)
+		if (_ffrac == 0.5)
 		{
 			constexpr std::array sf_num = {
 				5.210373977738306e-03,	-7.694671394585578e-03, 1.635979377907092e-03,	9.852449140857658e-05,
@@ -74,7 +74,7 @@ namespace noise
 			_shape_gain = 5.210373977738306e-03;
 			_shape_filter = std::make_unique<IirFilter>(sf_den.data(), sf_num.data(), sf_num.size());
 		}
-		else if (_ffrac != 0.0f)
+		else if (_ffrac != 0.0)
 		{
 			LOG(Level::FATAL, "Fractional noise generation values other than 0.5 or 0 are not supported. ffrac={}",
 				_ffrac);

--- a/packages/libfers/src/noise/noise_generators.cpp
+++ b/packages/libfers/src/noise/noise_generators.cpp
@@ -34,9 +34,14 @@ namespace noise
 	}
 
 	// NOLINTNEXTLINE(readability-make-member-function-const)
-	void MultirateGenerator::skipSamples(const long long samples) noexcept
+	void MultirateGenerator::skipSamples(const std::size_t samples) noexcept
 	{
-		if (const int skip_branches = static_cast<int>(std::log10(samples)) - 1; skip_branches > 0)
+		if (samples == 0)
+		{
+			return;
+		}
+
+		if (const int skip_branches = static_cast<int>(std::log10(static_cast<double>(samples))) - 1; skip_branches > 0)
 		{
 			std::vector<FAlphaBranch*> flushbranches;
 			FAlphaBranch* branch = _topbranch.get();
@@ -49,8 +54,9 @@ namespace noise
 
 			if (branch != nullptr)
 			{
-				const auto reduced_samples = samples / static_cast<long long>(std::pow(10.0, skip_branches));
-				for (long long i = 0; i < reduced_samples; ++i)
+				const auto reduced_samples =
+					samples / static_cast<std::size_t>(std::pow(10.0, static_cast<double>(skip_branches)));
+				for (std::size_t i = 0; i < reduced_samples; ++i)
 				{
 					branch->getSample();
 				}
@@ -63,7 +69,7 @@ namespace noise
 		}
 		else
 		{
-			for (long long i = 0; i < samples; ++i)
+			for (std::size_t i = 0; i < samples; ++i)
 			{
 				_topbranch->getSample();
 			}
@@ -149,7 +155,7 @@ namespace noise
 		return sample;
 	}
 
-	void ClockModelGenerator::skipSamples(const long long samples)
+	void ClockModelGenerator::skipSamples(const std::size_t samples)
 	{
 		for (const auto& generator : _generators)
 		{

--- a/packages/libfers/src/noise/noise_generators.h
+++ b/packages/libfers/src/noise/noise_generators.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <random>
@@ -138,7 +139,7 @@ namespace noise
 		 *
 		 * @param samples The number of samples to skip.
 		 */
-		void skipSamples(long long samples) noexcept;
+		void skipSamples(std::size_t samples) noexcept;
 
 		/**
 		 * @brief Resets the noise generator state.
@@ -196,7 +197,7 @@ namespace noise
 		 *
 		 * @param samples The number of samples to skip.
 		 */
-		void skipSamples(long long samples);
+		void skipSamples(std::size_t samples);
 
 		/**
 		 * @brief Resets the noise generator state.
@@ -217,6 +218,6 @@ namespace noise
 		RealType _phase_offset; ///< Phase offset for the noise.
 		RealType _freq_offset; ///< Frequency offset for the noise.
 		RealType _frequency; ///< Base frequency of the clock model.
-		unsigned long _count = 0; ///< Sample counter.
+		std::size_t _count = 0; ///< Sample counter.
 	};
 }

--- a/packages/libfers/src/processing/finalizer_pipeline.cpp
+++ b/packages/libfers/src/processing/finalizer_pipeline.cpp
@@ -27,21 +27,39 @@ namespace processing::pipeline
 {
 	void advanceTimingModel(timing::Timing* timing_model, const radar::Receiver* receiver, const RealType rate)
 	{
+
 		if ((timing_model == nullptr) || !timing_model->isEnabled())
 		{
 			return;
 		}
 
+		// Convert the duration-derived sample advance to a signed temporary first.
+		// The physical calculation can legitimately produce a negative or zero result
+		// (for example due to floor() or an inter-pulse gap that is not positive),
+		// but skipSamples() models advancing by a non-negative sample count only.
+		// After validating that the computed value is > 0, cast to std::size_t for
+		// the skipSamples() call chain:
+		//   Timing::skipSamples -> ClockModelGenerator::skipSamples ->
+		//   MultirateGenerator::skipSamples.
+		// This preserves the sign until validation and avoids passing invalid negative
+		// counts into the timing/noise generators.
 		if (timing_model->getSyncOnPulse())
 		{
 			timing_model->reset();
-			timing_model->skipSamples(static_cast<long>(std::floor(rate * receiver->getWindowSkip())));
+			const auto skip_samples = static_cast<long long>(std::floor(rate * receiver->getWindowSkip()));
+			if (skip_samples > 0)
+			{
+				timing_model->skipSamples(static_cast<std::size_t>(skip_samples));
+			}
 		}
 		else
 		{
 			const RealType inter_pulse_skip_duration = 1.0 / receiver->getWindowPrf() - receiver->getWindowLength();
-			const auto samples_to_skip = static_cast<long>(std::floor(rate * inter_pulse_skip_duration));
-			timing_model->skipSamples(samples_to_skip);
+			const auto samples_to_skip = static_cast<long long>(std::floor(rate * inter_pulse_skip_duration));
+			if (samples_to_skip > 0)
+			{
+				timing_model->skipSamples(static_cast<std::size_t>(samples_to_skip));
+			}
 		}
 	}
 

--- a/packages/libfers/src/processing/signal_processor.cpp
+++ b/packages/libfers/src/processing/signal_processor.cpp
@@ -57,18 +57,18 @@ namespace
 	 * @param localWindowSize The size of the local window in samples.
 	 */
 	void processResponse(const serial::Response* resp, std::vector<ComplexType>& localWindow, const RealType rate,
-						 const RealType start, const RealType fracDelay, const unsigned localWindowSize)
+						 const RealType start, const RealType fracDelay, const std::size_t localWindowSize)
 	{
 		unsigned psize;
 		RealType prate;
 		const auto array = resp->renderBinary(prate, psize, fracDelay);
 		int start_sample = static_cast<int>(std::round(rate * (resp->startTime() - start)));
-		const unsigned roffset = start_sample < 0 ? -start_sample : 0;
-		start_sample = std::max(start_sample, 0);
+		const auto roffset = start_sample < 0 ? static_cast<std::size_t>(-start_sample) : std::size_t{0};
+		const auto start_offset = static_cast<std::size_t>(std::max(start_sample, 0));
 
-		for (unsigned i = roffset; i < psize && i + start_sample < localWindowSize; ++i)
+		for (std::size_t i = roffset; i < psize && i + start_offset < localWindowSize; ++i)
 		{
-			localWindow[i + start_sample] += array[i];
+			localWindow[i + start_offset] += array[i];
 		}
 	}
 }
@@ -90,7 +90,7 @@ namespace processing
 		}
 
 		const RealType rate = params::rate() * params::oversampleRatio();
-		const auto local_window_size = static_cast<unsigned>(std::ceil(length * rate));
+		const auto local_window_size = static_cast<std::size_t>(std::ceil(length * rate));
 
 		std::vector local_window(local_window_size, ComplexType{});
 
@@ -101,7 +101,7 @@ namespace processing
 			processResponse(resp, local_window, rate, start, fracDelay, local_window_size);
 		}
 
-		for (unsigned i = 0; i < local_window_size; ++i)
+		for (std::size_t i = 0; i < local_window_size; ++i)
 		{
 			window[i] += local_window[i];
 		}

--- a/packages/libfers/src/serial/hdf5_handler.cpp
+++ b/packages/libfers/src/serial/hdf5_handler.cpp
@@ -82,7 +82,7 @@ namespace serial
 	{
 		std::scoped_lock lock(hdf5_global_mutex);
 
-		const unsigned size = data.size();
+		const std::size_t size = data.size();
 
 		const std::string base_chunk_name = "chunk_" + std::format("{:06}", count);
 		const std::string i_chunk_name = base_chunk_name + "_I";

--- a/packages/libfers/src/serial/kml_generator_utils.cpp
+++ b/packages/libfers/src/serial/kml_generator_utils.cpp
@@ -9,6 +9,7 @@
 #include <GeographicLib/Geodesic.hpp>
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <iomanip>
 #include <map>
 #include <ranges>
@@ -46,23 +47,24 @@ namespace serial::kml_generator_utils
 
 	double find3DbDropAngle(const double alpha, const double beta, const double gamma)
 	{
-		constexpr int num_points = 1000;
+		constexpr std::size_t num_points = 1000;
+		const auto midpoint = static_cast<std::ptrdiff_t>(num_points / 2);
 		std::vector<double> theta(num_points);
 		std::vector<double> gain(num_points);
-		for (int i = 0; i < num_points; ++i)
+		for (std::size_t i = 0; i < num_points; ++i)
 		{
-			theta[i] = -PI + 2.0 * PI * i / (num_points - 1);
+			theta[i] = -PI + 2.0 * PI * static_cast<double>(i) / static_cast<double>(num_points - 1);
 			gain[i] = sincAntennaGain(theta[i], alpha, beta, gamma);
 		}
-		const double max_gain = *std::max_element(gain.begin() + num_points / 2, gain.end());
+		const auto search_begin = gain.begin() + midpoint;
+		const double max_gain = *std::max_element(search_begin, gain.end());
 		const double max_gain_db = 10.0 * std::log10(max_gain);
 		const double target_gain_db = max_gain_db - 3.0;
-		double target_gain = std::pow(10.0, target_gain_db / 10.0);
-		const int idx = std::distance(
-			gain.begin() + num_points / 2,
-			std::min_element(gain.begin() + num_points / 2, gain.end(), [target_gain](const double a, const double b)
-							 { return std::abs(a - target_gain) < std::abs(b - target_gain); }));
-		const double angle_3db_drop = theta[idx + num_points / 2];
+		const double target_gain = std::pow(10.0, target_gain_db / 10.0);
+		const auto min_gain = std::min_element(search_begin, gain.end(), [target_gain](const double a, const double b)
+											   { return std::abs(a - target_gain) < std::abs(b - target_gain); });
+		const auto idx = static_cast<std::size_t>(std::distance(search_begin, min_gain));
+		const double angle_3db_drop = theta[static_cast<std::size_t>(midpoint) + idx];
 		return angle_3db_drop * 180.0 / PI;
 	}
 

--- a/packages/libfers/src/serial/waveform_factory.cpp
+++ b/packages/libfers/src/serial/waveform_factory.cpp
@@ -12,10 +12,12 @@
 
 #include "waveform_factory.h"
 
+#include <cmath>
 #include <complex>
 #include <cstddef>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <span>
 #include <stdexcept>
 #include <string_view>
@@ -33,6 +35,31 @@ using fers_signal::Signal;
 
 namespace
 {
+	[[nodiscard]] unsigned checked_sample_count(const std::size_t sample_count, const std::string_view source)
+	{
+		if (sample_count > static_cast<std::size_t>(std::numeric_limits<unsigned>::max()))
+		{
+			throw std::runtime_error(std::format("Waveform '{}' has too many samples to load into Signal.", source));
+		}
+		return static_cast<unsigned>(sample_count);
+	}
+
+	[[nodiscard]] unsigned parse_csv_sample_count(const RealType sample_count, const std::filesystem::path& filepath)
+	{
+		if (!std::isfinite(sample_count) || sample_count < 0.0 || std::trunc(sample_count) != sample_count)
+		{
+			throw std::runtime_error("Waveform file '" + filepath.string() + "' has an invalid sample count header.");
+		}
+
+		if (sample_count > static_cast<RealType>(std::numeric_limits<unsigned>::max()))
+		{
+			throw std::runtime_error("Waveform file '" + filepath.string() +
+									 "' declares more samples than Signal can represent.");
+		}
+
+		return static_cast<unsigned>(sample_count);
+	}
+
 	/**
 	 * @brief Loads a radar waveform from an HDF5 file and returns a RadarSignal object.
 	 *
@@ -49,11 +76,12 @@ namespace
 	{
 		std::vector<ComplexType> data;
 		serial::readPulseData(filepath.string(), data);
+		const unsigned sample_count = checked_sample_count(data.size(), filepath.string());
 
 		auto signal = std::make_unique<Signal>();
-		signal->load(data, data.size(), params::rate());
+		signal->load(data, sample_count, params::rate());
 		return std::make_unique<RadarSignal>(
-			name, power, carrierFreq, static_cast<RealType>(data.size()) / params::rate(), std::move(signal), id);
+			name, power, carrierFreq, static_cast<RealType>(sample_count) / params::rate(), std::move(signal), id);
 	}
 
 	/**
@@ -77,10 +105,20 @@ namespace
 			throw std::runtime_error("Could not open file '" + filepath.string() + "' to read waveform");
 		}
 
-		RealType rlength, rate;
-		ifile >> rlength >> rate;
+		RealType rlength = 0.0;
+		RealType rate = 0.0;
+		if (!(ifile >> rlength >> rate))
+		{
+			LOG(logging::Level::FATAL, "Could not read waveform header from file '{}'", filepath.string());
+			throw std::runtime_error("Could not read waveform header from file '" + filepath.string() + "'");
+		}
+		if (!std::isfinite(rate) || rate <= 0.0)
+		{
+			LOG(logging::Level::FATAL, "Waveform file '{}' has invalid sample rate {}", filepath.string(), rate);
+			throw std::runtime_error("Waveform file '" + filepath.string() + "' has an invalid sample rate");
+		}
 
-		const auto length = static_cast<std::size_t>(rlength);
+		const unsigned length = parse_csv_sample_count(rlength, filepath);
 		std::vector<ComplexType> data(length);
 
 		// Read the file data

--- a/packages/libfers/src/serial/xml_parser_utils.cpp
+++ b/packages/libfers/src/serial/xml_parser_utils.cpp
@@ -139,67 +139,89 @@ namespace serial::xml_parser_utils
 		}
 		LOG(logging::Level::DEBUG, "Sample rate set to: {:.5f}", params_out.rate);
 
-		auto set_param_with_exception_handling =
-			[&](const XmlElement& element, const std::string& paramName, const RealType defaultValue, auto setter)
+		const auto parse_unsigned_parameter = [&](const std::string_view param_name, const RealType raw_value)
 		{
-			try
+			if (!std::isfinite(raw_value))
 			{
-				if (paramName == "adc_bits" || paramName == "oversample")
-				{
-					setter(static_cast<unsigned>(std::floor(get_child_real_type(element, paramName))));
-				}
-				else
-				{
-					setter(get_child_real_type(element, paramName));
-				}
+				throw XmlException(std::format("Parameter '{}' must be finite.", param_name));
 			}
-			catch (const XmlException&)
+			if (raw_value < 0.0)
 			{
-				LOG(logging::Level::WARNING, "Failed to set parameter {}. Using default value. {}", paramName,
-					defaultValue);
+				throw XmlException(std::format("Parameter '{}' must be non-negative.", param_name));
 			}
+
+			const RealType floored_value = std::floor(raw_value);
+			if (floored_value > static_cast<RealType>(std::numeric_limits<unsigned>::max()))
+			{
+				throw XmlException(std::format("Parameter '{}' exceeds the supported unsigned range.", param_name));
+			}
+
+			return static_cast<unsigned>(floored_value);
 		};
 
-		set_param_with_exception_handling(parameters, "c", params::Parameters::DEFAULT_C,
-										  [&](RealType v)
-										  {
-											  params_out.c = v;
-											  LOG(logging::Level::INFO, "Propagation speed (c) set to: {:.5f}", v);
-										  });
-
-		set_param_with_exception_handling(parameters, "simSamplingRate", 1000.0,
-										  [&](RealType v)
-										  {
-											  params_out.sim_sampling_rate = v;
-											  LOG(logging::Level::DEBUG, "Simulation sampling rate set to: {:.5f} Hz",
-												  v);
-										  });
-
-		try
+		auto set_optional_real_parameter = [&](const std::string& param_name, const RealType default_value, auto setter)
 		{
-			const auto seed = static_cast<unsigned>(std::floor(get_child_real_type(parameters, "randomseed")));
+			if (!parameters.childElement(param_name, 0).isValid())
+			{
+				LOG(logging::Level::WARNING, "Failed to set parameter {}. Using default value. {}", param_name,
+					default_value);
+				return;
+			}
+
+			setter(get_child_real_type(parameters, param_name));
+		};
+
+		auto set_optional_unsigned_parameter =
+			[&](const std::string& param_name, const unsigned default_value, auto setter)
+		{
+			if (!parameters.childElement(param_name, 0).isValid())
+			{
+				LOG(logging::Level::WARNING, "Failed to set parameter {}. Using default value. {}", param_name,
+					default_value);
+				return;
+			}
+
+			setter(parse_unsigned_parameter(param_name, get_child_real_type(parameters, param_name)));
+		};
+
+		set_optional_real_parameter("c", params::Parameters::DEFAULT_C,
+									[&](const RealType value)
+									{
+										params_out.c = value;
+										LOG(logging::Level::INFO, "Propagation speed (c) set to: {:.5f}", value);
+									});
+
+		set_optional_real_parameter("simSamplingRate", 1000.0,
+									[&](const RealType value)
+									{
+										params_out.sim_sampling_rate = value;
+										LOG(logging::Level::DEBUG, "Simulation sampling rate set to: {:.5f} Hz", value);
+									});
+
+		if (parameters.childElement("randomseed", 0).isValid())
+		{
+			const auto seed = parse_unsigned_parameter("randomseed", get_child_real_type(parameters, "randomseed"));
 			params_out.random_seed = seed;
 			LOG(logging::Level::DEBUG, "Random seed set to: {}", seed);
 		}
-		catch (const XmlException&)
-		{
-		}
 
-		set_param_with_exception_handling(parameters, "adc_bits", 0,
-										  [&](unsigned v)
-										  {
-											  params_out.adc_bits = v;
-											  LOG(logging::Level::DEBUG, "ADC quantization bits set to: {}", v);
-										  });
+		set_optional_unsigned_parameter("adc_bits", 0,
+										[&](const unsigned value)
+										{
+											params_out.adc_bits = value;
+											LOG(logging::Level::DEBUG, "ADC quantization bits set to: {}", value);
+										});
 
-		set_param_with_exception_handling(parameters, "oversample", 1,
-										  [&](unsigned v)
-										  {
-											  if (v == 0)
-												  throw std::runtime_error("Oversample ratio must be >= 1");
-											  params_out.oversample_ratio = v;
-											  LOG(logging::Level::DEBUG, "Oversampling enabled with ratio: {}", v);
-										  });
+		set_optional_unsigned_parameter("oversample", 1,
+										[&](const unsigned value)
+										{
+											if (value == 0)
+											{
+												throw std::runtime_error("Oversample ratio must be >= 1");
+											}
+											params_out.oversample_ratio = value;
+											LOG(logging::Level::DEBUG, "Oversampling enabled with ratio: {}", value);
+										});
 
 		try
 		{
@@ -1023,15 +1045,15 @@ namespace serial::xml_parser_utils
 		params::params = ctx.parameters;
 
 		auto parseElements =
-			[](const XmlElement& root, const std::string& elementName, ParserContext& ctx, auto parseFunction)
+			[](const XmlElement& parent, const std::string& elementName, ParserContext& parser_ctx, auto parseFunction)
 		{
 			unsigned index = 0;
 			while (true)
 			{
-				XmlElement element = root.childElement(elementName, index++);
+				XmlElement element = parent.childElement(elementName, index++);
 				if (!element.isValid())
 					break;
-				parseFunction(element, ctx);
+				parseFunction(element, parser_ctx);
 			}
 		};
 

--- a/packages/libfers/src/serial/xml_parser_utils.cpp
+++ b/packages/libfers/src/serial/xml_parser_utils.cpp
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <filesystem>
 #include <format>
+#include <limits>
 #include <string_view>
 
 #include "antenna/antenna_factory.h"
@@ -38,6 +39,16 @@ namespace fs = std::filesystem;
 
 namespace serial::xml_parser_utils
 {
+	namespace
+	{
+		[[nodiscard]] unsigned next_seed(std::mt19937& master_seeder)
+		{
+			static_assert(std::mt19937::max() <= std::numeric_limits<unsigned>::max(),
+						  "std::mt19937 output must fit into unsigned seeds.");
+			return static_cast<unsigned>(master_seeder());
+		}
+	}
+
 	RealType get_child_real_type(const XmlElement& element, const std::string& elementName)
 	{
 		const std::string text = element.childElement(elementName, 0).getText();
@@ -664,7 +675,7 @@ namespace serial::xml_parser_utils
 							   "'");
 		}
 		const auto timing_obj =
-			std::make_shared<timing::Timing>(proto->getName(), (*ctx.master_seeder)(), proto->getId());
+			std::make_shared<timing::Timing>(proto->getName(), next_seed(*ctx.master_seeder), proto->getId());
 		timing_obj->initializeModel(proto);
 		transmitter_obj->setTiming(timing_obj);
 
@@ -688,7 +699,7 @@ namespace serial::xml_parser_utils
 		const bool is_pulsed = pulsed_mode_element.isValid();
 		const radar::OperationMode mode = is_pulsed ? radar::OperationMode::PULSED_MODE : radar::OperationMode::CW_MODE;
 
-		auto receiver_obj = std::make_unique<radar::Receiver>(platform, name, (*ctx.master_seeder)(), mode, id);
+		auto receiver_obj = std::make_unique<radar::Receiver>(platform, name, next_seed(*ctx.master_seeder), mode, id);
 
 		const SimId ant_id = resolve_reference_id(receiver, "antenna", "receiver '" + name + "'", *refs.antennas);
 		const antenna::Antenna* antenna = ctx.world->findAntenna(ant_id);
@@ -741,7 +752,7 @@ namespace serial::xml_parser_utils
 			throw XmlException("Timing ID '" + std::to_string(timing_id) + "' not found for receiver '" + name + "'");
 		}
 		const auto timing_obj =
-			std::make_shared<timing::Timing>(proto->getName(), (*ctx.master_seeder)(), proto->getId());
+			std::make_shared<timing::Timing>(proto->getName(), next_seed(*ctx.master_seeder), proto->getId());
 		timing_obj->initializeModel(proto);
 		receiver_obj->setTiming(timing_obj);
 
@@ -791,7 +802,7 @@ namespace serial::xml_parser_utils
 
 		const std::string rcs_type = XmlElement::getSafeAttribute(rcs_element, "type");
 		std::unique_ptr<radar::Target> target_obj;
-		const unsigned seed = (*ctx.master_seeder)();
+		const unsigned seed = next_seed(*ctx.master_seeder);
 
 		if (rcs_type == "isotropic")
 		{

--- a/packages/libfers/src/serial/xml_serializer_utils.h
+++ b/packages/libfers/src/serial/xml_serializer_utils.h
@@ -83,7 +83,8 @@ namespace serial::xml_serializer_utils
 			std::array<char, 64> buffer{};
 			if (auto [ptr, ec] = std::to_chars(buffer.data(), buffer.data() + buffer.size(), value); ec == std::errc())
 			{
-				addChildWithText(parent, name, std::string(buffer.data(), ptr - buffer.data()));
+				const auto length = static_cast<std::string::size_type>(ptr - buffer.data());
+				addChildWithText(parent, name, std::string(buffer.data(), length));
 			}
 			else
 			{

--- a/packages/libfers/src/signal/dsp_filters.h
+++ b/packages/libfers/src/signal/dsp_filters.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <span>
 #include <vector>
@@ -146,7 +147,7 @@ namespace fers_signal
 	private:
 		std::vector<RealType> _filter; ///< Filter coefficients
 		std::vector<RealType> _w; ///< Internal state
-		unsigned _order{}; ///< Filter order
+		std::size_t _order{}; ///< Filter order
 	};
 
 	/**

--- a/packages/libfers/src/signal/radar_signal.cpp
+++ b/packages/libfers/src/signal/radar_signal.cpp
@@ -26,7 +26,7 @@
 
 namespace fers_signal
 {
-	std::vector<ComplexType> CwSignal::render(const std::vector<interp::InterpPoint>& points, unsigned& size,
+	std::vector<ComplexType> CwSignal::render(const std::vector<interp::InterpPoint>& /*points*/, unsigned& size,
 											  const RealType /*fracWinDelay*/) const
 	{
 		size = 0;

--- a/packages/libfers/src/signal/radar_signal.cpp
+++ b/packages/libfers/src/signal/radar_signal.cpp
@@ -109,7 +109,7 @@ namespace fers_signal
 				calculateWeightsAndDelays(iter, next, sample_time, idelay, fracWinDelay);
 			const auto& filt = interp.getFilter(fdelay);
 			ComplexType accum = performConvolution(i, filt.data(), filt_length, amplitude, i_sample_unwrap);
-			out[i] = std::exp(ComplexType(0.0, 1.0) * phase) * accum;
+			out[static_cast<std::size_t>(i)] = std::exp(ComplexType(0.0, 1.0) * phase) * accum;
 
 			sample_time += timestep;
 		}
@@ -145,10 +145,11 @@ namespace fers_signal
 
 		for (int j = start; j < end; ++j)
 		{
-			if (const unsigned sample_idx = i + j + iSampleUnwrap;
-				sample_idx < _size && j + filtLength / 2 < filtLength)
+			const int sample_idx = i + j + iSampleUnwrap;
+			const int filt_idx = j + filtLength / 2;
+			if (sample_idx >= 0 && sample_idx < static_cast<int>(_size) && filt_idx >= 0 && filt_idx < filtLength)
 			{
-				accum += amplitude * _data[sample_idx] * filt[j + filtLength / 2];
+				accum += amplitude * _data[static_cast<std::size_t>(sample_idx)] * filt[filt_idx];
 			}
 		}
 

--- a/packages/libfers/src/timing/timing.cpp
+++ b/packages/libfers/src/timing/timing.cpp
@@ -70,7 +70,7 @@ namespace timing
 		_model = std::make_unique<noise::ClockModelGenerator>(_rng, _alphas, _weights, _frequency, _phase_offset,
 															  _freq_offset, 15);
 
-		if (timing->getFrequency() == 0.0f)
+		if (timing->getFrequency() == 0.0)
 		{
 			LOG(Level::INFO, "Timing source frequency not set, results could be incorrect.");
 		}

--- a/packages/libfers/src/timing/timing.cpp
+++ b/packages/libfers/src/timing/timing.cpp
@@ -28,7 +28,7 @@ namespace timing
 	}
 
 	// NOLINTNEXTLINE(readability-make-member-function-const)
-	void Timing::skipSamples(const long long samples) noexcept
+	void Timing::skipSamples(const std::size_t samples) noexcept
 	{
 		if (_enabled && _model)
 		{

--- a/packages/libfers/src/timing/timing.h
+++ b/packages/libfers/src/timing/timing.h
@@ -56,9 +56,9 @@ namespace timing
 		/**
 		 * @brief Gets the next sample from the timing source.
 		 *
-		 * @return The next sample value or 0.0f if not enabled.
+		 * @return The next sample value or 0.0 if not enabled.
 		 */
-		[[nodiscard]] RealType getNextSample() const noexcept { return _enabled ? _model->getSample() : 0.0f; }
+		[[nodiscard]] RealType getNextSample() const noexcept { return _enabled ? _model->getSample() : 0.0; }
 
 		/**
 		 * @brief Gets the name of the timing source.

--- a/packages/libfers/src/timing/timing.h
+++ b/packages/libfers/src/timing/timing.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <random>
 #include <string>
@@ -119,7 +120,7 @@ namespace timing
 		 *
 		 * @param samples The number of samples to skip.
 		 */
-		void skipSamples(long long samples) noexcept;
+		void skipSamples(std::size_t samples) noexcept;
 
 		/**
 		 * @brief Initializes the timing model.

--- a/packages/libfers/tests/api/test_api_paths.cpp
+++ b/packages/libfers/tests/api/test_api_paths.cpp
@@ -86,6 +86,9 @@ TEST_CASE("API motion path interpolation falls back to repeated positions for no
 		REQUIRE_THAT(point.x, WithinAbs(2.0, 1e-12));
 		REQUIRE_THAT(point.y, WithinAbs(3.0, 1e-12));
 		REQUIRE_THAT(point.z, WithinAbs(4.0, 1e-12));
+		REQUIRE_THAT(point.vx, WithinAbs(0.0, 1e-12));
+		REQUIRE_THAT(point.vy, WithinAbs(0.0, 1e-12));
+		REQUIRE_THAT(point.vz, WithinAbs(0.0, 1e-12));
 	}
 }
 

--- a/packages/libfers/tests/api/test_api_runtime.cpp
+++ b/packages/libfers/tests/api/test_api_runtime.cpp
@@ -44,8 +44,13 @@ TEST_CASE("API log level mapping covers all exported enum values", "[api][runtim
 		fers_log_level_t level;
 		const char* label;
 	} cases[] = {
-		{FERS_LOG_TRACE, "trace"}, {FERS_LOG_DEBUG, "debug"}, {FERS_LOG_WARNING, "warning"},
-		{FERS_LOG_ERROR, "error"}, {FERS_LOG_FATAL, "fatal"}, {static_cast<fers_log_level_t>(999), "default"},
+		{FERS_LOG_TRACE, "trace"},
+		{FERS_LOG_DEBUG, "debug"},
+		{FERS_LOG_WARNING, "warning"},
+		{FERS_LOG_ERROR, "error"},
+		{FERS_LOG_FATAL, "fatal"},
+		// Exercise the fallback branch with a value outside the exported enum set but still representable.
+		{static_cast<fers_log_level_t>(FERS_LOG_FATAL + 1), "default"},
 	};
 
 	for (const auto& entry : cases)

--- a/packages/libfers/tests/interpolation/test_interpolation_filter.cpp
+++ b/packages/libfers/tests/interpolation/test_interpolation_filter.cpp
@@ -91,3 +91,15 @@ TEST_CASE("InterpFilter getFilter rejects out of range", "[interpolation][filter
 	REQUIRE_THROWS_AS(filter.getFilter(1.1), std::runtime_error);
 	REQUIRE_THROWS_AS(filter.getFilter(-1.1), std::runtime_error);
 }
+
+TEST_CASE("InterpFilter getFilter keeps the upper boundary in range", "[interpolation][filter]")
+{
+	interp::InterpFilter& filter = interp::InterpFilter::getInstance();
+
+	const auto last_filter = filter.getFilter(1.0);
+	const auto near_last_filter = filter.getFilter(0.999);
+
+	REQUIRE(last_filter.size() == params::renderFilterLength());
+	REQUIRE(near_last_filter.size() == last_filter.size());
+	REQUIRE(last_filter.data() >= near_last_filter.data());
+}

--- a/packages/libfers/tests/interpolation/test_interpolation_set.cpp
+++ b/packages/libfers/tests/interpolation/test_interpolation_set.cpp
@@ -67,6 +67,17 @@ TEST_CASE("InterpSetData linearly interpolates", "[interpolation][set]")
 	REQUIRE_THAT(*mid, WithinAbs(5.0, 1e-12));
 }
 
+TEST_CASE("InterpSetData linearly interpolates float queries", "[interpolation][set]")
+{
+	interp::InterpSetData data;
+	data.insertSample(0.0, 0.0);
+	data.insertSample(10.0, 20.0);
+
+	auto mid = data.value(2.5f);
+	REQUIRE(mid.has_value());
+	REQUIRE_THAT(*mid, WithinAbs(5.0f, 1e-6f));
+}
+
 TEST_CASE("InterpSetData max uses absolute magnitude", "[interpolation][set]")
 {
 	interp::InterpSetData data;

--- a/packages/libfers/tests/processing/test_finalizer.cpp
+++ b/packages/libfers/tests/processing/test_finalizer.cpp
@@ -67,11 +67,6 @@ namespace
 		return prefix + "_" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
 	}
 
-	std::filesystem::path resultPath(const std::string& receiver_name)
-	{
-		return std::filesystem::current_path() / (receiver_name + "_results.h5");
-	}
-
 	void removeIfExists(const std::filesystem::path& path)
 	{
 		std::error_code ec;

--- a/packages/libfers/tests/serial/test_json_serializer_stress.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer_stress.cpp
@@ -146,6 +146,7 @@ namespace
 	{
 		std::uniform_real_distribution<RealType> dist_real(0.1, 1000.0);
 		std::uniform_int_distribution<int> dist_mode(0, 1);
+		std::uniform_int_distribution<unsigned> seed_dist;
 
 		std::vector<SimId> wave_ids, ant_ids, time_ids;
 
@@ -243,7 +244,7 @@ namespace
 			auto tx = std::make_unique<radar::Transmitter>(plat.get(), "tx_" + std::to_string(i), tx_mode);
 			tx->setWave(world.findWaveform(wave_ids[i % wave_ids.size()]));
 			tx->setAntenna(world.findAntenna(ant_ids[i % ant_ids.size()]));
-			auto tx_tim = std::make_shared<timing::Timing>(proto_tim->getName(), rng(), proto_tim->getId());
+			auto tx_tim = std::make_shared<timing::Timing>(proto_tim->getName(), seed_dist(rng), proto_tim->getId());
 			tx_tim->initializeModel(proto_tim);
 			tx->setTiming(tx_tim);
 			if (tx_mode == radar::OperationMode::PULSED_MODE)
@@ -253,9 +254,9 @@ namespace
 
 			// Standalone Receiver
 			auto rx_mode = dist_mode(rng) == 0 ? radar::OperationMode::PULSED_MODE : radar::OperationMode::CW_MODE;
-			auto rx = std::make_unique<radar::Receiver>(plat.get(), "rx_" + std::to_string(i), rng(), rx_mode);
+			auto rx = std::make_unique<radar::Receiver>(plat.get(), "rx_" + std::to_string(i), seed_dist(rng), rx_mode);
 			rx->setAntenna(world.findAntenna(ant_ids[(i + 1) % ant_ids.size()]));
-			auto rx_tim = std::make_shared<timing::Timing>(proto_tim->getName(), rng(), proto_tim->getId());
+			auto rx_tim = std::make_shared<timing::Timing>(proto_tim->getName(), seed_dist(rng), proto_tim->getId());
 			rx_tim->initializeModel(proto_tim);
 			rx->setTiming(rx_tim);
 			rx->setNoiseTemperature(290.0);
@@ -273,18 +274,20 @@ namespace
 			auto mono_tx = std::make_unique<radar::Transmitter>(plat.get(), "mono_tx_" + std::to_string(i), mono_mode);
 			mono_tx->setWave(world.findWaveform(wave_ids[(i + 2) % wave_ids.size()]));
 			mono_tx->setAntenna(world.findAntenna(ant_ids[(i + 2) % ant_ids.size()]));
-			auto mono_tx_tim = std::make_shared<timing::Timing>(proto_tim->getName(), rng(), proto_tim->getId());
+			auto mono_tx_tim =
+				std::make_shared<timing::Timing>(proto_tim->getName(), seed_dist(rng), proto_tim->getId());
 			mono_tx_tim->initializeModel(proto_tim);
 			mono_tx->setTiming(mono_tx_tim);
 			if (mono_mode == radar::OperationMode::PULSED_MODE)
 				mono_tx->setPrf(2000.0 + dist_real(rng));
 			mono_tx->setSchedule({{0.01, 0.09}});
 
-			auto mono_rx =
-				std::make_unique<radar::Receiver>(plat.get(), "mono_rx_" + std::to_string(i), rng(), mono_mode);
+			auto mono_rx = std::make_unique<radar::Receiver>(plat.get(), "mono_rx_" + std::to_string(i), seed_dist(rng),
+															 mono_mode);
 			mono_rx->setAntenna(
 				world.findAntenna(ant_ids[(i + 2) % ant_ids.size()])); // Monostatic usually shares antenna
-			auto mono_rx_tim = std::make_shared<timing::Timing>(proto_tim->getName(), rng(), proto_tim->getId());
+			auto mono_rx_tim =
+				std::make_shared<timing::Timing>(proto_tim->getName(), seed_dist(rng), proto_tim->getId());
 			mono_rx_tim->initializeModel(proto_tim);
 			mono_rx->setTiming(mono_rx_tim);
 			mono_rx->setNoiseTemperature(300.0);
@@ -299,7 +302,7 @@ namespace
 			world.add(std::move(mono_rx));
 
 			// Target
-			auto tgt = radar::createIsoTarget(plat.get(), "tgt_" + std::to_string(i), dist_real(rng), rng());
+			auto tgt = radar::createIsoTarget(plat.get(), "tgt_" + std::to_string(i), dist_real(rng), seed_dist(rng));
 			if (i % 2 == 0)
 			{
 				tgt->setFluctuationModel(std::make_unique<radar::RcsChiSquare>(tgt->getRngEngine(), 2.0));

--- a/packages/libfers/tests/serial/test_waveform_factory.cpp
+++ b/packages/libfers/tests/serial/test_waveform_factory.cpp
@@ -214,7 +214,56 @@ TEST_CASE("Waveform factory throws for incomplete CSV waveform data", "[serial][
 	removeIfExists(path);
 }
 
-// TODO: Add a malformed CSV header test once loadWaveformFromCsvFile validates
-// header extraction before using the parsed values. The current implementation
-// reads header values into uninitialized locals on extraction failure, which is
-// not reliable to exercise deterministically in a unit test.
+TEST_CASE("Waveform factory throws for malformed CSV header", "[serial][waveform_factory]")
+{
+	const std::filesystem::path path = tempFilePath(uniqueFileName("waveform_factory_bad_header", ".csv"));
+	removeIfExists(path);
+
+	{
+		std::ofstream out(path);
+		REQUIRE(out.is_open());
+		out << "not-a-count\n";
+		out << "still-not-a-rate\n";
+	}
+
+	REQUIRE_THROWS_AS(serial::loadWaveformFromFile("wave", path.string(), 1.0, 2.0), std::runtime_error);
+
+	removeIfExists(path);
+}
+
+TEST_CASE("Waveform factory rejects invalid CSV sample counts", "[serial][waveform_factory]")
+{
+	SECTION("fractional sample count")
+	{
+		const std::filesystem::path path = tempFilePath(uniqueFileName("waveform_factory_fractional_count", ".csv"));
+		removeIfExists(path);
+
+		{
+			std::ofstream out(path);
+			REQUIRE(out.is_open());
+			out << 2.5 << "\n";
+			out << 16.0 << "\n";
+			out << ComplexType(1.0, 0.0) << "\n";
+			out << ComplexType(0.0, 1.0) << "\n";
+		}
+
+		REQUIRE_THROWS_AS(serial::loadWaveformFromFile("wave", path.string(), 1.0, 2.0), std::runtime_error);
+		removeIfExists(path);
+	}
+
+	SECTION("negative sample count")
+	{
+		const std::filesystem::path path = tempFilePath(uniqueFileName("waveform_factory_negative_count", ".csv"));
+		removeIfExists(path);
+
+		{
+			std::ofstream out(path);
+			REQUIRE(out.is_open());
+			out << -1 << "\n";
+			out << 16.0 << "\n";
+		}
+
+		REQUIRE_THROWS_AS(serial::loadWaveformFromFile("wave", path.string(), 1.0, 2.0), std::runtime_error);
+		removeIfExists(path);
+	}
+}

--- a/packages/libfers/tests/serial/test_xml_parser_utils.cpp
+++ b/packages/libfers/tests/serial/test_xml_parser_utils.cpp
@@ -3,6 +3,7 @@
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <filesystem>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -182,6 +183,59 @@ TEST_CASE("parseParameters extracts simulation parameters", "[serial][xml_parser
 		REQUIRE(p.random_seed.value() == 42);
 		REQUIRE(p.rotation_angle_unit == params::RotationAngleUnit::Radians);
 		REQUIRE(p.coordinate_frame == params::CoordinateFrame::ECEF);
+	}
+
+	SECTION("Unsigned optional parameters floor positive fractional values")
+	{
+		auto doc = loadXml("<parameters>"
+						   "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
+						   "  <randomseed>42.9</randomseed>"
+						   "  <adc_bits>12.8</adc_bits>"
+						   "  <oversample>4.2</oversample>"
+						   "</parameters>");
+
+		params::Parameters p;
+		serial::xml_parser_utils::parseParameters(doc.getRootElement(), p);
+
+		REQUIRE(p.random_seed.has_value());
+		REQUIRE(p.random_seed.value() == 42);
+		REQUIRE(p.adc_bits == 12);
+		REQUIRE(p.oversample_ratio == 4);
+	}
+
+	SECTION("Unsigned optional parameters reject invalid values")
+	{
+		const auto parse_invalid = [](const std::string& xml)
+		{
+			params::Parameters p;
+			auto doc = loadXml(xml);
+			serial::xml_parser_utils::parseParameters(doc.getRootElement(), p);
+		};
+		const auto too_large_unsigned =
+			std::to_string(static_cast<unsigned long long>(std::numeric_limits<unsigned>::max()) + 1ULL);
+
+		REQUIRE_THROWS_AS(parse_invalid("<parameters>"
+										"  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
+										"  <randomseed>-1</randomseed>"
+										"</parameters>"),
+						  XmlException);
+
+		REQUIRE_THROWS_AS(parse_invalid("<parameters>"
+										"  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
+										"  <adc_bits>nan</adc_bits>"
+										"</parameters>"),
+						  XmlException);
+
+		REQUIRE_THROWS_AS(parse_invalid("<parameters>"
+										"  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
+										"  <oversample>0</oversample>"
+										"</parameters>"),
+						  std::runtime_error);
+
+		REQUIRE_THROWS_AS(parse_invalid(std::string("<parameters>") +
+										"  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>" +
+										"  <adc_bits>" + too_large_unsigned + "</adc_bits>" + "</parameters>"),
+						  XmlException);
 	}
 
 	SECTION("UTM North Hemisphere")

--- a/packages/libfers/tests/serial/test_xml_parser_utils.cpp
+++ b/packages/libfers/tests/serial/test_xml_parser_utils.cpp
@@ -596,6 +596,8 @@ TEST_CASE("parseTarget handles chisquare model", "[serial][xml_parser_utils]")
 {
 	core::World world;
 	std::mt19937 seeder(42);
+	const unsigned expected_seed = static_cast<unsigned>(seeder());
+	seeder.seed(42);
 	serial::xml_parser_utils::ParserContext ctx;
 	ctx.world = &world;
 	ctx.master_seeder = &seeder;
@@ -612,6 +614,7 @@ TEST_CASE("parseTarget handles chisquare model", "[serial][xml_parser_utils]")
 	auto* tgt = world.getTargets().front().get();
 	auto* model = dynamic_cast<const radar::RcsChiSquare*>(tgt->getFluctuationModel());
 	REQUIRE(model != nullptr);
+	REQUIRE(tgt->getSeed() == expected_seed);
 	REQUIRE_THAT(model->getK(), WithinAbs(2.0, 1e-5));
 }
 

--- a/packages/libfers/tests/simulation/test_channel_model_direct.cpp
+++ b/packages/libfers/tests/simulation/test_channel_model_direct.cpp
@@ -104,9 +104,7 @@ TEST_CASE("solveReDirect Friis equation with different distances", "[simulation]
 	params::params.reset();
 
 	// Verify inverse-square law: doubling distance should quarter the power
-	const RealType c = params::c();
 	const RealType carrier = 3.0e9; // 3 GHz
-	const RealType lambda = c / carrier;
 
 	antenna::Isotropic iso_ant("iso");
 	auto timing = std::make_shared<timing::Timing>("clk", 42);

--- a/packages/libfers/tests/simulation/test_channel_model_response.cpp
+++ b/packages/libfers/tests/simulation/test_channel_model_response.cpp
@@ -301,9 +301,6 @@ TEST_CASE("calculateResponse direct path interp points have consistent Friis pow
 	const RealType dist = 2000.0;
 	const RealType carrier = 1.0e9;
 	const RealType c = params::c();
-	const RealType lambda = c / carrier;
-
-	const RealType expected_power = (lambda * lambda) / (16.0 * PI * PI * dist * dist);
 
 	radar::Platform tx_plat("tx_plat");
 	setupPlatform(tx_plat, math::Vec3{0.0, 0.0, 0.0});

--- a/scripts/summarize_build_log.py
+++ b/scripts/summarize_build_log.py
@@ -1,0 +1,1007 @@
+#!/usr/bin/env python3
+"""
+summarize_build_log.py
+
+Summarize a CMake/Make/Ninja C/C++ build log into a readable report.
+
+The script can:
+- parse compiler warnings, errors, and notes from a build log
+- detect build targets and link steps
+- count raw emitted warnings and unique warning sites
+- distinguish header-origin warnings from source-file warnings
+- optionally enrich the analysis with compile_commands.json
+- emit plain text, Markdown, or JSON output
+
+Examples:
+    python summarize_build_log.py build.log
+    python summarize_build_log.py build.log --markdown
+    python summarize_build_log.py build.log --json
+    python summarize_build_log.py build.log --compile-db build/release/compile_commands.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Optional
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+WARNING_RE = re.compile(
+    r"""
+    ^
+    (?P<file>.*?)
+    :
+    (?P<line>\d+)
+    :
+    (?P<col>\d+)
+    :
+    \s+
+    warning:
+    \s+
+    (?P<message>.*?)
+    (?:\s+\[(?P<flag>[^\]]+)\])?
+    \s*$
+    """,
+    re.VERBOSE,
+)
+
+ERROR_RE = re.compile(
+    r"""
+    ^
+    (?P<file>.*?)
+    :
+    (?P<line>\d+)
+    :
+    (?P<col>\d+)
+    :
+    \s+
+    error:
+    \s+
+    (?P<message>.*?)
+    (?:\s+\[(?P<flag>[^\]]+)\])?
+    \s*$
+    """,
+    re.VERBOSE,
+)
+
+NOTE_RE = re.compile(
+    r"""
+    ^
+    (?P<file>.*?)
+    :
+    (?P<line>\d+)
+    :
+    (?P<col>\d+)
+    :
+    \s+
+    note:
+    \s+
+    (?P<message>.*?)
+    \s*$
+    """,
+    re.VERBOSE,
+)
+
+IN_FUNCTION_RE = re.compile(
+    r"^\s*(?P<file>.*?): In (?:function|member function|constructor|destructor|lambda function)\s+[‘'].*$"
+)
+INSTANTIATION_RE = re.compile(r"^\s*(?P<file>.*?): In instantiation of [‘'].*$")
+BUILDING_OBJ_RE = re.compile(r"^\[\s*\d+%\] Building (?:C|CXX) object (.+)$")
+LINKING_RE = re.compile(r"^\[\s*\d+%\] Linking (.+)$")
+BUILT_TARGET_RE = re.compile(r"^\[\s*\d+%\] Built target (.+)$")
+
+COMPILER_CMD_RE = re.compile(r"(^|\s)(?:/usr/bin/)?(?:c\+\+|g\+\+|clang\+\+|cc|gcc|clang)(\s|$)")
+WARNING_FLAG_IN_CMD_RE = re.compile(r"(?<!\S)(-W[a-zA-Z0-9][\w=-]*)(?!\S)")
+STD_RE = re.compile(r"(?<!\S)-std=([^\s]+)")
+OPT_RE = re.compile(r"(?<!\S)(-O[0-3sgz]|-Ofast)(?!\S)")
+DEFINE_RE = re.compile(r"(?<!\S)-D([A-Za-z_]\w*)(?:=([^\s]+))?")
+INCLUDE_RE = re.compile(r"(?<!\S)(?:-I|-isystem)\s*([^\s]+)")
+MAKE_ERROR_RE = re.compile(r"(?:gmake|make|ninja)(?:\[\d+\])?: \*\*\*")
+FATAL_RE = re.compile(r"\bfatal error\b", re.IGNORECASE)
+FAILED_RE = re.compile(r"\b(?:FAILED|failed)\b")
+ENTER_DIR_RE = re.compile(r"Entering directory '([^']+)'")
+SOURCE_PATH_RE = re.compile(r"(?<!\S)(/[^ ]+\.(?:c|cc|cpp|cxx|c\+\+|C))(?!\S)")
+OUTPUT_OBJ_RE = re.compile(r"(?<!\S)-o\s+([^\s]+(?:\.o|\.obj))(?!\S)")
+
+
+@dataclass
+class Diagnostic:
+    kind: str
+    file: str
+    line: int
+    col: int
+    message: str
+    flag: Optional[str] = None
+    context: Optional[str] = None
+    translation_unit: Optional[str] = None
+    target_hint: Optional[str] = None
+
+    def site_key(self) -> tuple:
+        return (self.kind, self.file, self.line, self.col, self.message, self.flag)
+
+    def broad_key(self) -> tuple:
+        return (self.kind, self.file, self.line, self.message, self.flag)
+
+
+@dataclass
+class CompileCommand:
+    directory: Optional[str]
+    file: Optional[str]
+    output: Optional[str]
+    command: Optional[str]
+    arguments: list[str] = field(default_factory=list)
+    std: Optional[str] = None
+    optimization: Optional[str] = None
+    warning_flags: list[str] = field(default_factory=list)
+    defines: list[str] = field(default_factory=list)
+    includes: list[str] = field(default_factory=list)
+    target_hint: Optional[str] = None
+
+
+@dataclass
+class BuildSummary:
+    build_dir: Optional[str] = None
+    build_command: Optional[str] = None
+    success: Optional[bool] = None
+
+    warnings: int = 0
+    errors: int = 0
+    notes: int = 0
+
+    diagnostics: list[Diagnostic] = field(default_factory=list)
+    compile_commands: list[CompileCommand] = field(default_factory=list)
+
+    warnings_by_flag: Counter = field(default_factory=Counter)
+    warnings_by_file: Counter = field(default_factory=Counter)
+    errors_by_file: Counter = field(default_factory=Counter)
+
+    built_targets: list[str] = field(default_factory=list)
+    building_steps: list[str] = field(default_factory=list)
+    linking_steps: list[str] = field(default_factory=list)
+    directories_entered: list[str] = field(default_factory=list)
+
+    compiler_warning_flags_seen: Counter = field(default_factory=Counter)
+    standards_seen: Counter = field(default_factory=Counter)
+    optimization_levels_seen: Counter = field(default_factory=Counter)
+
+    raw_error_lines: list[str] = field(default_factory=list)
+    fatal_lines: list[str] = field(default_factory=list)
+
+
+def strip_ansi(text: str) -> str:
+    return ANSI_RE.sub("", text)
+
+
+def compact_message(msg: str, limit: int = 150) -> str:
+    msg = " ".join(msg.split())
+    return msg if len(msg) <= limit else msg[: limit - 1] + "…"
+
+
+def shorten_path(path: str, build_dir: Optional[str]) -> str:
+    p = path.strip()
+    if not p:
+        return p
+
+    home = str(Path.home())
+    if p.startswith(home):
+        p = "~" + p[len(home):]
+
+    if build_dir:
+        bd = build_dir.rstrip("/")
+        if p.startswith(bd):
+            rel = p[len(bd):].lstrip("/")
+            return f"<build>/{rel}" if rel else "<build>"
+
+    return p
+
+
+def normalize_path(path: Optional[str], base_dir: Optional[str] = None) -> Optional[str]:
+    if not path:
+        return None
+    p = Path(path)
+    if not p.is_absolute() and base_dir:
+        p = Path(base_dir) / p
+    try:
+        return str(p.resolve(strict=False))
+    except Exception:
+        return str(p)
+
+
+def extract_target_hint(output: Optional[str], directory: Optional[str]) -> Optional[str]:
+    candidate = output or directory
+    if not candidate:
+        return None
+
+    parts = Path(candidate).parts
+    if "CMakeFiles" in parts:
+        idx = parts.index("CMakeFiles")
+        if idx + 1 < len(parts):
+            name = parts[idx + 1]
+            if name.endswith(".dir"):
+                return name[:-4]
+
+    for part in reversed(parts):
+        if part.endswith(".dir"):
+            return part[:-4]
+    return None
+
+
+def parse_compile_command_from_line(line: str) -> Optional[CompileCommand]:
+    if not COMPILER_CMD_RE.search(line):
+        return None
+    if " -c " not in line:
+        return None
+
+    warning_flags = sorted(set(WARNING_FLAG_IN_CMD_RE.findall(line)))
+    std_match = STD_RE.search(line)
+    opt_match = OPT_RE.search(line)
+    defines = [m.group(1) for m in DEFINE_RE.finditer(line)]
+    includes = [m.group(1) for m in INCLUDE_RE.finditer(line)]
+    source = None
+    candidates = SOURCE_PATH_RE.findall(line)
+    if candidates:
+        source = candidates[-1]
+    output_match = OUTPUT_OBJ_RE.search(line)
+    output = output_match.group(1) if output_match else None
+
+    return CompileCommand(
+        directory=None,
+        file=source,
+        output=output,
+        command=line,
+        arguments=[],
+        std=std_match.group(1) if std_match else None,
+        optimization=opt_match.group(1) if opt_match else None,
+        warning_flags=warning_flags,
+        defines=defines,
+        includes=includes,
+        target_hint=extract_target_hint(output, None),
+    )
+
+
+def load_compile_database(path: str) -> list[CompileCommand]:
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        raw = json.load(f)
+
+    commands: list[CompileCommand] = []
+    for entry in raw:
+        directory = entry.get("directory")
+        file_ = normalize_path(entry.get("file"), directory)
+        output = normalize_path(entry.get("output"), directory) if entry.get("output") else None
+
+        command_text = entry.get("command")
+        arguments = entry.get("arguments", [])
+
+        text_for_scan = command_text or " ".join(arguments)
+
+        warning_flags = sorted(set(WARNING_FLAG_IN_CMD_RE.findall(text_for_scan)))
+        std_match = STD_RE.search(text_for_scan)
+        opt_match = OPT_RE.search(text_for_scan)
+        defines = [m.group(1) for m in DEFINE_RE.finditer(text_for_scan)]
+        includes = [m.group(1) for m in INCLUDE_RE.finditer(text_for_scan)]
+
+        commands.append(
+            CompileCommand(
+                directory=normalize_path(directory),
+                file=file_,
+                output=output,
+                command=command_text,
+                arguments=arguments,
+                std=std_match.group(1) if std_match else None,
+                optimization=opt_match.group(1) if opt_match else None,
+                warning_flags=warning_flags,
+                defines=defines,
+                includes=includes,
+                target_hint=extract_target_hint(output, directory),
+            )
+        )
+    return commands
+
+
+def parse_log(path: str) -> BuildSummary:
+    summary = BuildSummary()
+    current_context: Optional[str] = None
+    current_tu: Optional[str] = None
+
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        for raw_line in f:
+            line = strip_ansi(raw_line.rstrip("\n"))
+            if not line.strip():
+                continue
+
+            if line.startswith("Change Dir: "):
+                summary.build_dir = line.split(":", 1)[1].strip().strip("'")
+                continue
+
+            if line.startswith("Run Build Command(s): "):
+                summary.build_command = line.split(":", 1)[1].strip()
+                continue
+
+            m = ENTER_DIR_RE.search(line)
+            if m:
+                summary.directories_entered.append(m.group(1))
+                continue
+
+            m = BUILDING_OBJ_RE.match(line)
+            if m:
+                summary.building_steps.append(m.group(1))
+                continue
+
+            m = LINKING_RE.match(line)
+            if m:
+                summary.linking_steps.append(m.group(1))
+                continue
+
+            m = BUILT_TARGET_RE.match(line)
+            if m:
+                summary.built_targets.append(m.group(1))
+                continue
+
+            cmd = parse_compile_command_from_line(line)
+            if cmd:
+                summary.compile_commands.append(cmd)
+                current_tu = normalize_path(cmd.file)
+                for wf in cmd.warning_flags:
+                    summary.compiler_warning_flags_seen[wf] += 1
+                if cmd.std:
+                    summary.standards_seen[cmd.std] += 1
+                if cmd.optimization:
+                    summary.optimization_levels_seen[cmd.optimization] += 1
+                continue
+
+            m = IN_FUNCTION_RE.match(line)
+            if m:
+                current_context = compact_message(line.strip())
+                continue
+
+            m = INSTANTIATION_RE.match(line)
+            if m:
+                current_context = compact_message(line.strip())
+                continue
+
+            m = WARNING_RE.match(line)
+            if m:
+                d = Diagnostic(
+                    kind="warning",
+                    file=normalize_path(m.group("file")) or m.group("file"),
+                    line=int(m.group("line")),
+                    col=int(m.group("col")),
+                    message=m.group("message").strip(),
+                    flag=m.group("flag"),
+                    context=current_context,
+                    translation_unit=current_tu,
+                )
+                summary.diagnostics.append(d)
+                summary.warnings += 1
+                summary.warnings_by_file[d.file] += 1
+                summary.warnings_by_flag[d.flag or "(unclassified)"] += 1
+                continue
+
+            m = ERROR_RE.match(line)
+            if m:
+                d = Diagnostic(
+                    kind="error",
+                    file=normalize_path(m.group("file")) or m.group("file"),
+                    line=int(m.group("line")),
+                    col=int(m.group("col")),
+                    message=m.group("message").strip(),
+                    flag=m.group("flag"),
+                    context=current_context,
+                    translation_unit=current_tu,
+                )
+                summary.diagnostics.append(d)
+                summary.errors += 1
+                summary.errors_by_file[d.file] += 1
+                summary.raw_error_lines.append(line)
+                continue
+
+            m = NOTE_RE.match(line)
+            if m:
+                d = Diagnostic(
+                    kind="note",
+                    file=normalize_path(m.group("file")) or m.group("file"),
+                    line=int(m.group("line")),
+                    col=int(m.group("col")),
+                    message=m.group("message").strip(),
+                    context=current_context,
+                    translation_unit=current_tu,
+                )
+                summary.diagnostics.append(d)
+                summary.notes += 1
+                continue
+
+            if FATAL_RE.search(line):
+                summary.fatal_lines.append(line)
+            if MAKE_ERROR_RE.search(line) or FAILED_RE.search(line):
+                summary.raw_error_lines.append(line)
+
+    if summary.errors > 0 or summary.fatal_lines or summary.raw_error_lines:
+        summary.success = False
+    elif summary.built_targets:
+        summary.success = True
+    else:
+        summary.success = None
+
+    return summary
+
+
+def merge_compile_database(summary: BuildSummary, compile_db: list[CompileCommand]) -> None:
+    if not compile_db:
+        return
+
+    if not summary.compile_commands:
+        summary.compile_commands = compile_db
+    else:
+        known = {(c.file, c.output, c.target_hint) for c in summary.compile_commands}
+        for cmd in compile_db:
+            key = (cmd.file, cmd.output, cmd.target_hint)
+            if key not in known:
+                summary.compile_commands.append(cmd)
+                known.add(key)
+
+    summary.compiler_warning_flags_seen.clear()
+    summary.standards_seen.clear()
+    summary.optimization_levels_seen.clear()
+
+    for cmd in summary.compile_commands:
+        for wf in cmd.warning_flags:
+            summary.compiler_warning_flags_seen[wf] += 1
+        if cmd.std:
+            summary.standards_seen[cmd.std] += 1
+        if cmd.optimization:
+            summary.optimization_levels_seen[cmd.optimization] += 1
+
+    tu_to_targets: dict[str, set[str]] = defaultdict(set)
+    for cmd in summary.compile_commands:
+        if cmd.file and cmd.target_hint:
+            tu_to_targets[cmd.file].add(cmd.target_hint)
+
+    for d in summary.diagnostics:
+        if d.translation_unit and d.translation_unit in tu_to_targets:
+            targets = sorted(tu_to_targets[d.translation_unit])
+            if len(targets) == 1:
+                d.target_hint = targets[0]
+            elif targets:
+                d.target_hint = ",".join(targets)
+
+
+def unique_diagnostics(diags: list[Diagnostic], mode: str) -> list[Diagnostic]:
+    seen = set()
+    out = []
+    for d in diags:
+        key = d.site_key() if mode == "site" else d.broad_key()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(d)
+    return out
+
+
+def top_counter(counter: Counter, n: int) -> list[tuple[str, int]]:
+    return counter.most_common(n)
+
+
+def unique_sources(summary: BuildSummary) -> int:
+    return len({c.file for c in summary.compile_commands if c.file})
+
+
+def format_status(summary: BuildSummary) -> str:
+    if summary.success is True:
+        return "SUCCESS"
+    if summary.success is False:
+        return "FAILED"
+    return "UNKNOWN"
+
+
+def is_header(path: str) -> bool:
+    lower = path.lower()
+    return lower.endswith((".h", ".hh", ".hpp", ".hxx"))
+
+
+def diagnostic_repetition_map(diags: list[Diagnostic], mode: str) -> dict[tuple, int]:
+    counter: Counter = Counter()
+    for d in diags:
+        key = d.site_key() if mode == "site" else d.broad_key()
+        counter[key] += 1
+    return dict(counter)
+
+
+def summarize_warning_hotspots(summary: BuildSummary, dedupe_mode: str) -> dict:
+    warnings = [d for d in summary.diagnostics if d.kind == "warning"]
+    unique_warns = unique_diagnostics(warnings, dedupe_mode)
+    raw_repeat_map = diagnostic_repetition_map(warnings, dedupe_mode)
+
+    unique_by_file = Counter()
+    raw_by_file = Counter()
+    unique_by_flag = Counter()
+    raw_by_flag = Counter()
+    repeated_sites = []
+
+    for d in warnings:
+        raw_by_file[d.file] += 1
+        raw_by_flag[d.flag or "(unclassified)"] += 1
+
+    for d in unique_warns:
+        unique_by_file[d.file] += 1
+        unique_by_flag[d.flag or "(unclassified)"] += 1
+        key = d.site_key() if dedupe_mode == "site" else d.broad_key()
+        repeats = raw_repeat_map.get(key, 1)
+        if repeats > 1:
+            repeated_sites.append((d, repeats))
+
+    repeated_sites.sort(key=lambda item: item[1], reverse=True)
+
+    header_raw = sum(1 for d in warnings if is_header(d.file))
+    header_unique = sum(1 for d in unique_warns if is_header(d.file))
+    source_raw = len(warnings) - header_raw
+    source_unique = len(unique_warns) - header_unique
+
+    return {
+        "raw_count": len(warnings),
+        "unique_count": len(unique_warns),
+        "raw_by_file": raw_by_file,
+        "unique_by_file": unique_by_file,
+        "raw_by_flag": raw_by_flag,
+        "unique_by_flag": unique_by_flag,
+        "header_raw": header_raw,
+        "header_unique": header_unique,
+        "source_raw": source_raw,
+        "source_unique": source_unique,
+        "repeated_sites": repeated_sites,
+        "unique_warnings": unique_warns,
+    }
+
+
+def representative_diagnostics(diags: list[Diagnostic], max_examples: int, dedupe_mode: str) -> list[Diagnostic]:
+    return unique_diagnostics(diags, dedupe_mode)[:max_examples]
+
+
+def format_diag_text_lines(d: Diagnostic, build_dir: Optional[str]) -> list[str]:
+    location = f"{shorten_path(d.file, build_dir)}:{d.line}:{d.col}"
+    flag = f" [{d.flag}]" if d.flag else ""
+    lines = [f"- {location}{flag}", f"  {compact_message(d.message)}"]
+    if d.context:
+        lines.append(f"  Context: {compact_message(d.context)}")
+    if d.translation_unit:
+        lines.append(f"  TU: {shorten_path(d.translation_unit, build_dir)}")
+    if d.target_hint:
+        lines.append(f"  Target: {d.target_hint}")
+    return lines
+
+
+def format_diag_markdown_lines(d: Diagnostic, build_dir: Optional[str]) -> list[str]:
+    location = f"{shorten_path(d.file, build_dir)}:{d.line}:{d.col}"
+    flag = f" `{d.flag}`" if d.flag else ""
+    lines = [f"- **{location}**{flag}: {compact_message(d.message)}"]
+    if d.context:
+        lines.append(f"  - Context: `{compact_message(d.context)}`")
+    if d.translation_unit:
+        lines.append(f"  - TU: `{shorten_path(d.translation_unit, build_dir)}`")
+    if d.target_hint:
+        lines.append(f"  - Target: `{d.target_hint}`")
+    return lines
+
+
+def generate_human_summary(
+    summary: BuildSummary,
+    dedupe_mode: str = "site",
+    max_examples: int = 5,
+    show_files: int = 10,
+    show_flags: int = 10,
+    show_repeated: int = 5,
+) -> str:
+    lines: list[str] = []
+    warn_stats = summarize_warning_hotspots(summary, dedupe_mode)
+    warnings = [d for d in summary.diagnostics if d.kind == "warning"]
+    errors = [d for d in summary.diagnostics if d.kind == "error"]
+
+    lines.append("BUILD SUMMARY")
+    lines.append("=" * 72)
+    lines.append(f"Status           : {format_status(summary)}")
+    if summary.build_dir:
+        lines.append(f"Build directory  : {shorten_path(summary.build_dir, summary.build_dir)}")
+    if summary.build_command:
+        lines.append(f"Build command    : {summary.build_command}")
+    lines.append(f"Dedupe mode      : {dedupe_mode}")
+    lines.append("")
+
+    lines.append("High-level results")
+    lines.append("-" * 72)
+    lines.append(f"Raw warnings     : {warn_stats['raw_count']}")
+    lines.append(f"Unique warnings  : {warn_stats['unique_count']}")
+    lines.append(f"Errors           : {summary.errors}")
+    lines.append(f"Notes            : {summary.notes}")
+    lines.append(f"Compile commands : {len(summary.compile_commands)}")
+    lines.append(f"Unique sources   : {unique_sources(summary)}")
+    lines.append(f"Built targets    : {len(summary.built_targets)}")
+    lines.append("")
+
+    lines.append("Warning origin breakdown")
+    lines.append("-" * 72)
+    lines.append(f"Header warnings  : raw={warn_stats['header_raw']}, unique={warn_stats['header_unique']}")
+    lines.append(f"Source warnings  : raw={warn_stats['source_raw']}, unique={warn_stats['source_unique']}")
+    if warn_stats["raw_count"] > 0:
+        lines.append(f"Repeat factor    : {warn_stats['raw_count'] / max(warn_stats['unique_count'], 1):.2f}x raw-to-unique")
+    lines.append("")
+
+    if summary.built_targets:
+        lines.append("Targets built")
+        lines.append("-" * 72)
+        for t in summary.built_targets[:20]:
+            lines.append(f"- {t}")
+        if len(summary.built_targets) > 20:
+            lines.append(f"... and {len(summary.built_targets) - 20} more")
+        lines.append("")
+
+    if summary.standards_seen or summary.optimization_levels_seen or summary.compiler_warning_flags_seen:
+        lines.append("Compiler configuration detected")
+        lines.append("-" * 72)
+        if summary.standards_seen:
+            lines.append("C++ standards    : " + ", ".join(f"{k} ({v})" for k, v in summary.standards_seen.most_common()))
+        if summary.optimization_levels_seen:
+            lines.append("Optimization     : " + ", ".join(f"{k} ({v})" for k, v in summary.optimization_levels_seen.most_common()))
+        if summary.compiler_warning_flags_seen:
+            top_flags_text = ", ".join(
+                f"{flag} ({count})"
+                for flag, count in summary.compiler_warning_flags_seen.most_common(min(12, len(summary.compiler_warning_flags_seen)))
+            )
+            lines.append(f"Warning flags    : {top_flags_text}")
+        lines.append("")
+
+    lines.append("Most common warning categories")
+    lines.append("-" * 72)
+    for flag, count in top_counter(warn_stats["raw_by_flag"], show_flags):
+        uniq = warn_stats["unique_by_flag"].get(flag, 0)
+        lines.append(f"- {flag}: raw={count}, unique={uniq}")
+    lines.append("")
+
+    lines.append("Files with the most warnings")
+    lines.append("-" * 72)
+    for file, count in top_counter(warn_stats["raw_by_file"], show_files):
+        uniq = warn_stats["unique_by_file"].get(file, 0)
+        lines.append(f"- {shorten_path(file, summary.build_dir)}: raw={count}, unique={uniq}")
+    lines.append("")
+
+    if warn_stats["repeated_sites"]:
+        lines.append("Most repeated warning sites")
+        lines.append("-" * 72)
+        for d, repeats in warn_stats["repeated_sites"][:show_repeated]:
+            location = f"{shorten_path(d.file, summary.build_dir)}:{d.line}:{d.col}"
+            flag = f" [{d.flag}]" if d.flag else ""
+            lines.append(f"- {location}{flag}: repeated {repeats} times")
+            lines.append(f"  {compact_message(d.message)}")
+        lines.append("")
+
+    warn_examples = representative_diagnostics(warnings, max_examples, dedupe_mode)
+    if warn_examples:
+        lines.append("Representative warnings")
+        lines.append("-" * 72)
+        for d in warn_examples:
+            lines.extend(format_diag_text_lines(d, summary.build_dir))
+        lines.append("")
+
+    err_examples = representative_diagnostics(errors, max_examples, dedupe_mode)
+    if err_examples:
+        lines.append("Representative errors")
+        lines.append("-" * 72)
+        for d in err_examples:
+            lines.extend(format_diag_text_lines(d, summary.build_dir))
+        lines.append("")
+
+    lines.append("Interpretation")
+    lines.append("-" * 72)
+    if summary.success is True and summary.errors == 0:
+        if warn_stats["raw_count"] == 0:
+            lines.append("The build completed cleanly with no warnings or errors.")
+        else:
+            top_raw = warn_stats["raw_by_flag"].most_common(3)
+            top_text = ", ".join(f"{flag} ({count})" for flag, count in top_raw)
+            lines.append(f"The build succeeded, but warnings remain. Dominant raw warning classes: {top_text}.")
+            if warn_stats["raw_count"] != warn_stats["unique_count"]:
+                lines.append(
+                    f"Many warnings are repeated emissions: {warn_stats['raw_count']} raw warnings collapse to "
+                    f"{warn_stats['unique_count']} unique warning sites."
+                )
+            if warn_stats["header_raw"] > warn_stats["source_raw"]:
+                lines.append(
+                    "Most warning volume originates in headers, which suggests a small number of warning sites "
+                    "are being re-emitted across many translation units."
+                )
+    elif summary.success is False:
+        if summary.errors > 0:
+            lines.append("The build failed because compiler errors were detected.")
+        else:
+            lines.append("The build appears to have failed, but no structured compiler error lines were parsed.")
+    else:
+        lines.append("The parser could not conclusively determine build status.")
+
+    top_flag = warn_stats["raw_by_flag"].most_common(1)
+    if top_flag:
+        flag_name, _ = top_flag[0]
+        if flag_name == "-Wshadow":
+            lines.append("The biggest cleanup opportunity is shadowed identifiers.")
+        elif flag_name in {"-Wconversion", "-Wsign-conversion"}:
+            lines.append("The biggest cleanup opportunity is numeric conversion hygiene.")
+
+    return "\n".join(lines)
+
+
+def generate_markdown_summary(
+    summary: BuildSummary,
+    dedupe_mode: str = "site",
+    max_examples: int = 5,
+    show_files: int = 10,
+    show_flags: int = 10,
+    show_repeated: int = 5,
+) -> str:
+    warn_stats = summarize_warning_hotspots(summary, dedupe_mode)
+    warnings = [d for d in summary.diagnostics if d.kind == "warning"]
+    errors = [d for d in summary.diagnostics if d.kind == "error"]
+
+    lines: list[str] = []
+    lines.append("# Build Summary")
+    lines.append("")
+    lines.append("| Field | Value |")
+    lines.append("|---|---|")
+    lines.append(f"| Status | {format_status(summary)} |")
+    if summary.build_dir:
+        lines.append(f"| Build directory | `{shorten_path(summary.build_dir, summary.build_dir)}` |")
+    if summary.build_command:
+        lines.append(f"| Build command | `{summary.build_command}` |")
+    lines.append(f"| Dedupe mode | `{dedupe_mode}` |")
+    lines.append("")
+
+    lines.append("## High-level Results")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|---|---:|")
+    lines.append(f"| Raw warnings | {warn_stats['raw_count']} |")
+    lines.append(f"| Unique warnings | {warn_stats['unique_count']} |")
+    lines.append(f"| Errors | {summary.errors} |")
+    lines.append(f"| Notes | {summary.notes} |")
+    lines.append(f"| Compile commands | {len(summary.compile_commands)} |")
+    lines.append(f"| Unique sources | {unique_sources(summary)} |")
+    lines.append(f"| Built targets | {len(summary.built_targets)} |")
+    lines.append("")
+
+    lines.append("## Warning Origin Breakdown")
+    lines.append("")
+    lines.append("| Category | Raw | Unique |")
+    lines.append("|---|---:|---:|")
+    lines.append(f"| Headers | {warn_stats['header_raw']} | {warn_stats['header_unique']} |")
+    lines.append(f"| Sources | {warn_stats['source_raw']} | {warn_stats['source_unique']} |")
+    if warn_stats["raw_count"] > 0:
+        lines.append("")
+        lines.append(f"- Repeat factor: **{warn_stats['raw_count'] / max(warn_stats['unique_count'], 1):.2f}x** raw-to-unique")
+    lines.append("")
+
+    if summary.built_targets:
+        lines.append("## Targets Built")
+        lines.append("")
+        for t in summary.built_targets[:20]:
+            lines.append(f"- `{t}`")
+        if len(summary.built_targets) > 20:
+            lines.append(f"- ... and {len(summary.built_targets) - 20} more")
+        lines.append("")
+
+    if summary.standards_seen or summary.optimization_levels_seen or summary.compiler_warning_flags_seen:
+        lines.append("## Compiler Configuration")
+        lines.append("")
+        if summary.standards_seen:
+            lines.append("- C++ standards: " + ", ".join(f"`{k}` ({v})" for k, v in summary.standards_seen.most_common()))
+        if summary.optimization_levels_seen:
+            lines.append("- Optimization: " + ", ".join(f"`{k}` ({v})" for k, v in summary.optimization_levels_seen.most_common()))
+        if summary.compiler_warning_flags_seen:
+            lines.append(
+                "- Warning flags: "
+                + ", ".join(
+                    f"`{flag}` ({count})"
+                    for flag, count in summary.compiler_warning_flags_seen.most_common(min(12, len(summary.compiler_warning_flags_seen)))
+                )
+            )
+        lines.append("")
+
+    lines.append("## Most Common Warning Categories")
+    lines.append("")
+    lines.append("| Warning flag | Raw | Unique |")
+    lines.append("|---|---:|---:|")
+    for flag, count in top_counter(warn_stats["raw_by_flag"], show_flags):
+        uniq = warn_stats["unique_by_flag"].get(flag, 0)
+        lines.append(f"| `{flag}` | {count} | {uniq} |")
+    lines.append("")
+
+    lines.append("## Files with the Most Warnings")
+    lines.append("")
+    lines.append("| File | Raw | Unique |")
+    lines.append("|---|---:|---:|")
+    for file, count in top_counter(warn_stats["raw_by_file"], show_files):
+        uniq = warn_stats["unique_by_file"].get(file, 0)
+        lines.append(f"| `{shorten_path(file, summary.build_dir)}` | {count} | {uniq} |")
+    lines.append("")
+
+    if warn_stats["repeated_sites"]:
+        lines.append("## Most Repeated Warning Sites")
+        lines.append("")
+        for d, repeats in warn_stats["repeated_sites"][:show_repeated]:
+            location = f"{shorten_path(d.file, summary.build_dir)}:{d.line}:{d.col}"
+            flag = f" `{d.flag}`" if d.flag else ""
+            lines.append(f"- **{location}**{flag}: repeated **{repeats}** times")
+            lines.append(f"  - {compact_message(d.message)}")
+        lines.append("")
+
+    warn_examples = representative_diagnostics(warnings, max_examples, dedupe_mode)
+    if warn_examples:
+        lines.append("## Representative Warnings")
+        lines.append("")
+        for d in warn_examples:
+            lines.extend(format_diag_markdown_lines(d, summary.build_dir))
+        lines.append("")
+
+    err_examples = representative_diagnostics(errors, max_examples, dedupe_mode)
+    if err_examples:
+        lines.append("## Representative Errors")
+        lines.append("")
+        for d in err_examples:
+            lines.extend(format_diag_markdown_lines(d, summary.build_dir))
+        lines.append("")
+
+    lines.append("## Interpretation")
+    lines.append("")
+    if summary.success is True and summary.errors == 0:
+        if warn_stats["raw_count"] == 0:
+            lines.append("- The build completed cleanly with no warnings or errors.")
+        else:
+            top_raw = warn_stats["raw_by_flag"].most_common(3)
+            top_text = ", ".join(f"`{flag}` ({count})" for flag, count in top_raw)
+            lines.append(f"- The build succeeded, but warnings remain. Dominant raw warning classes: {top_text}.")
+            if warn_stats["raw_count"] != warn_stats["unique_count"]:
+                lines.append(
+                    f"- Many warnings are repeated emissions: **{warn_stats['raw_count']}** raw warnings collapse to "
+                    f"**{warn_stats['unique_count']}** unique warning sites."
+                )
+            if warn_stats["header_raw"] > warn_stats["source_raw"]:
+                lines.append(
+                    "- Most warning volume originates in headers, which suggests a small number of warning sites are "
+                    "being re-emitted across many translation units."
+                )
+    elif summary.success is False:
+        if summary.errors > 0:
+            lines.append("- The build failed because compiler errors were detected.")
+        else:
+            lines.append("- The build appears to have failed, but no structured compiler error lines were parsed.")
+    else:
+        lines.append("- The parser could not conclusively determine build status.")
+
+    top_flag = warn_stats["raw_by_flag"].most_common(1)
+    if top_flag:
+        flag_name, _ = top_flag[0]
+        if flag_name == "-Wshadow":
+            lines.append("- The biggest cleanup opportunity is shadowed identifiers.")
+        elif flag_name in {"-Wconversion", "-Wsign-conversion"}:
+            lines.append("- The biggest cleanup opportunity is numeric conversion hygiene.")
+
+    return "\n".join(lines)
+
+
+def summary_to_json(summary: BuildSummary, dedupe_mode: str, max_examples: int) -> dict:
+    warn_stats = summarize_warning_hotspots(summary, dedupe_mode)
+    warnings = [d for d in summary.diagnostics if d.kind == "warning"]
+    errors = [d for d in summary.diagnostics if d.kind == "error"]
+
+    return {
+        "status": format_status(summary),
+        "build_dir": summary.build_dir,
+        "build_command": summary.build_command,
+        "dedupe_mode": dedupe_mode,
+        "counts": {
+            "warnings_raw": warn_stats["raw_count"],
+            "warnings_unique": warn_stats["unique_count"],
+            "errors": summary.errors,
+            "notes": summary.notes,
+            "compile_commands": len(summary.compile_commands),
+            "unique_sources": unique_sources(summary),
+            "built_targets": len(summary.built_targets),
+            "header_warnings_raw": warn_stats["header_raw"],
+            "header_warnings_unique": warn_stats["header_unique"],
+            "source_warnings_raw": warn_stats["source_raw"],
+            "source_warnings_unique": warn_stats["source_unique"],
+        },
+        "built_targets": summary.built_targets,
+        "warning_categories_raw": dict(warn_stats["raw_by_flag"].most_common()),
+        "warning_categories_unique": dict(warn_stats["unique_by_flag"].most_common()),
+        "warnings_by_file_raw": dict(warn_stats["raw_by_file"].most_common()),
+        "warnings_by_file_unique": dict(warn_stats["unique_by_file"].most_common()),
+        "errors_by_file": dict(summary.errors_by_file.most_common()),
+        "compiler_config": {
+            "standards_seen": dict(summary.standards_seen.most_common()),
+            "optimization_levels_seen": dict(summary.optimization_levels_seen.most_common()),
+            "warning_flags_seen_in_commands": dict(summary.compiler_warning_flags_seen.most_common()),
+        },
+        "most_repeated_warning_sites": [
+            {"repeats": repeats, "diagnostic": asdict(d)}
+            for d, repeats in warn_stats["repeated_sites"][:max_examples]
+        ],
+        "examples": {
+            "warnings": [asdict(d) for d in representative_diagnostics(warnings, max_examples, dedupe_mode)],
+            "errors": [asdict(d) for d in representative_diagnostics(errors, max_examples, dedupe_mode)],
+        },
+    }
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Summarize a C/C++ build log.")
+    p.add_argument("logfile", help="Path to build log")
+    p.add_argument("--compile-db", help="Optional path to compile_commands.json")
+    p.add_argument("--json", action="store_true", help="Emit JSON output")
+    p.add_argument("--markdown", action="store_true", help="Emit Markdown output")
+    p.add_argument("--max-examples", type=int, default=5)
+    p.add_argument("--show-files", type=int, default=10)
+    p.add_argument("--show-flags", type=int, default=10)
+    p.add_argument("--show-repeated", type=int, default=5)
+    p.add_argument(
+        "--dedupe-mode",
+        choices=["site", "broad"],
+        default="site",
+        help="site=(file,line,col,message,flag), broad=(file,line,message,flag)",
+    )
+    return p
+
+
+def main() -> int:
+    args = build_arg_parser().parse_args()
+
+    if args.json and args.markdown:
+        print("error: choose only one of --json or --markdown", file=sys.stderr)
+        return 2
+
+    if not os.path.isfile(args.logfile):
+        print(f"error: file not found: {args.logfile}", file=sys.stderr)
+        return 2
+
+    summary = parse_log(args.logfile)
+
+    if args.compile_db:
+        if not os.path.isfile(args.compile_db):
+            print(f"error: compile database not found: {args.compile_db}", file=sys.stderr)
+            return 2
+        compile_db = load_compile_database(args.compile_db)
+        merge_compile_database(summary, compile_db)
+
+    if args.json:
+        print(json.dumps(summary_to_json(summary, args.dedupe_mode, args.max_examples), indent=2))
+    elif args.markdown:
+        print(
+            generate_markdown_summary(
+                summary,
+                dedupe_mode=args.dedupe_mode,
+                max_examples=args.max_examples,
+                show_files=args.show_files,
+                show_flags=args.show_flags,
+                show_repeated=args.show_repeated,
+            )
+        )
+    else:
+        print(
+            generate_human_summary(
+                summary,
+                dedupe_mode=args.dedupe_mode,
+                max_examples=args.max_examples,
+                show_files=args.show_files,
+                show_flags=args.show_flags,
+                show_repeated=args.show_repeated,
+            )
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/summarize_build_log.py
+++ b/scripts/summarize_build_log.py
@@ -895,6 +895,17 @@ def summary_to_json(summary: BuildSummary, dedupe_mode: str, max_examples: int) 
     warn_stats = summarize_warning_hotspots(summary, dedupe_mode)
     warnings = [d for d in summary.diagnostics if d.kind == "warning"]
     errors = [d for d in summary.diagnostics if d.kind == "error"]
+    notes = [d for d in summary.diagnostics if d.kind == "note"]
+    warning_details_by_file: dict[str, list[dict]] = defaultdict(list)
+    error_details_by_file: dict[str, list[dict]] = defaultdict(list)
+    note_details_by_file: dict[str, list[dict]] = defaultdict(list)
+
+    for d in warnings:
+        warning_details_by_file[d.file].append(asdict(d))
+    for d in errors:
+        error_details_by_file[d.file].append(asdict(d))
+    for d in notes:
+        note_details_by_file[d.file].append(asdict(d))
 
     return {
         "status": format_status(summary),
@@ -919,7 +930,20 @@ def summary_to_json(summary: BuildSummary, dedupe_mode: str, max_examples: int) 
         "warning_categories_unique": dict(warn_stats["unique_by_flag"].most_common()),
         "warnings_by_file_raw": dict(warn_stats["raw_by_file"].most_common()),
         "warnings_by_file_unique": dict(warn_stats["unique_by_file"].most_common()),
+        "warning_details_by_file": {
+            file: warning_details_by_file[file]
+            for file, _ in warn_stats["raw_by_file"].most_common()
+        },
         "errors_by_file": dict(summary.errors_by_file.most_common()),
+        "error_details_by_file": {
+            file: error_details_by_file[file]
+            for file, _ in summary.errors_by_file.most_common()
+        },
+        "notes_by_file": dict(Counter(d.file for d in notes).most_common()),
+        "note_details_by_file": {
+            file: note_details_by_file[file]
+            for file, _ in Counter(d.file for d in notes).most_common()
+        },
         "compiler_config": {
             "standards_seen": dict(summary.standards_seen.most_common()),
             "optimization_levels_seen": dict(summary.optimization_levels_seen.most_common()),

--- a/verification/oversampling/.gitignore
+++ b/verification/oversampling/.gitignore
@@ -1,0 +1,2 @@
+build/
+output/

--- a/verification/oversampling/CMakeLists.txt
+++ b/verification/oversampling/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.22)
+project(oversampling_audit LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if (NOT CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
+endif ()
+
+add_subdirectory(src)
+

--- a/verification/oversampling/README.md
+++ b/verification/oversampling/README.md
@@ -1,0 +1,85 @@
+# Oversampling Audit Harness
+
+This directory contains a standalone C++ executable for auditing the oversampling implementation used by `libfers`.
+
+## Scope
+
+- Source-faithful copies of the core oversampling path:
+  - `packages/libfers/src/signal/dsp_filters.*`
+  - `packages/libfers/src/signal/radar_signal.*`
+  - `packages/libfers/src/interpolation/interpolation_filter.*`
+  - `packages/libfers/src/serial/response.*`
+  - `packages/libfers/src/processing/signal_processor.*`
+  - `packages/libfers/src/processing/finalizer_pipeline.*`
+- Formula-level probes for oversampling-dependent callers:
+  - transmitter PRF quantization
+  - receiver window PRF/skip quantization
+  - CW timestep and CW buffer sizing
+- Deferred executable coverage:
+  - `packages/libfers/src/noise/falpha_branch.cpp` uses `signal::DecadeUpsampler`, but this harness only documents that path in manifests and source maps.
+
+## Usage
+
+Configure and build:
+
+```bash
+cmake -S verification/oversampling -B verification/oversampling/build
+cmake --build verification/oversampling/build
+```
+
+Run a single suite:
+
+```bash
+./verification/oversampling/build/src/oversampling_audit suite render --ratio 4 --filter-length 33 --seed 42 --output-dir verification/oversampling/output
+```
+
+Run all suites for one parameter set:
+
+```bash
+./verification/oversampling/build/src/oversampling_audit all --ratio 4 --filter-length 33 --seed 42 --output-dir verification/oversampling/output
+```
+
+Run a matrix:
+
+```bash
+./verification/oversampling/build/src/oversampling_audit matrix --ratios 1,2,4,8 --filter-lengths 8,33 --seed 42 --output-dir verification/oversampling/output
+```
+
+Run the comprehensive Python driver and post-analysis:
+
+```bash
+python3 verification/oversampling/run_and_analyze.py --clean-output
+```
+
+## Output
+
+Each suite writes:
+
+- `manifest.json`
+- `summary.csv`
+- suite-specific CSV artifacts
+- `README.txt` describing the generated files
+
+The matrix and `all` commands create per-suite subdirectories so each process can initialize the interpolation-filter singleton with one filter length only.
+
+## Python Analysis
+
+`run_and_analyze.py` automates the end-to-end workflow:
+
+- optionally rebuilds the standalone harness
+- runs a matrix over ratios and filter lengths
+- parses every generated `manifest.json`, `summary.csv`, and suite-specific CSV
+- emits aggregated analysis artifacts under `output/.../analysis/`
+
+Generated analysis artifacts:
+
+- `case_analysis.csv`: one row per `(ratio, filter_length, suite)` case
+- `suite_summary.csv`: pass/fail rollup by suite
+- `global_summary.json`: machine-readable aggregate report
+- `report.md`: human-readable Markdown report with key findings and failing cases
+
+Default comprehensive sweep:
+
+- ratios: `1,2,4,8,16,24,32,64`
+- filter lengths: `8,16,33,64`
+- seed: `42`

--- a/verification/oversampling/run_and_analyze.py
+++ b/verification/oversampling/run_and_analyze.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+"""
+Run the standalone oversampling audit harness across a parameter matrix and
+analyze the generated CSV/manifest outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parent
+DEFAULT_BUILD_DIR = ROOT / "build"
+DEFAULT_EXECUTABLE = DEFAULT_BUILD_DIR / "src" / "oversampling_audit"
+DEFAULT_OUTPUT_DIR = ROOT / "output" / "analysis_runs"
+DEFAULT_ANALYSIS_DIRNAME = "analysis"
+DEFAULT_RATIOS = [1, 2, 4, 8, 16, 24, 32, 64]
+DEFAULT_FILTER_LENGTHS = [8, 16, 33, 64]
+DEFAULT_SEED = 42
+
+
+@dataclass(frozen=True)
+class CaseDescriptor:
+    ratio: int
+    filter_length: int
+    suite: str
+    path: Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the oversampling audit executable over a matrix and analyze the outputs."
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=DEFAULT_BUILD_DIR,
+        help="CMake build directory for the standalone harness.",
+    )
+    parser.add_argument(
+        "--executable",
+        type=Path,
+        default=DEFAULT_EXECUTABLE,
+        help="Path to the built oversampling_audit executable.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Directory where raw harness outputs will be written.",
+    )
+    parser.add_argument(
+        "--analysis-dirname",
+        default=DEFAULT_ANALYSIS_DIRNAME,
+        help="Subdirectory name within output-dir for aggregated analysis artifacts.",
+    )
+    parser.add_argument(
+        "--ratios",
+        default=",".join(str(v) for v in DEFAULT_RATIOS),
+        help="Comma-separated oversampling ratios to run.",
+    )
+    parser.add_argument(
+        "--filter-lengths",
+        default=",".join(str(v) for v in DEFAULT_FILTER_LENGTHS),
+        help="Comma-separated render filter lengths to run.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_SEED,
+        help="Seed passed to the C++ harness.",
+    )
+    parser.add_argument(
+        "--skip-build",
+        action="store_true",
+        help="Do not run cmake --build before executing the harness.",
+    )
+    parser.add_argument(
+        "--skip-run",
+        action="store_true",
+        help="Analyze an existing output tree without invoking the harness.",
+    )
+    parser.add_argument(
+        "--clean-output",
+        action="store_true",
+        help="Delete the output directory before running.",
+    )
+    return parser.parse_args()
+
+
+def parse_int_list(value: str) -> list[int]:
+    out = [int(token.strip()) for token in value.split(",") if token.strip()]
+    if not out:
+        raise ValueError("expected a non-empty comma-separated integer list")
+    return out
+
+
+def run_command(command: list[str], cwd: Path) -> None:
+    print("+", " ".join(str(part) for part in command))
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def build_harness(build_dir: Path) -> None:
+    if not build_dir.exists():
+        raise FileNotFoundError(f"Build directory does not exist: {build_dir}")
+    run_command(["cmake", "--build", str(build_dir)], cwd=ROOT)
+
+
+def run_matrix(executable: Path, output_dir: Path, ratios: list[int], filter_lengths: list[int], seed: int) -> None:
+    if not executable.exists():
+        raise FileNotFoundError(f"Executable does not exist: {executable}")
+    command = [
+        str(executable),
+        "matrix",
+        "--ratios",
+        ",".join(str(v) for v in ratios),
+        "--filter-lengths",
+        ",".join(str(v) for v in filter_lengths),
+        "--seed",
+        str(seed),
+        "--output-dir",
+        str(output_dir),
+    ]
+    run_command(command, cwd=ROOT)
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def read_summary(path: Path) -> dict[str, str]:
+    rows = read_csv(path)
+    return {row["metric"]: row["value"] for row in rows}
+
+
+def read_manifest(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def as_float(value: str) -> float:
+    return float(value)
+
+
+def safe_rel_error(observed: float, expected: float) -> float:
+    if expected == 0.0:
+        return abs(observed - expected)
+    return abs(observed - expected) / abs(expected)
+
+
+def find_cases(output_dir: Path) -> list[CaseDescriptor]:
+    cases: list[CaseDescriptor] = []
+    for manifest_path in output_dir.glob("ratio_*/filter_*/*/manifest.json"):
+        suite_dir = manifest_path.parent
+        suite = suite_dir.name
+        filter_token = suite_dir.parent.name
+        ratio_token = suite_dir.parent.parent.name
+        ratio = int(ratio_token.removeprefix("ratio_"))
+        filter_length = int(filter_token.removeprefix("filter_"))
+        cases.append(
+            CaseDescriptor(
+                ratio=ratio,
+                filter_length=filter_length,
+                suite=suite,
+                path=suite_dir,
+            )
+        )
+    cases.sort(key=lambda item: (item.ratio, item.filter_length, item.suite))
+    return cases
+
+
+def analyze_resampler(case: CaseDescriptor) -> dict[str, Any]:
+    summary = read_summary(case.path / "summary.csv")
+    tones = read_csv(case.path / "tone_roundtrip.csv")
+    scenarios = read_csv(case.path / "scenario_roundtrip.csv")
+    alignment = read_csv(case.path / "group_delay_alignment.csv")
+
+    min_tone_corr = min(as_float(row["normalized_correlation"]) for row in tones)
+    max_tone_rms = max(as_float(row["rms_error"]) for row in tones)
+    min_scenario_corr = min(as_float(row["normalized_correlation"]) for row in scenarios)
+    max_scenario_rms = max(as_float(row["rms_error"]) for row in scenarios)
+    max_peak_error = max(abs(as_float(row["peak_index_error"])) for row in alignment)
+    fir_sum = as_float(summary["fir_sum"])
+
+    return {
+        "suite": case.suite,
+        "ratio": case.ratio,
+        "filter_length": case.filter_length,
+        "fir_sum_error": fir_sum - case.ratio,
+        "min_tone_correlation": min_tone_corr,
+        "max_tone_rms_error": max_tone_rms,
+        "min_scenario_correlation": min_scenario_corr,
+        "max_scenario_rms_error": max_scenario_rms,
+        "max_group_delay_peak_error": max_peak_error,
+        "pass": (
+            abs(fir_sum - case.ratio) < 2e-3
+            and min_tone_corr > 0.98
+            and min_scenario_corr > 0.95
+            and max_peak_error <= 0.0
+        ),
+    }
+
+
+def analyze_render(case: CaseDescriptor) -> dict[str, Any]:
+    summary = read_summary(case.path / "summary.csv")
+    constant_rows = read_csv(case.path / "constant_render.csv")
+    interpolation_rows = read_csv(case.path / "power_phase_interpolation.csv")
+    fractional_rows = read_csv(case.path / "fractional_delay_sweep.csv")
+    oversampled_rows = read_csv(case.path / "oversampled_render_comparison.csv")
+
+    center_index = case.filter_length
+    center_row = next(row for row in constant_rows if int(row["index"]) == center_index)
+    constant_real_error = abs(as_float(center_row["real"]) - as_float(summary["constant_expected_real"]))
+    constant_imag_error = abs(as_float(center_row["imag"]) - as_float(summary["constant_expected_imag"]))
+
+    max_interp_error = 0.0
+    for row in interpolation_rows:
+        real_error = abs(as_float(row["observed_real"]) - as_float(row["expected_real"]))
+        imag_error = abs(as_float(row["observed_imag"]) - as_float(row["expected_imag"]))
+        max_interp_error = max(max_interp_error, real_error, imag_error)
+
+    max_fractional_error = 0.0
+    for row in fractional_rows:
+        max_fractional_error = max(
+            max_fractional_error,
+            abs(as_float(row["observed_real"]) - as_float(row["expected_real"])),
+            abs(as_float(row["observed_imag"])),
+        )
+
+    oversampled_corr = min(as_float(row["normalized_correlation"]) for row in oversampled_rows)
+    oversampled_rms = max(as_float(row["rms_error"]) for row in oversampled_rows)
+
+    return {
+        "suite": case.suite,
+        "ratio": case.ratio,
+        "filter_length": case.filter_length,
+        "constant_center_real_error": constant_real_error,
+        "constant_center_imag_error": constant_imag_error,
+        "max_interpolation_error": max_interp_error,
+        "max_fractional_delay_error": max_fractional_error,
+        "oversampled_render_correlation": oversampled_corr,
+        "oversampled_render_rms_error": oversampled_rms,
+        "pass": (
+            constant_real_error < 1e-5
+            and constant_imag_error < 1e-5
+            and max_fractional_error < 1e-3
+            and oversampled_corr > 0.999
+            and oversampled_rms < 5e-2
+        ),
+    }
+
+
+def analyze_pipeline(case: CaseDescriptor) -> dict[str, Any]:
+    summary = read_summary(case.path / "summary.csv")
+    thermal_rows = read_csv(case.path / "thermal_noise_stats.csv")
+    downsampling_rows = read_csv(case.path / "downsampling_quantization.csv")
+
+    max_thermal_rel_error = 0.0
+    for row in thermal_rows:
+        expected = as_float(row["expected_per_channel_power"])
+        variance_real = as_float(row["variance_real"])
+        variance_imag = as_float(row["variance_imag"])
+        if expected == 0.0:
+            continue
+        max_thermal_rel_error = max(
+            max_thermal_rel_error,
+            safe_rel_error(variance_real, expected),
+            safe_rel_error(variance_imag, expected),
+        )
+
+    min_downsampling_corr = min(as_float(row["normalized_correlation"]) for row in downsampling_rows)
+    max_downsampling_rms = max(as_float(row["rms_error"]) for row in downsampling_rows)
+
+    histogram_level_count: int | None = None
+    histogram_paths = sorted(case.path.glob("adc_histogram_bits_*.csv"))
+    if histogram_paths:
+        histogram_level_count = max(len(read_csv(path)) for path in histogram_paths)
+
+    return {
+        "suite": case.suite,
+        "ratio": case.ratio,
+        "filter_length": case.filter_length,
+        "thermal_max_relative_error": max_thermal_rel_error,
+        "downsampling_correlation": min_downsampling_corr,
+        "downsampling_rms_error": max_downsampling_rms,
+        "downsampled_fullscale": as_float(summary["downsampled_fullscale"]),
+        "max_adc_histogram_levels": histogram_level_count if histogram_level_count is not None else 0,
+        "pass": max_thermal_rel_error < 0.25 and min_downsampling_corr > 0.99 and max_downsampling_rms < 0.04,
+    }
+
+
+def analyze_clocking(case: CaseDescriptor) -> dict[str, Any]:
+    summary = read_summary(case.path / "summary.csv")
+    tx_rows = read_csv(case.path / "transmitter_prf_quantization.csv")
+    rx_rows = read_csv(case.path / "receiver_window_quantization.csv")
+    cw_rows = read_csv(case.path / "cw_timestep_and_buffer.csv")
+
+    worst_tx = max(tx_rows, key=lambda row: abs(as_float(row["error"])))
+    worst_rx = max(rx_rows, key=lambda row: abs(as_float(row["skip_error"])))
+    smallest_dt = min(as_float(row["dt_sim"]) for row in cw_rows)
+    largest_buffer = max(int(row["cw_buffer_size"]) for row in cw_rows)
+
+    return {
+        "suite": case.suite,
+        "ratio": case.ratio,
+        "filter_length": case.filter_length,
+        "max_abs_prf_error": abs(as_float(summary["max_abs_prf_error"])),
+        "max_abs_skip_error": abs(as_float(summary["max_abs_skip_error"])),
+        "worst_prf_requested": as_float(worst_tx["requested_prf"]),
+        "worst_skip_requested": as_float(worst_rx["requested_skip"]),
+        "smallest_dt_sim": smallest_dt,
+        "largest_cw_buffer_size": largest_buffer,
+        "pass": True,
+    }
+
+
+SUITE_ANALYZERS = {
+    "resampler": analyze_resampler,
+    "render": analyze_render,
+    "pipeline": analyze_pipeline,
+    "clocking": analyze_clocking,
+}
+
+
+def analyze_cases(cases: list[CaseDescriptor]) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for case in cases:
+        manifest = read_manifest(case.path / "manifest.json")
+        if manifest["suite"] != case.suite:
+            raise RuntimeError(f"Manifest suite mismatch at {case.path}")
+        analyzer = SUITE_ANALYZERS.get(case.suite)
+        if analyzer is None:
+            raise RuntimeError(f"No analyzer registered for suite {case.suite}")
+        results.append(analyzer(case))
+    return results
+
+
+def coerce_table_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, float):
+        return f"{value:.12e}"
+    return str(value)
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        raise RuntimeError(f"No rows to write to {path}")
+    fieldnames: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        for key in row:
+            if key not in seen:
+                seen.add(key)
+                fieldnames.append(key)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: coerce_table_value(row.get(key, "")) for key in fieldnames})
+
+
+def summarize_by_suite(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    suite_names = sorted({str(row["suite"]) for row in rows})
+    out: list[dict[str, Any]] = []
+    for suite in suite_names:
+        suite_rows = [row for row in rows if row["suite"] == suite]
+        pass_count = sum(1 for row in suite_rows if bool(row["pass"]))
+        out.append(
+            {
+                "suite": suite,
+                "cases": len(suite_rows),
+                "passes": pass_count,
+                "failures": len(suite_rows) - pass_count,
+                "pass_rate": pass_count / len(suite_rows) if suite_rows else 0.0,
+            }
+        )
+    return out
+
+
+def build_global_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    suite_summary = summarize_by_suite(rows)
+    total_cases = len(rows)
+    total_passes = sum(1 for row in rows if bool(row["pass"]))
+    failing_cases = [row for row in rows if not bool(row["pass"])]
+    return {
+        "total_cases": total_cases,
+        "total_passes": total_passes,
+        "total_failures": total_cases - total_passes,
+        "overall_pass_rate": total_passes / total_cases if total_cases else 0.0,
+        "suite_summary": suite_summary,
+        "failing_cases": failing_cases,
+    }
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def worst_case(rows: list[dict[str, Any]], suite: str, metric: str, reverse: bool = True) -> dict[str, Any] | None:
+    suite_rows = [row for row in rows if row["suite"] == suite and metric in row]
+    if not suite_rows:
+        return None
+    return sorted(suite_rows, key=lambda row: float(row[metric]), reverse=reverse)[0]
+
+
+def generate_markdown_report(rows: list[dict[str, Any]], global_summary: dict[str, Any], args: argparse.Namespace) -> str:
+    lines: list[str] = []
+    lines.append("# Oversampling Audit Analysis")
+    lines.append("")
+    lines.append("## Run Configuration")
+    lines.append("")
+    lines.append(f"- Output root: `{args.output_dir}`")
+    lines.append(f"- Ratios: `{args.ratios}`")
+    lines.append(f"- Filter lengths: `{args.filter_lengths}`")
+    lines.append(f"- Seed: `{args.seed}`")
+    lines.append("")
+    lines.append("## Overall Result")
+    lines.append("")
+    lines.append(f"- Cases analyzed: `{global_summary['total_cases']}`")
+    lines.append(f"- Passing cases: `{global_summary['total_passes']}`")
+    lines.append(f"- Failing cases: `{global_summary['total_failures']}`")
+    lines.append(f"- Overall pass rate: `{global_summary['overall_pass_rate']:.2%}`")
+    lines.append("")
+    lines.append("## Suite Summary")
+    lines.append("")
+    lines.append("| Suite | Cases | Passes | Failures | Pass Rate |")
+    lines.append("| --- | ---: | ---: | ---: | ---: |")
+    for item in global_summary["suite_summary"]:
+        lines.append(
+            f"| {item['suite']} | {item['cases']} | {item['passes']} | {item['failures']} | {item['pass_rate']:.2%} |"
+        )
+    lines.append("")
+    lines.append("## Key Findings")
+    lines.append("")
+
+    resampler = worst_case(rows, "resampler", "max_tone_rms_error", reverse=True)
+    if resampler is not None:
+        lines.append(
+            "- Resampler worst tone RMS error: "
+            f"`{resampler['max_tone_rms_error']:.6e}` at ratio `{resampler['ratio']}`, filter `{resampler['filter_length']}`."
+        )
+    render = worst_case(rows, "render", "max_fractional_delay_error", reverse=True)
+    if render is not None:
+        lines.append(
+            "- Render worst fractional-delay error: "
+            f"`{render['max_fractional_delay_error']:.6e}` at ratio `{render['ratio']}`, filter `{render['filter_length']}`."
+        )
+    pipeline = worst_case(rows, "pipeline", "thermal_max_relative_error", reverse=True)
+    if pipeline is not None:
+        lines.append(
+            "- Pipeline worst thermal-noise relative error: "
+            f"`{pipeline['thermal_max_relative_error']:.6e}` at ratio `{pipeline['ratio']}`, filter `{pipeline['filter_length']}`."
+        )
+    clocking = worst_case(rows, "clocking", "max_abs_prf_error", reverse=True)
+    if clocking is not None:
+        lines.append(
+            "- Clocking worst PRF quantization error: "
+            f"`{clocking['max_abs_prf_error']:.6e}` at ratio `{clocking['ratio']}`, filter `{clocking['filter_length']}`."
+        )
+    lines.append("")
+
+    if global_summary["failing_cases"]:
+        lines.append("## Failing Cases")
+        lines.append("")
+        lines.append("| Suite | Ratio | Filter | Notes |")
+        lines.append("| --- | ---: | ---: | --- |")
+        for row in global_summary["failing_cases"]:
+            notes = []
+            if row["suite"] == "resampler":
+                notes.append(f"min tone corr={row['min_tone_correlation']:.6e}")
+                notes.append(f"min scenario corr={row['min_scenario_correlation']:.6e}")
+            elif row["suite"] == "render":
+                notes.append(f"max fractional error={row['max_fractional_delay_error']:.6e}")
+                notes.append(f"oversampled corr={row['oversampled_render_correlation']:.6e}")
+            elif row["suite"] == "pipeline":
+                notes.append(f"thermal rel err={row['thermal_max_relative_error']:.6e}")
+                notes.append(f"downsample corr={row['downsampling_correlation']:.6e}")
+            lines.append(f"| {row['suite']} | {row['ratio']} | {row['filter_length']} | {'; '.join(notes)} |")
+        lines.append("")
+    else:
+        lines.append("## Failing Cases")
+        lines.append("")
+        lines.append("No failing cases were detected using the current analysis thresholds.")
+        lines.append("")
+
+    lines.append("## Analysis Artifacts")
+    lines.append("")
+    lines.append(f"- `analysis/case_analysis.csv`: per-case extracted metrics and pass/fail results")
+    lines.append(f"- `analysis/suite_summary.csv`: aggregated pass/fail counts by suite")
+    lines.append(f"- `analysis/global_summary.json`: machine-readable rollup of all analysis results")
+    lines.append(f"- `analysis/report.md`: this report")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_analysis_outputs(rows: list[dict[str, Any]], args: argparse.Namespace) -> None:
+    analysis_dir = args.output_dir / args.analysis_dirname
+    analysis_dir.mkdir(parents=True, exist_ok=True)
+
+    case_analysis_path = analysis_dir / "case_analysis.csv"
+    suite_summary_path = analysis_dir / "suite_summary.csv"
+    global_summary_path = analysis_dir / "global_summary.json"
+    report_path = analysis_dir / "report.md"
+
+    suite_summary = summarize_by_suite(rows)
+    global_summary = build_global_summary(rows)
+
+    write_csv(case_analysis_path, rows)
+    write_csv(suite_summary_path, suite_summary)
+    write_json(global_summary_path, global_summary)
+    report_text = generate_markdown_report(rows, global_summary, args)
+    report_path.write_text(report_text + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    args.build_dir = args.build_dir.resolve()
+    args.executable = args.executable.resolve()
+    args.output_dir = args.output_dir.resolve()
+    ratios = parse_int_list(args.ratios)
+    filter_lengths = parse_int_list(args.filter_lengths)
+
+    if args.clean_output and args.output_dir.exists():
+        shutil.rmtree(args.output_dir)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not args.skip_build:
+        build_harness(args.build_dir)
+
+    if not args.skip_run:
+        run_matrix(args.executable, args.output_dir, ratios, filter_lengths, args.seed)
+
+    cases = find_cases(args.output_dir)
+    if not cases:
+        raise RuntimeError(f"No matrix cases found under {args.output_dir}")
+
+    analysis_rows = analyze_cases(cases)
+    write_analysis_outputs(analysis_rows, args)
+
+    global_summary = build_global_summary(analysis_rows)
+    print(
+        "Analysis complete:",
+        f"{global_summary['total_passes']}/{global_summary['total_cases']} cases passed",
+        f"({global_summary['overall_pass_rate']:.2%})",
+    )
+    print(f"Artifacts written under: {args.output_dir / args.analysis_dirname}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/verification/oversampling/src/CMakeLists.txt
+++ b/verification/oversampling/src/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_executable(oversampling_audit
+	main.cpp
+	core/logging.cpp
+	interpolation/interpolation_filter.cpp
+	processing/finalizer_pipeline.cpp
+	processing/signal_processor.cpp
+	serial/response.cpp
+	signal/dsp_filters.cpp
+	signal/radar_signal.cpp
+)
+
+target_include_directories(oversampling_audit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+

--- a/verification/oversampling/src/core/config.h
+++ b/verification/oversampling/src/core/config.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Copyright (c) 2024-present FERS Contributors (see AUTHORS.md).
+//
+// Upstream reference:
+//   packages/libfers/src/core/config.h
+
+#pragma once
+
+#include <complex>
+#include <limits>
+#include <numbers>
+
+using RealType = double;
+using ComplexType = std::complex<RealType>;
+
+constexpr RealType PI = std::numbers::pi_v<RealType>;
+constexpr RealType EPSILON = std::numeric_limits<RealType>::epsilon();
+

--- a/verification/oversampling/src/core/logging.cpp
+++ b/verification/oversampling/src/core/logging.cpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Local harness support code.
+
+#include "logging.h"
+
+namespace logging
+{
+	Logger logger;
+
+	const char* Logger::levelString(const Level level) noexcept
+	{
+		switch (level)
+		{
+		case Level::TRACE:
+			return "TRACE";
+		case Level::DEBUG:
+			return "DEBUG";
+		case Level::INFO:
+			return "INFO";
+		case Level::WARNING:
+			return "WARNING";
+		case Level::ERROR:
+			return "ERROR";
+		case Level::FATAL:
+			return "FATAL";
+		case Level::OFF:
+			return "OFF";
+		}
+		return "UNKNOWN";
+	}
+}
+

--- a/verification/oversampling/src/core/logging.h
+++ b/verification/oversampling/src/core/logging.h
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Local harness support code.
+
+#pragma once
+
+#include <iostream>
+#include <mutex>
+#include <sstream>
+#include <string>
+
+namespace logging
+{
+	enum class Level
+	{
+		TRACE,
+		DEBUG,
+		INFO,
+		WARNING,
+		ERROR,
+		FATAL,
+		OFF
+	};
+
+	class Logger
+	{
+	public:
+		void setLevel(const Level level) noexcept { _level = level; }
+
+		template <typename... Args>
+		void log(const Level level, Args&&... args) noexcept
+		{
+			if (level < _level || _level == Level::OFF)
+			{
+				return;
+			}
+
+			std::ostringstream stream;
+			(stream << ... << std::forward<Args>(args));
+
+			std::scoped_lock lock(_mutex);
+			std::cerr << "[" << levelString(level) << "] " << stream.str() << '\n';
+		}
+
+	private:
+		static const char* levelString(Level level) noexcept;
+
+		Level _level = Level::INFO;
+		std::mutex _mutex;
+	};
+
+	extern Logger logger;
+}
+
+#define LOG(level, ...) ::logging::logger.log(level, __VA_ARGS__)
+

--- a/verification/oversampling/src/core/parameters.h
+++ b/verification/oversampling/src/core/parameters.h
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Local harness support code derived from:
+//   packages/libfers/src/core/parameters.h
+
+#pragma once
+
+#include <optional>
+#include <random>
+#include <stdexcept>
+
+#include "config.h"
+
+namespace params
+{
+	struct Parameters
+	{
+		constexpr static RealType DEFAULT_C = 299792458.0;
+		constexpr static RealType DEFAULT_BOLTZMANN_K = 1.3806503e-23;
+
+		RealType c = DEFAULT_C;
+		RealType boltzmann_k = DEFAULT_BOLTZMANN_K;
+		RealType start = 0.0;
+		RealType end = 0.0;
+		RealType sim_sampling_rate = 1000.0;
+		RealType rate = 0.0;
+		std::optional<unsigned> random_seed;
+		unsigned adc_bits = 0;
+		unsigned filter_length = 33;
+		unsigned render_threads = 1;
+		unsigned oversample_ratio = 1;
+
+		void reset() noexcept { *this = Parameters{}; }
+	};
+
+	inline Parameters params;
+
+	inline RealType c() noexcept { return params.c; }
+	inline RealType boltzmannK() noexcept { return params.boltzmann_k; }
+	inline RealType startTime() noexcept { return params.start; }
+	inline RealType endTime() noexcept { return params.end; }
+	inline RealType simSamplingRate() noexcept { return params.sim_sampling_rate; }
+	inline RealType rate() noexcept { return params.rate; }
+	inline unsigned randomSeed() noexcept { return params.random_seed.value_or(0); }
+	inline unsigned adcBits() noexcept { return params.adc_bits; }
+	inline unsigned renderFilterLength() noexcept { return params.filter_length; }
+	inline unsigned renderThreads() noexcept { return params.render_threads; }
+	inline unsigned oversampleRatio() noexcept { return params.oversample_ratio; }
+
+	inline void setTime(const RealType start_time, const RealType end_time) noexcept
+	{
+		params.start = start_time;
+		params.end = end_time;
+	}
+
+	inline void setRate(const RealType rate_value)
+	{
+		if (rate_value <= 0.0)
+		{
+			throw std::runtime_error("Sampling rate must be > 0");
+		}
+		params.rate = rate_value;
+	}
+
+	inline void setRandomSeed(const unsigned seed) noexcept { params.random_seed = seed; }
+	inline void setAdcBits(const unsigned bits) noexcept { params.adc_bits = bits; }
+
+	inline void setOversampleRatio(const unsigned ratio)
+	{
+		if (ratio == 0)
+		{
+			throw std::runtime_error("Oversample ratio must be >= 1");
+		}
+		params.oversample_ratio = ratio;
+	}
+}
+

--- a/verification/oversampling/src/interpolation/interpolation_filter.cpp
+++ b/verification/oversampling/src/interpolation/interpolation_filter.cpp
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Copyright (c) 2006-2008 Marc Brooker and Michael Inggs
+// Copyright (c) 2008-present FERS Contributors (see AUTHORS.md).
+//
+// Upstream reference:
+//   packages/libfers/src/interpolation/interpolation_filter.cpp
+
+#include "interpolation_filter.h"
+
+#include <cmath>
+#include <stdexcept>
+
+#include "core/logging.h"
+#include "core/parameters.h"
+
+using logging::Level;
+
+namespace
+{
+	std::expected<RealType, std::string> besselI0(const RealType x)
+	{
+		if (x < 0.0)
+		{
+			return std::unexpected("Modified Bessel approximation only valid for x > 0");
+		}
+		RealType t = x / 3.75;
+		if (t <= 1.0)
+		{
+			t *= t;
+			return 1.0 +
+				t * (3.5156229 +
+					 t * (3.0899424 + t * (1.2067492 + t * (0.2659732 + t * (0.0360768 + t * 0.0045813)))));
+		}
+
+		const RealType i0 =
+			0.39894228 +
+			t *
+				(0.01328592 +
+				 t *
+					 (0.00225319 +
+					  t *
+						  (-0.00157565 +
+						   t * (0.00916281 + t * (-0.02057706 + t * (0.02635537 + t * (-0.01647633 + t * 0.00392377)))))));
+		return i0 * std::exp(x) / std::sqrt(x);
+	}
+}
+
+namespace interp
+{
+	InterpFilter& InterpFilter::getInstance() noexcept
+	{
+		static InterpFilter instance;
+		return instance;
+	}
+
+	std::expected<RealType, std::string> InterpFilter::kaiserWinCompute(const RealType x) const noexcept
+	{
+		if (x < 0 || x > _alpha * 2)
+		{
+			return 0;
+		}
+		auto bessel = besselI0(_beta * std::sqrt(1 - std::pow((x - _alpha) / _alpha, 2)));
+		if (bessel)
+		{
+			return *bessel / _bessel_beta;
+		}
+
+		return std::unexpected(bessel.error());
+	}
+
+	std::expected<RealType, std::string> InterpFilter::interpFilter(const RealType x) const noexcept
+	{
+		auto kaiser = kaiserWinCompute(x + _alpha);
+		if (kaiser)
+		{
+			return *kaiser * sinc(x);
+		}
+
+		return std::unexpected(kaiser.error());
+	}
+
+	InterpFilter::InterpFilter()
+	{
+		_length = static_cast<int>(params::renderFilterLength());
+		_table_filters = 1000;
+		_filter_table = std::vector<RealType>(static_cast<size_t>(_table_filters * _length));
+
+		_alpha = std::floor(params::renderFilterLength() / 2.0);
+		if (auto bessel = besselI0(_beta); bessel)
+		{
+			_bessel_beta = *bessel;
+		}
+		else
+		{
+			LOG(Level::FATAL, "Bessel function calculation failed: ", bessel.error());
+			throw std::runtime_error("Bessel function calculation failed");
+		}
+
+		const int hfilt = _table_filters / 2;
+
+		for (int i = -hfilt; i < hfilt; ++i)
+		{
+			const RealType delay = i / static_cast<RealType>(hfilt);
+			for (int j = static_cast<int>(-_alpha); j < _alpha; ++j)
+			{
+				if (auto interp = interpFilter(j - delay); interp)
+				{
+					_filter_table[static_cast<size_t>((i + hfilt) * _length + j + static_cast<int>(_alpha))] = *interp;
+				}
+				else
+				{
+					LOG(Level::FATAL, "Interpolation filter calculation failed: ", interp.error());
+					throw std::runtime_error("Interpolation filter calculation failed");
+				}
+			}
+		}
+	}
+
+	std::span<const RealType> InterpFilter::getFilter(const RealType delay) const
+	{
+		if (delay < -1 || delay > 1)
+		{
+			LOG(Level::FATAL, "Requested delay filter value out of range: ", delay);
+			throw std::runtime_error("Requested delay filter value out of range");
+		}
+
+		const auto filt = static_cast<unsigned>((delay + 1) * (_table_filters / 2.0));
+		return std::span{&_filter_table[static_cast<size_t>(filt * _length)], static_cast<size_t>(_length)};
+	}
+}
+

--- a/verification/oversampling/src/interpolation/interpolation_filter.h
+++ b/verification/oversampling/src/interpolation/interpolation_filter.h
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Copyright (c) 2006-2008 Marc Brooker and Michael Inggs
+// Copyright (c) 2008-present FERS Contributors (see AUTHORS.md).
+//
+// Upstream reference:
+//   packages/libfers/src/interpolation/interpolation_filter.h
+
+#pragma once
+
+#include <expected>
+#include <span>
+#include <vector>
+
+#include "core/config.h"
+
+namespace interp
+{
+	class InterpFilter
+	{
+	public:
+		InterpFilter(const InterpFilter&) = delete;
+		InterpFilter(InterpFilter&&) = delete;
+		InterpFilter& operator=(const InterpFilter&) = delete;
+		InterpFilter& operator=(InterpFilter&&) = delete;
+		~InterpFilter() = default;
+
+		static constexpr RealType sinc(const RealType x) noexcept
+		{
+			return x == 0.0 ? 1.0 : std::sin(x * PI) / (x * PI);
+		}
+
+		[[nodiscard]] std::expected<RealType, std::string> kaiserWinCompute(RealType x) const noexcept;
+		[[nodiscard]] std::expected<RealType, std::string> interpFilter(RealType x) const noexcept;
+		[[nodiscard]] std::span<const RealType> getFilter(RealType delay) const;
+		static InterpFilter& getInstance() noexcept;
+
+	private:
+		InterpFilter();
+
+		RealType _alpha;
+		RealType _beta = 5;
+		RealType _bessel_beta;
+		int _length;
+		int _table_filters;
+		std::vector<RealType> _filter_table;
+	};
+}
+

--- a/verification/oversampling/src/interpolation/interpolation_point.h
+++ b/verification/oversampling/src/interpolation/interpolation_point.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Copyright (c) 2006-2008 Marc Brooker and Michael Inggs
+// Copyright (c) 2008-present FERS Contributors (see AUTHORS.md).
+//
+// Upstream reference:
+//   packages/libfers/src/interpolation/interpolation_point.h
+
+#pragma once
+
+#include "core/config.h"
+
+namespace interp
+{
+	struct InterpPoint
+	{
+		RealType power{};
+		RealType time{};
+		RealType delay{};
+		RealType phase{};
+	};
+}
+

--- a/verification/oversampling/src/main.cpp
+++ b/verification/oversampling/src/main.cpp
@@ -1,0 +1,1324 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Standalone oversampling audit harness for isolated script-style analysis.
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <complex>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <numeric>
+#include <optional>
+#include <random>
+#include <set>
+#include <span>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "core/logging.h"
+#include "core/parameters.h"
+#include "interpolation/interpolation_filter.h"
+#include "interpolation/interpolation_point.h"
+#include "processing/finalizer_pipeline.h"
+#include "processing/signal_processor.h"
+#include "serial/response.h"
+#include "signal/dsp_filters.h"
+#include "signal/radar_signal.h"
+
+namespace fs = std::filesystem;
+
+namespace
+{
+	struct ParamGuard
+	{
+		params::Parameters saved;
+		ParamGuard() : saved(params::params) {}
+		~ParamGuard() { params::params = saved; }
+	};
+
+	struct SourceMapping
+	{
+		std::string suite;
+		std::string upstream_file;
+		std::string upstream_lines;
+		std::string local_file;
+		std::string note;
+	};
+
+	struct SuiteResult
+	{
+		std::string suite;
+		fs::path output_dir;
+		std::vector<std::string> generated_files;
+		std::vector<std::pair<std::string, std::string>> summary_rows;
+		std::vector<SourceMapping> source_mappings;
+		std::string readme;
+	};
+
+	enum class CommandType
+	{
+		Suite,
+		All,
+		Matrix
+	};
+
+	struct CliOptions
+	{
+		CommandType command = CommandType::All;
+		std::string suite = "all";
+		unsigned ratio = 4;
+		unsigned filter_length = 33;
+		unsigned seed = 42;
+		std::vector<unsigned> ratios = {1, 2, 4, 8};
+		std::vector<unsigned> filter_lengths = {8, 33};
+		fs::path output_dir = fs::path("verification/oversampling/output");
+		fs::path executable_path;
+	};
+
+	struct RenderComparison
+	{
+		RealType rms_error{};
+		RealType normalized_correlation{};
+		RealType fitted_gain{};
+		RealType fitted_phase{};
+	};
+
+	std::string toString(const RealType value, const int precision = 12)
+	{
+		std::ostringstream stream;
+		stream << std::setprecision(precision) << std::scientific << value;
+		return stream.str();
+	}
+
+	std::string toString(const unsigned value)
+	{
+		return std::to_string(value);
+	}
+
+	std::string jsonEscape(const std::string& value)
+	{
+		std::string out;
+		out.reserve(value.size() + 8);
+		for (const char ch : value)
+		{
+			switch (ch)
+			{
+			case '\\':
+				out += "\\\\";
+				break;
+			case '"':
+				out += "\\\"";
+				break;
+			case '\n':
+				out += "\\n";
+				break;
+			case '\r':
+				out += "\\r";
+				break;
+			case '\t':
+				out += "\\t";
+				break;
+			default:
+				out += ch;
+				break;
+			}
+		}
+		return out;
+	}
+
+	void ensureDirectory(const fs::path& directory)
+	{
+		std::error_code error;
+		fs::create_directories(directory, error);
+		if (error)
+		{
+			throw std::runtime_error("Failed to create directory: " + directory.string());
+		}
+	}
+
+	void writeTextFile(const fs::path& path, const std::string& text)
+	{
+		ensureDirectory(path.parent_path());
+		std::ofstream file(path);
+		if (!file.is_open())
+		{
+			throw std::runtime_error("Failed to open file for writing: " + path.string());
+		}
+		file << text;
+	}
+
+	void writeCsv(const fs::path& path, const std::vector<std::string>& header,
+				  const std::vector<std::vector<std::string>>& rows)
+	{
+		ensureDirectory(path.parent_path());
+		std::ofstream file(path);
+		if (!file.is_open())
+		{
+			throw std::runtime_error("Failed to open file for writing: " + path.string());
+		}
+
+		for (size_t i = 0; i < header.size(); ++i)
+		{
+			file << header[i];
+			if (i + 1 < header.size())
+			{
+				file << ',';
+			}
+		}
+		file << '\n';
+
+		for (const auto& row : rows)
+		{
+			for (size_t i = 0; i < row.size(); ++i)
+			{
+				file << row[i];
+				if (i + 1 < row.size())
+				{
+					file << ',';
+				}
+			}
+			file << '\n';
+		}
+	}
+
+	void addGeneratedFile(SuiteResult& result, const fs::path& path)
+	{
+		result.generated_files.push_back(fs::relative(path, result.output_dir).string());
+	}
+
+	std::string shellQuote(const std::string& value)
+	{
+		std::string out = "'";
+		for (const char ch : value)
+		{
+			if (ch == '\'')
+			{
+				out += "'\"'\"'";
+			}
+			else
+			{
+				out += ch;
+			}
+		}
+		out += "'";
+		return out;
+	}
+
+	std::vector<unsigned> parseUnsignedList(const std::string& value)
+	{
+		std::vector<unsigned> out;
+		std::stringstream stream(value);
+		std::string token;
+		while (std::getline(stream, token, ','))
+		{
+			if (!token.empty())
+			{
+				out.push_back(static_cast<unsigned>(std::stoul(token)));
+			}
+		}
+		if (out.empty())
+		{
+			throw std::runtime_error("Expected a non-empty comma-separated unsigned list");
+		}
+		return out;
+	}
+
+	CliOptions parseCli(const int argc, char* argv[])
+	{
+		CliOptions options;
+		options.executable_path = fs::absolute(argv[0]);
+
+		if (argc >= 2)
+		{
+			const std::string command = argv[1];
+			if (command == "suite")
+			{
+				options.command = CommandType::Suite;
+				if (argc < 3)
+				{
+					throw std::runtime_error("suite command requires a suite name");
+				}
+				options.suite = argv[2];
+			}
+			else if (command == "matrix")
+			{
+				options.command = CommandType::Matrix;
+			}
+			else if (command == "all")
+			{
+				options.command = CommandType::All;
+			}
+			else
+			{
+				throw std::runtime_error("Unknown command: " + command);
+			}
+		}
+
+		const int start_index = options.command == CommandType::Suite ? 3 : 2;
+		for (int i = start_index; i < argc; ++i)
+		{
+			const std::string arg = argv[i];
+			if (arg == "--ratio" && i + 1 < argc)
+			{
+				options.ratio = static_cast<unsigned>(std::stoul(argv[++i]));
+			}
+			else if (arg == "--filter-length" && i + 1 < argc)
+			{
+				options.filter_length = static_cast<unsigned>(std::stoul(argv[++i]));
+			}
+			else if (arg == "--seed" && i + 1 < argc)
+			{
+				options.seed = static_cast<unsigned>(std::stoul(argv[++i]));
+			}
+			else if (arg == "--output-dir" && i + 1 < argc)
+			{
+				options.output_dir = argv[++i];
+			}
+			else if (arg == "--ratios" && i + 1 < argc)
+			{
+				options.ratios = parseUnsignedList(argv[++i]);
+			}
+			else if (arg == "--filter-lengths" && i + 1 < argc)
+			{
+				options.filter_lengths = parseUnsignedList(argv[++i]);
+			}
+			else
+			{
+				throw std::runtime_error("Unknown or incomplete option: " + arg);
+			}
+		}
+
+		return options;
+	}
+
+	std::vector<RealType> blackmanFirAudit(const RealType cutoff, const unsigned render_filter_length)
+	{
+		const unsigned filt_length = render_filter_length * 2;
+		std::vector<RealType> coeffs(filt_length);
+		const RealType n = filt_length / 2.0;
+		const RealType pi_n = PI / n;
+
+		for (unsigned i = 0; i < filt_length; ++i)
+		{
+			const RealType sinc_arg = cutoff * (static_cast<RealType>(i) - n);
+			const RealType sinc_val = sinc_arg == 0 ? 1.0 : std::sin(sinc_arg * PI) / (sinc_arg * PI);
+			const RealType window =
+				0.42 - 0.5 * std::cos(pi_n * static_cast<RealType>(i)) + 0.08 * std::cos(2.0 * pi_n * static_cast<RealType>(i));
+			coeffs[i] = sinc_val * window;
+		}
+
+		return coeffs;
+	}
+
+	std::vector<ComplexType> makeTone(const size_t sample_count, const RealType frequency)
+	{
+		std::vector<ComplexType> out(sample_count);
+		for (size_t i = 0; i < sample_count; ++i)
+		{
+			const RealType phase = 2.0 * PI * frequency * static_cast<RealType>(i);
+			out[i] = {std::cos(phase), std::sin(phase)};
+		}
+		return out;
+	}
+
+	std::vector<ComplexType> makeChirp(const size_t sample_count, const RealType start_frequency, const RealType end_frequency)
+	{
+		std::vector<ComplexType> out(sample_count);
+		for (size_t i = 0; i < sample_count; ++i)
+		{
+			const RealType t = sample_count > 1 ? static_cast<RealType>(i) / static_cast<RealType>(sample_count - 1) : 0.0;
+			const RealType frequency = std::lerp(start_frequency, end_frequency, t);
+			const RealType phase = 2.0 * PI * frequency * static_cast<RealType>(i);
+			out[i] = {std::cos(phase), std::sin(phase)};
+		}
+		return out;
+	}
+
+	std::vector<ComplexType> makeLowBandNoise(const size_t sample_count, std::mt19937& rng)
+	{
+		std::uniform_real_distribution<RealType> phase_dist(0.0, 2.0 * PI);
+		std::uniform_real_distribution<RealType> freq_dist(0.01, 0.12);
+		std::vector<RealType> freqs(16);
+		std::vector<RealType> phases(16);
+		for (size_t i = 0; i < freqs.size(); ++i)
+		{
+			freqs[i] = freq_dist(rng);
+			phases[i] = phase_dist(rng);
+		}
+
+		std::vector<ComplexType> out(sample_count, ComplexType{0.0, 0.0});
+		for (size_t n = 0; n < sample_count; ++n)
+		{
+			ComplexType accum{0.0, 0.0};
+			for (size_t i = 0; i < freqs.size(); ++i)
+			{
+				const RealType phase = 2.0 * PI * freqs[i] * static_cast<RealType>(n) + phases[i];
+				accum += ComplexType(std::cos(phase), std::sin(phase));
+			}
+			out[n] = accum / static_cast<RealType>(freqs.size());
+		}
+		return out;
+	}
+
+	RenderComparison compareSignals(std::span<const ComplexType> reference, std::span<const ComplexType> observed,
+									const size_t skip_edge)
+	{
+		const size_t start = std::min(skip_edge, std::min(reference.size(), observed.size()));
+		const size_t end = reference.size() > skip_edge && observed.size() > skip_edge ?
+			std::min(reference.size(), observed.size()) - skip_edge :
+			std::min(reference.size(), observed.size());
+
+		ComplexType correlation{0.0, 0.0};
+		RealType output_energy = 0.0;
+		RealType reference_energy = 0.0;
+		RealType mse = 0.0;
+		size_t count = 0;
+
+		for (size_t i = start; i < end; ++i)
+		{
+			correlation += observed[i] * std::conj(reference[i]);
+			output_energy += std::norm(observed[i]);
+			reference_energy += std::norm(reference[i]);
+			mse += std::norm(observed[i] - reference[i]);
+			++count;
+		}
+
+		RenderComparison result;
+		result.rms_error = count == 0 ? 0.0 : std::sqrt(mse / static_cast<RealType>(count));
+		result.normalized_correlation =
+			(output_energy == 0.0 || reference_energy == 0.0) ? 0.0 : std::abs(correlation) / std::sqrt(output_energy * reference_energy);
+
+		ComplexType fitted = reference_energy == 0.0 ? ComplexType{0.0, 0.0} : correlation / reference_energy;
+		result.fitted_gain = std::abs(fitted);
+		result.fitted_phase = std::arg(fitted);
+		return result;
+	}
+
+	ComplexType expectedConstantRender(const std::span<const RealType> filter, const RealType amplitude,
+									   const RealType phase)
+	{
+		const int filt_length = static_cast<int>(filter.size());
+		RealType sum = 0.0;
+		for (int j = -filt_length / 2; j < filt_length / 2; ++j)
+		{
+			const int idx = j + filt_length / 2;
+			if (idx >= 0 && idx < filt_length)
+			{
+				sum += filter[static_cast<size_t>(idx)];
+			}
+		}
+		return amplitude * std::exp(ComplexType{0.0, 1.0} * phase) * sum;
+	}
+
+	RealType wrappedDelayFromFracWinDelay(const RealType frac_win_delay)
+	{
+		RealType fdelay = -frac_win_delay;
+		const int unwrap = static_cast<int>(std::floor(fdelay));
+		fdelay -= unwrap;
+		return fdelay;
+	}
+
+	void writeSummaryFile(SuiteResult& result)
+	{
+		std::vector<std::vector<std::string>> rows;
+		rows.reserve(result.summary_rows.size());
+		for (const auto& [metric, value] : result.summary_rows)
+		{
+			rows.push_back({metric, value});
+		}
+		const fs::path path = result.output_dir / "summary.csv";
+		writeCsv(path, {"metric", "value"}, rows);
+		addGeneratedFile(result, path);
+	}
+
+	void writeSourceMappingFile(SuiteResult& result)
+	{
+		std::vector<std::vector<std::string>> rows;
+		rows.reserve(result.source_mappings.size());
+		for (const auto& mapping : result.source_mappings)
+		{
+			rows.push_back({mapping.suite, mapping.upstream_file, mapping.upstream_lines, mapping.local_file, mapping.note});
+		}
+		const fs::path path = result.output_dir / "source_mapping.csv";
+		writeCsv(path, {"suite", "upstream_file", "upstream_lines", "local_file", "note"}, rows);
+		addGeneratedFile(result, path);
+	}
+
+	void writeReadmeFile(SuiteResult& result)
+	{
+		const fs::path path = result.output_dir / "README.txt";
+		writeTextFile(path, result.readme);
+		addGeneratedFile(result, path);
+	}
+
+	void writeManifestFile(const SuiteResult& result, const CliOptions& options)
+	{
+		std::ostringstream stream;
+		stream << "{\n";
+		stream << "  \"suite\": \"" << jsonEscape(result.suite) << "\",\n";
+		stream << "  \"ratio\": " << options.ratio << ",\n";
+		stream << "  \"filter_length\": " << options.filter_length << ",\n";
+		stream << "  \"seed\": " << options.seed << ",\n";
+		stream << "  \"generated_files\": [\n";
+		for (size_t i = 0; i < result.generated_files.size(); ++i)
+		{
+			stream << "    \"" << jsonEscape(result.generated_files[i]) << "\"";
+			if (i + 1 < result.generated_files.size())
+			{
+				stream << ',';
+			}
+			stream << '\n';
+		}
+		stream << "  ],\n";
+		stream << "  \"source_mappings\": [\n";
+		for (size_t i = 0; i < result.source_mappings.size(); ++i)
+		{
+			const auto& mapping = result.source_mappings[i];
+			stream << "    {\n";
+			stream << "      \"suite\": \"" << jsonEscape(mapping.suite) << "\",\n";
+			stream << "      \"upstream_file\": \"" << jsonEscape(mapping.upstream_file) << "\",\n";
+			stream << "      \"upstream_lines\": \"" << jsonEscape(mapping.upstream_lines) << "\",\n";
+			stream << "      \"local_file\": \"" << jsonEscape(mapping.local_file) << "\",\n";
+			stream << "      \"note\": \"" << jsonEscape(mapping.note) << "\"\n";
+			stream << "    }";
+			if (i + 1 < result.source_mappings.size())
+			{
+				stream << ',';
+			}
+			stream << '\n';
+		}
+		stream << "  ],\n";
+		stream << "  \"deferred_paths\": [\n";
+		stream << "    {\n";
+		stream << "      \"upstream_file\": \"packages/libfers/src/noise/falpha_branch.cpp\",\n";
+		stream << "      \"upstream_lines\": \"154-166\",\n";
+		stream << "      \"reason\": \"Documents the DecadeUpsampler caller path but does not execute it in this harness version.\"\n";
+		stream << "    }\n";
+		stream << "  ]\n";
+		stream << "}\n";
+
+		writeTextFile(result.output_dir / "manifest.json", stream.str());
+	}
+
+	SuiteResult makeSuiteResult(const std::string& suite, const fs::path& output_dir)
+	{
+		SuiteResult result;
+		result.suite = suite;
+		result.output_dir = output_dir;
+		ensureDirectory(output_dir);
+		return result;
+	}
+
+	fers_signal::RadarSignal makeWaveform(const std::string& name, const std::vector<ComplexType>& samples,
+										  const RealType sample_rate, const RealType power = 1.0,
+										  const RealType carrier = 1.0)
+	{
+		auto signal = std::make_unique<fers_signal::Signal>();
+		signal->load(samples, static_cast<unsigned>(samples.size()), sample_rate);
+		return {name, power, carrier, static_cast<RealType>(samples.size()) / sample_rate, std::move(signal)};
+	}
+
+	SuiteResult runResamplerSuite(const CliOptions& options)
+	{
+		ParamGuard guard;
+		params::params.reset();
+		params::setOversampleRatio(options.ratio);
+		params::params.filter_length = options.filter_length;
+		params::setRate(1024.0);
+		params::setRandomSeed(options.seed);
+
+		SuiteResult result = makeSuiteResult("resampler", options.output_dir);
+		result.readme =
+			"summary.csv: scalar metrics for the FIR and round-trip checks.\n"
+			"fir_coefficients.csv: upstream-equivalent Blackman FIR taps generated from the current ratio and filter length.\n"
+			"impulse_response.csv: complex upsampled output for a unit impulse input.\n"
+			"step_response.csv: complex upsampled output for a unit step input.\n"
+			"tone_roundtrip.csv: tone-by-tone round-trip metrics after upsample+downsample.\n"
+			"scenario_roundtrip.csv: multitone, chirp, and low-band noise round-trip metrics.\n"
+			"truncation_behavior.csv: output length after downsampling non-divisible oversampled buffers.\n"
+			"group_delay_alignment.csv: peak-index alignment checks after round-trip reconstruction.\n";
+
+		result.source_mappings = {
+			{"resampler", "packages/libfers/src/signal/dsp_filters.cpp", "71-120", "src/signal/dsp_filters.cpp",
+			 "Exact copy of the complex oversample/downsample path under test."},
+			{"resampler", "packages/libfers/src/signal/dsp_filters.cpp", "46-65", "src/main.cpp",
+			 "Audit-only reimplementation of the upstream Blackman FIR coefficient generator for coefficient export."},
+		};
+
+		const auto coeffs = blackmanFirAudit(1.0 / static_cast<RealType>(options.ratio), options.filter_length);
+		RealType coeff_sum = std::accumulate(coeffs.begin(), coeffs.end(), 0.0);
+		RealType coeff_energy = std::inner_product(coeffs.begin(), coeffs.end(), coeffs.begin(), 0.0);
+
+		{
+			std::vector<std::vector<std::string>> rows;
+			rows.reserve(coeffs.size());
+			for (size_t i = 0; i < coeffs.size(); ++i)
+			{
+				rows.push_back({std::to_string(i), toString(coeffs[i])});
+			}
+			const fs::path path = result.output_dir / "fir_coefficients.csv";
+			writeCsv(path, {"index", "coefficient"}, rows);
+			addGeneratedFile(result, path);
+		}
+
+		{
+			const size_t input_size = 16;
+			std::vector<ComplexType> impulse(input_size, ComplexType{0.0, 0.0});
+			impulse[0] = ComplexType{1.0, 0.0};
+			std::vector<ComplexType> upsampled(input_size * options.ratio);
+			fers_signal::upsample(impulse, static_cast<unsigned>(impulse.size()), upsampled);
+
+			std::vector<std::vector<std::string>> rows;
+			rows.reserve(upsampled.size());
+			for (size_t i = 0; i < upsampled.size(); ++i)
+			{
+				rows.push_back({std::to_string(i), toString(upsampled[i].real()), toString(upsampled[i].imag()),
+								toString(std::abs(upsampled[i]))});
+			}
+			const fs::path path = result.output_dir / "impulse_response.csv";
+			writeCsv(path, {"index", "real", "imag", "magnitude"}, rows);
+			addGeneratedFile(result, path);
+		}
+
+		{
+			const size_t input_size = 16;
+			std::vector<ComplexType> step(input_size, ComplexType{1.0, 0.0});
+			std::vector<ComplexType> upsampled(input_size * options.ratio);
+			fers_signal::upsample(step, static_cast<unsigned>(step.size()), upsampled);
+
+			std::vector<std::vector<std::string>> rows;
+			rows.reserve(upsampled.size());
+			for (size_t i = 0; i < upsampled.size(); ++i)
+			{
+				rows.push_back({std::to_string(i), toString(upsampled[i].real()), toString(upsampled[i].imag()),
+								toString(std::abs(upsampled[i]))});
+			}
+			const fs::path path = result.output_dir / "step_response.csv";
+			writeCsv(path, {"index", "real", "imag", "magnitude"}, rows);
+			addGeneratedFile(result, path);
+		}
+
+		{
+			const size_t sample_count = 512;
+			const std::array<RealType, 5> freqs = {0.01, 0.05, 0.1, 0.18, 0.24};
+			std::vector<std::vector<std::string>> rows;
+			for (const RealType freq : freqs)
+			{
+				const auto input = makeTone(sample_count, freq);
+				std::vector<ComplexType> upsampled(sample_count * options.ratio);
+				fers_signal::upsample(input, static_cast<unsigned>(input.size()), upsampled);
+				auto downsampled = fers_signal::downsample(upsampled);
+				const auto metrics = compareSignals(input, downsampled, 16);
+				rows.push_back({toString(freq, 8), toString(metrics.rms_error), toString(metrics.normalized_correlation),
+								toString(metrics.fitted_gain), toString(metrics.fitted_phase)});
+			}
+			const fs::path path = result.output_dir / "tone_roundtrip.csv";
+			writeCsv(path, {"frequency", "rms_error", "normalized_correlation", "fitted_gain", "fitted_phase"}, rows);
+			addGeneratedFile(result, path);
+		}
+
+		{
+			std::mt19937 rng(options.seed);
+			std::vector<std::pair<std::string, std::vector<ComplexType>>> scenarios;
+			scenarios.emplace_back("multitone", [] {
+				std::vector<ComplexType> out(512, ComplexType{0.0, 0.0});
+				const auto a = makeTone(512, 0.03);
+				const auto b = makeTone(512, 0.07);
+				const auto c = makeTone(512, 0.12);
+				for (size_t i = 0; i < out.size(); ++i)
+				{
+					out[i] = (a[i] + b[i] + c[i]) / 3.0;
+				}
+				return out;
+			}());
+			scenarios.emplace_back("chirp", makeChirp(512, 0.01, 0.22));
+			scenarios.emplace_back("low_band_noise", makeLowBandNoise(512, rng));
+
+			std::vector<std::vector<std::string>> rows;
+			for (const auto& [name, input] : scenarios)
+			{
+				std::vector<ComplexType> upsampled(input.size() * options.ratio);
+				fers_signal::upsample(input, static_cast<unsigned>(input.size()), upsampled);
+				auto downsampled = fers_signal::downsample(upsampled);
+				const auto metrics = compareSignals(input, downsampled, 16);
+				rows.push_back({name, toString(metrics.rms_error), toString(metrics.normalized_correlation),
+								toString(metrics.fitted_gain), toString(metrics.fitted_phase)});
+			}
+			const fs::path path = result.output_dir / "scenario_roundtrip.csv";
+			writeCsv(path, {"scenario", "rms_error", "normalized_correlation", "fitted_gain", "fitted_phase"}, rows);
+			addGeneratedFile(result, path);
+		}
+
+		{
+			std::vector<std::vector<std::string>> rows;
+			for (const unsigned input_size : {63u, 64u, 65u})
+			{
+				std::vector<ComplexType> input(input_size, ComplexType{0.0, 0.0});
+				input[input_size / 2] = {1.0, 0.0};
+				std::vector<ComplexType> upsampled(static_cast<size_t>(input_size * options.ratio));
+				fers_signal::upsample(input, input_size, upsampled);
+				auto downsampled = fers_signal::downsample(upsampled);
+				rows.push_back({std::to_string(input_size), std::to_string(upsampled.size()), std::to_string(downsampled.size())});
+			}
+			const fs::path path = result.output_dir / "truncation_behavior.csv";
+			writeCsv(path, {"input_size", "oversampled_size", "downsampled_size"}, rows);
+			addGeneratedFile(result, path);
+		}
+
+		{
+			std::vector<std::vector<std::string>> rows;
+			for (const unsigned input_size : {64u, 96u})
+			{
+				std::vector<ComplexType> input(input_size, ComplexType{0.0, 0.0});
+				const unsigned peak_index = input_size / 2;
+				input[peak_index] = {1.0, 0.0};
+				std::vector<ComplexType> upsampled(static_cast<size_t>(input_size * options.ratio));
+				fers_signal::upsample(input, input_size, upsampled);
+				auto downsampled = fers_signal::downsample(upsampled);
+				const auto max_iter = std::max_element(downsampled.begin(), downsampled.end(),
+													   [](const ComplexType& a, const ComplexType& b)
+													   { return std::abs(a) < std::abs(b); });
+				const unsigned observed_peak = static_cast<unsigned>(std::distance(downsampled.begin(), max_iter));
+				rows.push_back({std::to_string(input_size), std::to_string(peak_index), std::to_string(observed_peak),
+								toString(static_cast<RealType>(static_cast<int>(observed_peak) - static_cast<int>(peak_index)))});
+			}
+			const fs::path path = result.output_dir / "group_delay_alignment.csv";
+			writeCsv(path, {"input_size", "expected_peak_index", "observed_peak_index", "peak_index_error"}, rows);
+			addGeneratedFile(result, path);
+		}
+
+		result.summary_rows = {
+			{"ratio", toString(options.ratio)},
+			{"filter_length", toString(options.filter_length)},
+			{"fir_coefficient_count", toString(static_cast<unsigned>(coeffs.size()))},
+			{"fir_sum", toString(coeff_sum)},
+			{"fir_energy", toString(coeff_energy)},
+		};
+
+		writeSummaryFile(result);
+		writeSourceMappingFile(result);
+		writeReadmeFile(result);
+		writeManifestFile(result, options);
+		return result;
+	}
+
+	SuiteResult runRenderSuite(const CliOptions& options)
+	{
+		ParamGuard guard;
+		params::params.reset();
+		params::params.filter_length = options.filter_length;
+		params::setRate(64.0);
+		params::setOversampleRatio(options.ratio);
+
+		SuiteResult result = makeSuiteResult("render", options.output_dir);
+		result.readme =
+			"summary.csv: scalar metrics for load, interpolation, and oversampled render checks.\n"
+			"signal_load.csv: observed versus expected size/rate scaling after Signal::load.\n"
+			"constant_render.csv: rendered samples for a constant waveform with fixed amplitude and phase.\n"
+			"power_phase_interpolation.csv: midpoint interpolation checks for power and phase.\n"
+			"fractional_delay_sweep.csv: fractional-delay wrapping checks against the interpolation filter table.\n"
+			"oversampled_render_comparison.csv: ratio-1 render versus oversampled-render-then-downsample metrics.\n"
+			"edge_behavior.csv: first and last rendered samples to expose window-edge truncation behavior.\n";
+
+		result.source_mappings = {
+			{"render", "packages/libfers/src/signal/radar_signal.cpp", "64-156", "src/signal/radar_signal.cpp",
+			 "Exact copy of Signal::load, Signal::render, and RadarSignal::render."},
+			{"render", "packages/libfers/src/interpolation/interpolation_filter.cpp", "62-146",
+			 "src/interpolation/interpolation_filter.cpp",
+			 "Exact copy of the interpolation-filter singleton used during rendering."},
+		};
+
+		const unsigned filter_length = params::renderFilterLength();
+		const unsigned sample_count = filter_length * 8;
+		const std::vector<ComplexType> input(sample_count, ComplexType{1.0, 0.0});
+
+		fers_signal::Signal signal;
+		signal.load(input, sample_count, params::rate());
+
+		{
+			const fs::path path = result.output_dir / "signal_load.csv";
+			writeCsv(path, {"input_samples", "ratio", "observed_rate", "expected_rate", "observed_render_size", "expected_render_size"},
+					 {{std::to_string(sample_count), std::to_string(options.ratio), toString(signal.getRate()),
+					   toString(params::rate() * options.ratio), std::to_string(sample_count * options.ratio),
+					   std::to_string(sample_count * options.ratio)}});
+			addGeneratedFile(result, path);
+		}
+
+		const auto& interp_filter = interp::InterpFilter::getInstance();
+
+		{
+			const RealType power = 4.0;
+			const RealType phase = PI / 4.0;
+			const std::vector<interp::InterpPoint> points = {{power, 0.0, 0.0, phase}};
+			unsigned size = 0;
+			const auto data = signal.render(points, size, 0.0);
+			const auto filter = interp_filter.getFilter(0.0);
+			const auto expected = expectedConstantRender(filter, std::sqrt(power), phase);
+
+			std::vector<std::vector<std::string>> rows;
+			for (size_t i = 0; i < data.size(); ++i)
+			{
+				rows.push_back({std::to_string(i), toString(data[i].real()), toString(data[i].imag()), toString(std::abs(data[i]))});
+			}
+			const fs::path path = result.output_dir / "constant_render.csv";
+			writeCsv(path, {"index", "real", "imag", "magnitude"}, rows);
+			addGeneratedFile(result, path);
+
+			result.summary_rows.push_back({"constant_expected_real", toString(expected.real())});
+			result.summary_rows.push_back({"constant_expected_imag", toString(expected.imag())});
+			result.summary_rows.push_back({"constant_observed_center_real", toString(data[filter_length].real())});
+			result.summary_rows.push_back({"constant_observed_center_imag", toString(data[filter_length].imag())});
+		}
+
+		{
+			const RealType power_a = 1.0;
+			const RealType power_b = 9.0;
+			const RealType phase_a = 0.0;
+			const RealType phase_b = PI / 2.0;
+			const std::vector<interp::InterpPoint> points = {{power_a, 0.0, 0.0, phase_a},
+															 {power_b, 2.0 * filter_length, 0.0, phase_b}};
+
+			unsigned size = 0;
+			const auto data = signal.render(points, size, 0.0);
+			const auto filter = interp_filter.getFilter(0.0);
+
+			std::vector<std::vector<std::string>> rows;
+			for (unsigned index : {filter_length / 2, filter_length, filter_length + filter_length / 2, filter_length * 2})
+			{
+				if (index >= data.size())
+				{
+					continue;
+				}
+
+				const RealType sample_time = static_cast<RealType>(index) / signal.getRate();
+				const RealType bw = sample_time / (2.0 * filter_length / signal.getRate());
+				const RealType amplitude = std::lerp(std::sqrt(power_a), std::sqrt(power_b), std::clamp(bw, 0.0, 1.0));
+				const RealType phase = std::lerp(phase_a, phase_b, std::clamp(bw, 0.0, 1.0));
+				const auto expected = expectedConstantRender(filter, amplitude, phase);
+				rows.push_back({std::to_string(index), toString(sample_time), toString(expected.real()), toString(expected.imag()),
+								toString(data[index].real()), toString(data[index].imag())});
+			}
+			const fs::path path = result.output_dir / "power_phase_interpolation.csv";
+			writeCsv(path, {"index", "sample_time", "expected_real", "expected_imag", "observed_real", "observed_imag"}, rows);
+			addGeneratedFile(result, path);
+		}
+
+		{
+			const std::vector<interp::InterpPoint> points = {{1.0, 0.0, 0.0, 0.0}};
+			std::vector<std::vector<std::string>> rows;
+			for (const RealType frac_delay : {-0.95, -0.75, -0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 0.95})
+			{
+				unsigned size = 0;
+				const auto data = signal.render(points, size, frac_delay);
+				const RealType effective_delay = wrappedDelayFromFracWinDelay(frac_delay);
+				const auto filter = interp_filter.getFilter(effective_delay);
+				const auto expected = expectedConstantRender(filter, 1.0, 0.0);
+				rows.push_back({toString(frac_delay, 8), toString(effective_delay, 8), toString(expected.real()),
+								toString(data[filter_length].real()), toString(data[filter_length].imag())});
+			}
+			const fs::path path = result.output_dir / "fractional_delay_sweep.csv";
+			writeCsv(path, {"frac_win_delay", "effective_delay", "expected_real", "observed_real", "observed_imag"}, rows);
+			addGeneratedFile(result, path);
+		}
+
+		{
+			params::setOversampleRatio(1);
+			params::setRate(64.0);
+			const auto reference_waveform = makeTone(256, 0.07);
+			fers_signal::Signal reference_signal;
+			reference_signal.load(reference_waveform, static_cast<unsigned>(reference_waveform.size()), params::rate());
+			const std::vector<interp::InterpPoint> points = {{1.0, 0.0, 0.0, 0.0}};
+			unsigned reference_size = 0;
+			const auto reference_render = reference_signal.render(points, reference_size, 0.15);
+
+			params::setOversampleRatio(options.ratio);
+			fers_signal::Signal oversampled_signal;
+			oversampled_signal.load(reference_waveform, static_cast<unsigned>(reference_waveform.size()), 64.0);
+			unsigned oversampled_size = 0;
+			auto oversampled_render = oversampled_signal.render(points, oversampled_size, 0.15);
+			auto downsampled_render = fers_signal::downsample(oversampled_render);
+			const auto metrics = compareSignals(reference_render, downsampled_render, 16);
+
+			const fs::path path = result.output_dir / "oversampled_render_comparison.csv";
+			writeCsv(path, {"scenario", "rms_error", "normalized_correlation", "fitted_gain", "fitted_phase"},
+					 {{"tone_constant_delay", toString(metrics.rms_error), toString(metrics.normalized_correlation),
+					   toString(metrics.fitted_gain), toString(metrics.fitted_phase)}});
+			addGeneratedFile(result, path);
+
+			result.summary_rows.push_back({"oversampled_render_rms_error", toString(metrics.rms_error)});
+			result.summary_rows.push_back({"oversampled_render_correlation", toString(metrics.normalized_correlation)});
+		}
+
+		{
+			params::setOversampleRatio(options.ratio);
+			fers_signal::Signal edge_signal;
+			edge_signal.load(input, sample_count, 64.0);
+			const std::vector<interp::InterpPoint> points = {{1.0, 0.0, 0.0, 0.0}};
+			unsigned size = 0;
+			const auto data = edge_signal.render(points, size, 0.0);
+
+			std::vector<std::vector<std::string>> rows;
+			for (size_t i = 0; i < std::min<size_t>(16, data.size()); ++i)
+			{
+				rows.push_back({"head", std::to_string(i), toString(data[i].real()), toString(data[i].imag()),
+								toString(std::abs(data[i]))});
+			}
+			for (size_t i = data.size() > 16 ? data.size() - 16 : 0; i < data.size(); ++i)
+			{
+				rows.push_back({"tail", std::to_string(i), toString(data[i].real()), toString(data[i].imag()),
+								toString(std::abs(data[i]))});
+			}
+			const fs::path path = result.output_dir / "edge_behavior.csv";
+			writeCsv(path, {"region", "index", "real", "imag", "magnitude"}, rows);
+			addGeneratedFile(result, path);
+		}
+
+		result.summary_rows.insert(result.summary_rows.begin(),
+								   {{"ratio", toString(options.ratio)}, {"filter_length", toString(options.filter_length)}});
+		writeSummaryFile(result);
+		writeSourceMappingFile(result);
+		writeReadmeFile(result);
+		writeManifestFile(result, options);
+		return result;
+	}
+
+	SuiteResult runPipelineSuite(const CliOptions& options)
+	{
+		ParamGuard guard;
+		params::params.reset();
+		params::setOversampleRatio(options.ratio);
+		params::params.filter_length = options.filter_length;
+		params::setRate(64.0);
+		params::setRandomSeed(options.seed);
+
+		SuiteResult result = makeSuiteResult("pipeline", options.output_dir);
+		result.readme =
+			"summary.csv: scalar metrics for renderWindow, thermal noise, and final decimation.\n"
+			"response_overlap.csv: window overlap and clipping metrics for multiple responses.\n"
+			"window_trace.csv: rendered receive-window samples after response accumulation.\n"
+			"thermal_noise_stats.csv: empirical means and variances against the implemented bandwidth formula.\n"
+			"downsampling_quantization.csv: final downsample-plus-normalize metrics.\n"
+			"adc_histogram_bits_*.csv: quantized code histograms for representative ADC depths.\n";
+
+		result.source_mappings = {
+			{"pipeline", "packages/libfers/src/serial/response.cpp", "27-33", "src/serial/response.cpp",
+			 "Exact copy of renderBinary delegation."},
+			{"pipeline", "packages/libfers/src/processing/signal_processor.cpp", "59-154", "src/processing/signal_processor.cpp",
+			 "Source-faithful renderWindow, thermal noise, and quantization behavior."},
+			{"pipeline", "packages/libfers/src/processing/finalizer_pipeline.cpp", "113-120",
+			 "src/processing/finalizer_pipeline.cpp", "Exact copy of the oversampling-aware final decimation step."},
+		};
+
+		const auto waveform_samples = makeTone(16, 0.05);
+		auto wave = makeWaveform("audit_wave", waveform_samples, 64.0);
+
+		std::vector<std::unique_ptr<serial::Response>> responses;
+		{
+			auto before = std::make_unique<serial::Response>(&wave);
+			before->addInterpPoint({1.0, 0.875, 0.0, 0.0});
+			before->addInterpPoint({1.0, 1.125, 0.0, 0.0});
+			responses.push_back(std::move(before));
+
+			auto inside = std::make_unique<serial::Response>(&wave);
+			inside->addInterpPoint({0.5, 1.125, 0.0, PI / 8.0});
+			inside->addInterpPoint({0.5, 1.375, 0.0, PI / 8.0});
+			responses.push_back(std::move(inside));
+
+			auto after = std::make_unique<serial::Response>(&wave);
+			after->addInterpPoint({0.75, 1.375, 0.0, PI / 4.0});
+			after->addInterpPoint({0.75, 1.625, 0.0, PI / 4.0});
+			responses.push_back(std::move(after));
+		}
+
+		const RealType window_start = 1.0;
+		const RealType window_length = 0.5;
+		const unsigned window_size = static_cast<unsigned>(std::ceil(window_length * params::rate() * params::oversampleRatio()));
+		std::vector<ComplexType> window(window_size, ComplexType{0.0, 0.0});
+		processing::renderWindow(window, window_length, window_start, 0.0, responses);
+
+		{
+			std::vector<std::vector<std::string>> overlap_rows;
+			for (const auto& response : responses)
+			{
+				RealType rate = 0.0;
+				unsigned size = 0;
+				const auto rendered = response->renderBinary(rate, size, 0.0);
+				const int start_sample = static_cast<int>(std::round(params::rate() * params::oversampleRatio() *
+																 (response->startTime() - window_start)));
+				const unsigned clipped_prefix = start_sample < 0 ? static_cast<unsigned>(-start_sample) : 0u;
+				const unsigned clipped_suffix = start_sample + static_cast<int>(size) > static_cast<int>(window_size) ?
+					static_cast<unsigned>(start_sample + static_cast<int>(size) - static_cast<int>(window_size)) :
+					0u;
+				RealType energy = 0.0;
+				for (const auto& sample : rendered)
+				{
+					energy += std::norm(sample);
+				}
+
+				overlap_rows.push_back({toString(response->startTime()), toString(response->endTime()), std::to_string(size),
+										std::to_string(clipped_prefix), std::to_string(clipped_suffix), toString(energy)});
+			}
+			const fs::path path = result.output_dir / "response_overlap.csv";
+			writeCsv(path, {"start_time", "end_time", "render_size", "clipped_prefix_samples", "clipped_suffix_samples",
+							"render_energy"},
+					 overlap_rows);
+			addGeneratedFile(result, path);
+		}
+
+		{
+			std::vector<std::vector<std::string>> trace_rows;
+			trace_rows.reserve(window.size());
+			for (size_t i = 0; i < window.size(); ++i)
+			{
+				trace_rows.push_back({std::to_string(i), toString(window[i].real()), toString(window[i].imag()),
+									  toString(std::abs(window[i]))});
+			}
+			const fs::path path = result.output_dir / "window_trace.csv";
+			writeCsv(path, {"index", "real", "imag", "magnitude"}, trace_rows);
+			addGeneratedFile(result, path);
+		}
+
+		{
+			std::vector<std::vector<std::string>> rows;
+			for (const RealType temperature : {0.0, 50.0, 300.0})
+			{
+				std::vector<ComplexType> noise_buffer(50000, ComplexType{0.0, 0.0});
+				std::mt19937 rng(options.seed + static_cast<unsigned>(temperature));
+				processing::applyThermalNoise(noise_buffer, temperature, rng);
+
+				RealType mean_real = 0.0;
+				RealType mean_imag = 0.0;
+				for (const auto& sample : noise_buffer)
+				{
+					mean_real += sample.real();
+					mean_imag += sample.imag();
+				}
+				mean_real /= static_cast<RealType>(noise_buffer.size());
+				mean_imag /= static_cast<RealType>(noise_buffer.size());
+
+				RealType var_real = 0.0;
+				RealType var_imag = 0.0;
+				for (const auto& sample : noise_buffer)
+				{
+					var_real += std::pow(sample.real() - mean_real, 2);
+					var_imag += std::pow(sample.imag() - mean_imag, 2);
+				}
+				var_real /= static_cast<RealType>(noise_buffer.size());
+				var_imag /= static_cast<RealType>(noise_buffer.size());
+
+				const RealType bandwidth = params::rate() / (2.0 * params::oversampleRatio());
+				const RealType expected_power = params::boltzmannK() * temperature * bandwidth / 2.0;
+				rows.push_back({toString(temperature), toString(mean_real), toString(mean_imag), toString(var_real),
+								toString(var_imag), toString(expected_power)});
+			}
+			const fs::path path = result.output_dir / "thermal_noise_stats.csv";
+			writeCsv(path, {"temperature", "mean_real", "mean_imag", "variance_real", "variance_imag",
+							"expected_per_channel_power"},
+					 rows);
+			addGeneratedFile(result, path);
+		}
+
+		{
+			params::setAdcBits(0);
+			const size_t sample_count = 64;
+			const auto baseband = makeTone(sample_count, 0.05);
+			std::vector<ComplexType> oversampled(sample_count * params::oversampleRatio());
+			fers_signal::upsample(baseband, static_cast<unsigned>(baseband.size()), oversampled);
+			const RealType fullscale = processing::pipeline::applyDownsamplingAndQuantization(oversampled);
+			const auto metrics = compareSignals(baseband, oversampled, 10);
+
+			const fs::path path = result.output_dir / "downsampling_quantization.csv";
+			writeCsv(path, {"scenario", "final_size", "fullscale", "rms_error", "normalized_correlation"},
+					 {{"normalize_only", std::to_string(oversampled.size()), toString(fullscale), toString(metrics.rms_error),
+					   toString(metrics.normalized_correlation)}});
+			addGeneratedFile(result, path);
+
+			result.summary_rows.push_back({"downsampled_fullscale", toString(fullscale)});
+			result.summary_rows.push_back({"downsampled_correlation", toString(metrics.normalized_correlation)});
+		}
+
+		for (const unsigned bits : {3u, 8u})
+		{
+			params::setAdcBits(bits);
+			std::vector<ComplexType> adc_window;
+			adc_window.reserve(256);
+			for (int i = 0; i < 256; ++i)
+			{
+				const RealType x = -1.0 + 2.0 * static_cast<RealType>(i) / 255.0;
+				adc_window.emplace_back(x, 0.5 * x);
+			}
+
+			const RealType fullscale = processing::quantizeAndScaleWindow(adc_window);
+			(void)fullscale;
+
+			std::map<std::string, unsigned> histogram;
+			for (const auto& sample : adc_window)
+			{
+				++histogram[toString(sample.real(), 6)];
+			}
+
+			std::vector<std::vector<std::string>> rows;
+			for (const auto& [level, count] : histogram)
+			{
+				rows.push_back({level, std::to_string(count)});
+			}
+			const fs::path path = result.output_dir / ("adc_histogram_bits_" + std::to_string(bits) + ".csv");
+			writeCsv(path, {"quantized_real_level", "count"}, rows);
+			addGeneratedFile(result, path);
+		}
+
+		result.summary_rows.insert(result.summary_rows.begin(),
+								   {{"ratio", toString(options.ratio)}, {"filter_length", toString(options.filter_length)}});
+		writeSummaryFile(result);
+		writeSourceMappingFile(result);
+		writeReadmeFile(result);
+		writeManifestFile(result, options);
+		return result;
+	}
+
+	RealType quantizedPrf(const RealType rate, const unsigned ratio, const RealType requested_prf)
+	{
+		const RealType oversampled_rate = rate * ratio;
+		return 1.0 / (std::floor(oversampled_rate / requested_prf) / oversampled_rate);
+	}
+
+	RealType quantizedSkip(const RealType rate, const unsigned ratio, const RealType skip)
+	{
+		const RealType oversampled_rate = rate * ratio;
+		return std::floor(oversampled_rate * skip) / oversampled_rate;
+	}
+
+	size_t cwBufferSize(const RealType start_time, const RealType end_time, const RealType rate, const unsigned ratio)
+	{
+		const RealType dt_sim = 1.0 / (rate * ratio);
+		return static_cast<size_t>(std::ceil((end_time - start_time) / dt_sim));
+	}
+
+	SuiteResult runClockingSuite(const CliOptions& options)
+	{
+		SuiteResult result = makeSuiteResult("clocking", options.output_dir);
+		result.readme =
+			"summary.csv: scalar maxima for the caller-formula probes.\n"
+			"transmitter_prf_quantization.csv: requested versus quantized transmitter PRFs.\n"
+			"receiver_window_quantization.csv: quantized receiver window PRFs and skips.\n"
+			"cw_timestep_and_buffer.csv: dt_sim and CW buffer sizes for representative durations.\n"
+			"source_mapping.csv: caller-to-formula mapping for non-sample-transforming oversampling users.\n";
+
+		result.source_mappings = {
+			{"clocking", "packages/libfers/src/radar/transmitter.cpp", "19-23", "src/main.cpp",
+			 "Formula probe mirroring transmitter PRF quantization."},
+			{"clocking", "packages/libfers/src/radar/receiver.cpp", "90-96", "src/main.cpp",
+			 "Formula probe mirroring receiver window PRF and skip quantization."},
+			{"clocking", "packages/libfers/src/core/sim_threading.cpp", "103-110", "src/main.cpp",
+			 "Formula probe mirroring the oversampled CW timestep."},
+			{"clocking", "packages/libfers/src/serial/xml_parser_utils.cpp", "1071-1081", "src/main.cpp",
+			 "Formula probe mirroring CW buffer preallocation from parsed parameters."},
+			{"clocking", "packages/libfers/src/serial/json_serializer.cpp", "1583-1594", "src/main.cpp",
+			 "Formula probe mirroring CW buffer preallocation from hydrated JSON state."},
+		};
+
+		RealType max_prf_error = 0.0;
+		{
+			std::vector<std::vector<std::string>> rows;
+			for (const RealType rate : {1.0e3, 1.0e6})
+			{
+				for (const unsigned ratio : {1u, 2u, 4u, options.ratio})
+				{
+					for (const RealType requested_prf : {7.0, 33.0, 123.45, 499.9})
+					{
+						const RealType effective = quantizedPrf(rate, ratio, requested_prf);
+						const RealType error = effective - requested_prf;
+						max_prf_error = std::max(max_prf_error, std::abs(error));
+						rows.push_back({toString(rate), std::to_string(ratio), toString(rate * ratio), toString(requested_prf),
+										toString(effective), toString(error)});
+					}
+				}
+			}
+			const fs::path path = result.output_dir / "transmitter_prf_quantization.csv";
+			writeCsv(path, {"rate", "ratio", "oversampled_rate", "requested_prf", "effective_prf", "error"}, rows);
+			addGeneratedFile(result, path);
+		}
+
+		RealType max_skip_error = 0.0;
+		{
+			std::vector<std::vector<std::string>> rows;
+			for (const RealType rate : {1.0e3, 1.0e6})
+			{
+				for (const unsigned ratio : {1u, 2u, 4u, options.ratio})
+				{
+					for (const RealType requested_prf : {7.0, 33.0, 123.45})
+					{
+						for (const RealType skip : {0.0, 1.0e-6, 0.00037, 0.0013})
+						{
+							const RealType effective_prf = quantizedPrf(rate, ratio, requested_prf);
+							const RealType effective_skip = quantizedSkip(rate, ratio, skip);
+							max_skip_error = std::max(max_skip_error, std::abs(effective_skip - skip));
+							rows.push_back({toString(rate), std::to_string(ratio), toString(requested_prf), toString(effective_prf),
+											toString(skip), toString(effective_skip), toString(effective_skip - skip)});
+						}
+					}
+				}
+			}
+			const fs::path path = result.output_dir / "receiver_window_quantization.csv";
+			writeCsv(path, {"rate", "ratio", "requested_prf", "effective_prf", "requested_skip", "effective_skip", "skip_error"},
+					 rows);
+			addGeneratedFile(result, path);
+		}
+
+		{
+			std::vector<std::vector<std::string>> rows;
+			for (const RealType rate : {1.0e3, 1.0e6})
+			{
+				for (const unsigned ratio : {1u, 2u, 4u, options.ratio})
+				{
+					for (const auto [start_time, end_time] :
+						 {std::pair{0.0, 1.0}, std::pair{0.0, 1.001}, std::pair{0.125, 0.125123}})
+					{
+						const RealType dt_sim = 1.0 / (rate * ratio);
+						rows.push_back({toString(rate), std::to_string(ratio), toString(start_time), toString(end_time),
+										toString(dt_sim), std::to_string(cwBufferSize(start_time, end_time, rate, ratio))});
+					}
+				}
+			}
+			const fs::path path = result.output_dir / "cw_timestep_and_buffer.csv";
+			writeCsv(path, {"rate", "ratio", "start_time", "end_time", "dt_sim", "cw_buffer_size"}, rows);
+			addGeneratedFile(result, path);
+		}
+
+		result.summary_rows = {{"max_abs_prf_error", toString(max_prf_error)}, {"max_abs_skip_error", toString(max_skip_error)}};
+		writeSummaryFile(result);
+		writeSourceMappingFile(result);
+		writeReadmeFile(result);
+		writeManifestFile(result, options);
+		return result;
+	}
+
+	SuiteResult runSuite(const CliOptions& options)
+	{
+		if (options.suite == "resampler")
+		{
+			return runResamplerSuite(options);
+		}
+		if (options.suite == "render")
+		{
+			return runRenderSuite(options);
+		}
+		if (options.suite == "pipeline")
+		{
+			return runPipelineSuite(options);
+		}
+		if (options.suite == "clocking")
+		{
+			return runClockingSuite(options);
+		}
+		throw std::runtime_error("Unknown suite: " + options.suite);
+	}
+
+	int runChildSuite(const CliOptions& parent_options, const std::string& suite, const unsigned ratio,
+					  const unsigned filter_length, const fs::path& output_dir)
+	{
+		std::vector<std::string> args = {"suite",
+										 suite,
+										 "--ratio",
+										 std::to_string(ratio),
+										 "--filter-length",
+										 std::to_string(filter_length),
+										 "--seed",
+										 std::to_string(parent_options.seed),
+										 "--output-dir",
+										 output_dir.string()};
+
+		std::ostringstream command;
+		command << shellQuote(parent_options.executable_path.string());
+		for (const auto& arg : args)
+		{
+			command << ' ' << shellQuote(arg);
+		}
+		return std::system(command.str().c_str());
+	}
+
+	int runAll(const CliOptions& options)
+	{
+		const std::array<std::string_view, 4> suites = {"resampler", "render", "pipeline", "clocking"};
+		for (const auto suite : suites)
+		{
+			const fs::path child_output =
+				options.output_dir / ("ratio_" + std::to_string(options.ratio)) / ("filter_" + std::to_string(options.filter_length)) /
+				std::string(suite);
+			const int status = runChildSuite(options, std::string(suite), options.ratio, options.filter_length, child_output);
+			if (status != 0)
+			{
+				return status;
+			}
+		}
+		return 0;
+	}
+
+	int runMatrix(const CliOptions& options)
+	{
+		for (const unsigned ratio : options.ratios)
+		{
+			for (const unsigned filter_length : options.filter_lengths)
+			{
+				const std::array<std::string_view, 4> suites = {"resampler", "render", "pipeline", "clocking"};
+				for (const auto suite : suites)
+				{
+					const fs::path child_output =
+						options.output_dir / ("ratio_" + std::to_string(ratio)) / ("filter_" + std::to_string(filter_length)) /
+						std::string(suite);
+					const int status = runChildSuite(options, std::string(suite), ratio, filter_length, child_output);
+					if (status != 0)
+					{
+						return status;
+					}
+				}
+			}
+		}
+		return 0;
+	}
+
+	std::string usage()
+	{
+		return "Usage:\n"
+			   "  oversampling_audit all [--ratio N] [--filter-length N] [--seed N] [--output-dir PATH]\n"
+			   "  oversampling_audit suite <resampler|render|pipeline|clocking> [--ratio N] [--filter-length N] "
+			   "[--seed N] [--output-dir PATH]\n"
+			   "  oversampling_audit matrix [--ratios csv] [--filter-lengths csv] [--seed N] [--output-dir PATH]\n";
+	}
+}
+
+int main(const int argc, char* argv[])
+{
+	try
+	{
+		logging::logger.setLevel(logging::Level::WARNING);
+		const CliOptions options = parseCli(argc, argv);
+
+		switch (options.command)
+		{
+		case CommandType::Suite:
+			runSuite(options);
+			return 0;
+		case CommandType::All:
+			return runAll(options);
+		case CommandType::Matrix:
+			return runMatrix(options);
+		}
+	}
+	catch (const std::exception& error)
+	{
+		std::cerr << error.what() << '\n' << usage();
+		return 1;
+	}
+
+	return 1;
+}

--- a/verification/oversampling/src/processing/finalizer_pipeline.cpp
+++ b/verification/oversampling/src/processing/finalizer_pipeline.cpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Copyright (c) 2026-present FERS Contributors (see AUTHORS.md).
+//
+// Upstream reference:
+//   packages/libfers/src/processing/finalizer_pipeline.cpp
+
+#include "finalizer_pipeline.h"
+
+#include "core/parameters.h"
+#include "processing/signal_processor.h"
+#include "signal/dsp_filters.h"
+
+namespace processing::pipeline
+{
+	RealType applyDownsamplingAndQuantization(std::vector<ComplexType>& buffer)
+	{
+		if (params::oversampleRatio() > 1)
+		{
+			buffer = std::move(fers_signal::downsample(buffer));
+		}
+		return quantizeAndScaleWindow(buffer);
+	}
+}
+

--- a/verification/oversampling/src/processing/finalizer_pipeline.h
+++ b/verification/oversampling/src/processing/finalizer_pipeline.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Copyright (c) 2026-present FERS Contributors (see AUTHORS.md).
+//
+// Upstream reference:
+//   packages/libfers/src/processing/finalizer_pipeline.h
+//
+// Local simplification:
+//   only the oversampling-specific downsampling + quantization step is required here.
+
+#pragma once
+
+#include <vector>
+
+#include "core/config.h"
+
+namespace processing::pipeline
+{
+	RealType applyDownsamplingAndQuantization(std::vector<ComplexType>& buffer);
+}
+

--- a/verification/oversampling/src/processing/signal_processor.cpp
+++ b/verification/oversampling/src/processing/signal_processor.cpp
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Copyright (c) 2006-2008 Marc Brooker and Michael Inggs
+// Copyright (c) 2008-present FERS Contributors (see AUTHORS.md).
+//
+// Upstream reference:
+//   packages/libfers/src/processing/signal_processor.cpp
+//
+// Local simplification:
+//   thermal noise uses std::normal_distribution directly instead of noise::WgnGenerator.
+
+#include "signal_processor.h"
+
+#include <algorithm>
+#include <cmath>
+#include <queue>
+#include <tuple>
+#include <vector>
+
+#include "core/parameters.h"
+#include "serial/response.h"
+
+namespace
+{
+	void adcSimulate(std::span<ComplexType> data, const unsigned bits, const RealType fullscale) noexcept
+	{
+		const RealType levels = std::pow(2, bits - 1);
+
+		for (auto& sample : data)
+		{
+			auto [i, q] = std::tuple{std::clamp(std::floor(levels * sample.real() / fullscale) / levels, -1.0, 1.0),
+									 std::clamp(std::floor(levels * sample.imag() / fullscale) / levels, -1.0, 1.0)};
+			sample = ComplexType(i, q);
+		}
+	}
+
+	void processResponse(const serial::Response* resp, std::vector<ComplexType>& localWindow, const RealType rate,
+						 const RealType start, const RealType fracDelay, const unsigned localWindowSize)
+	{
+		unsigned psize;
+		RealType prate;
+		const auto array = resp->renderBinary(prate, psize, fracDelay);
+		int start_sample = static_cast<int>(std::round(rate * (resp->startTime() - start)));
+		const unsigned roffset = start_sample < 0 ? static_cast<unsigned>(-start_sample) : 0u;
+		start_sample = std::max(start_sample, 0);
+
+		for (unsigned i = roffset; i < psize && i + static_cast<unsigned>(start_sample) < localWindowSize; ++i)
+		{
+			localWindow[i + static_cast<unsigned>(start_sample)] += array[i];
+		}
+	}
+}
+
+namespace processing
+{
+	void renderWindow(std::vector<ComplexType>& window, const RealType length, const RealType start,
+					  const RealType fracDelay, const std::span<const std::unique_ptr<serial::Response>> responses)
+	{
+		const RealType end = start + length;
+		std::queue<serial::Response*> work_list;
+
+		for (const auto& response : responses)
+		{
+			if (response->startTime() <= end && response->endTime() >= start)
+			{
+				work_list.push(response.get());
+			}
+		}
+
+		const RealType rate = params::rate() * params::oversampleRatio();
+		const auto local_window_size = static_cast<unsigned>(std::ceil(length * rate));
+
+		std::vector local_window(local_window_size, ComplexType{});
+
+		while (!work_list.empty())
+		{
+			const auto* resp = work_list.front();
+			work_list.pop();
+			processResponse(resp, local_window, rate, start, fracDelay, local_window_size);
+		}
+
+		for (unsigned i = 0; i < local_window_size; ++i)
+		{
+			window[i] += local_window[i];
+		}
+	}
+
+	void applyThermalNoise(std::span<ComplexType> window, const RealType noiseTemperature, std::mt19937& rngEngine)
+	{
+		if (noiseTemperature == 0)
+		{
+			return;
+		}
+
+		const RealType b = params::rate() / (2.0 * params::oversampleRatio());
+		const RealType total_power = params::boltzmannK() * noiseTemperature * b;
+		const RealType per_channel_power = total_power / 2.0;
+		const RealType stddev = std::sqrt(per_channel_power);
+		std::normal_distribution<RealType> dist(0.0, stddev);
+
+		for (auto& sample : window)
+		{
+			sample += ComplexType(dist(rngEngine), dist(rngEngine));
+		}
+	}
+
+	RealType quantizeAndScaleWindow(std::span<ComplexType> window)
+	{
+		RealType max_value = 0;
+		for (const auto& sample : window)
+		{
+			const RealType real_abs = std::fabs(sample.real());
+			const RealType imag_abs = std::fabs(sample.imag());
+			max_value = std::max({max_value, real_abs, imag_abs});
+		}
+
+		if (const auto adc_bits = params::adcBits(); adc_bits > 0)
+		{
+			adcSimulate(window, adc_bits, max_value);
+		}
+		else if (max_value != 0)
+		{
+			for (auto& sample : window)
+			{
+				sample /= max_value;
+			}
+		}
+		return max_value;
+	}
+}
+

--- a/verification/oversampling/src/processing/signal_processor.h
+++ b/verification/oversampling/src/processing/signal_processor.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Copyright (c) 2006-2008 Marc Brooker and Michael Inggs
+// Copyright (c) 2008-present FERS Contributors (see AUTHORS.md).
+//
+// Upstream reference:
+//   packages/libfers/src/processing/signal_processor.h
+
+#pragma once
+
+#include <memory>
+#include <random>
+#include <span>
+#include <vector>
+
+#include "core/config.h"
+
+namespace serial
+{
+	class Response;
+}
+
+namespace processing
+{
+	void renderWindow(std::vector<ComplexType>& window, RealType length, RealType start, RealType fracDelay,
+					  std::span<const std::unique_ptr<serial::Response>> responses);
+
+	void applyThermalNoise(std::span<ComplexType> window, RealType noiseTemperature, std::mt19937& rngEngine);
+
+	RealType quantizeAndScaleWindow(std::span<ComplexType> window);
+}
+

--- a/verification/oversampling/src/serial/response.cpp
+++ b/verification/oversampling/src/serial/response.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Copyright (c) 2006-2008 Marc Brooker and Michael Inggs
+// Copyright (c) 2008-present FERS Contributors (see AUTHORS.md).
+//
+// Upstream reference:
+//   packages/libfers/src/serial/response.cpp
+
+#include "response.h"
+
+#include "signal/radar_signal.h"
+
+namespace serial
+{
+	void Response::addInterpPoint(const interp::InterpPoint& point) { _points.push_back(point); }
+
+	std::vector<ComplexType> Response::renderBinary(RealType& rate, unsigned& size, const RealType fracWinDelay) const
+	{
+		rate = _wave->getRate();
+		return _wave->render(_points, size, fracWinDelay);
+	}
+}
+

--- a/verification/oversampling/src/serial/response.h
+++ b/verification/oversampling/src/serial/response.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Copyright (c) 2006-2008 Marc Brooker and Michael Inggs
+// Copyright (c) 2008-present FERS Contributors (see AUTHORS.md).
+//
+// Upstream reference:
+//   packages/libfers/src/serial/response.h
+//
+// Local simplification:
+//   transmitter ownership is removed because the harness only needs render timing.
+
+#pragma once
+
+#include <vector>
+
+#include "core/config.h"
+#include "interpolation/interpolation_point.h"
+
+namespace fers_signal
+{
+	class RadarSignal;
+}
+
+namespace serial
+{
+	class Response
+	{
+	public:
+		explicit Response(const fers_signal::RadarSignal* wave) noexcept : _wave(wave) {}
+
+		[[nodiscard]] RealType startTime() const noexcept { return _points.empty() ? 0.0 : _points.front().time; }
+		[[nodiscard]] RealType endTime() const noexcept { return _points.empty() ? 0.0 : _points.back().time; }
+		[[nodiscard]] RealType getLength() const noexcept { return endTime() - startTime(); }
+
+		void addInterpPoint(const interp::InterpPoint& point);
+		std::vector<ComplexType> renderBinary(RealType& rate, unsigned& size, RealType fracWinDelay) const;
+		[[nodiscard]] const std::vector<interp::InterpPoint>& points() const noexcept { return _points; }
+
+	private:
+		const fers_signal::RadarSignal* _wave;
+		std::vector<interp::InterpPoint> _points;
+	};
+}
+

--- a/verification/oversampling/src/signal/dsp_filters.cpp
+++ b/verification/oversampling/src/signal/dsp_filters.cpp
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Copyright (c) 2007-2008 Marc Brooker and Michael Inggs
+// Copyright (c) 2008-present FERS Contributors (see AUTHORS.md).
+//
+// Upstream reference:
+//   packages/libfers/src/signal/dsp_filters.cpp
+
+#include "dsp_filters.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <complex>
+#include <numeric>
+#include <ranges>
+#include <stdexcept>
+
+#include "core/parameters.h"
+
+constexpr RealType BLACKMAN_A0 = 0.42;
+constexpr RealType BLACKMAN_A1 = 0.5;
+constexpr RealType BLACKMAN_A2 = 0.08;
+
+namespace
+{
+	constexpr RealType sinc(const RealType x) noexcept { return x == 0 ? 1.0 : std::sin(x * PI) / (x * PI); }
+
+	std::vector<RealType> blackmanFir(const RealType cutoff, unsigned& filtLength) noexcept
+	{
+		filtLength = params::renderFilterLength() * 2;
+		std::vector<RealType> coeffs(filtLength);
+		const RealType n = filtLength / 2.0;
+		const RealType pi_n = PI / n;
+
+		std::ranges::for_each(coeffs,
+							  [cutoff, n, pi_n, i = 0u](RealType& coeff) mutable
+							  {
+								  const RealType sinc_val = sinc(cutoff * (i - n));
+								  const RealType window = BLACKMAN_A0 - BLACKMAN_A1 * std::cos(pi_n * i) +
+									  BLACKMAN_A2 * std::cos(2 * pi_n * i);
+								  coeff = sinc_val * window;
+								  ++i;
+							  });
+
+		return coeffs;
+	}
+}
+
+namespace fers_signal
+{
+	void upsample(const std::span<const ComplexType> in, const unsigned size, std::span<ComplexType> out)
+	{
+		const unsigned ratio = params::oversampleRatio();
+		unsigned filt_length;
+		const auto coeffs = blackmanFir(1 / static_cast<RealType>(ratio), filt_length);
+
+		std::vector tmp(static_cast<size_t>(size * ratio + filt_length), ComplexType{0.0, 0.0});
+
+		for (unsigned i = 0; i < size; ++i)
+		{
+			tmp[static_cast<size_t>(i * ratio)] = in[i];
+		}
+
+		const FirFilter filt(coeffs);
+		filt.filter(tmp);
+
+		const auto delay = filt_length / 2;
+		std::ranges::copy_n(tmp.begin() + delay, size * ratio, out.begin());
+	}
+
+	std::vector<ComplexType> downsample(std::span<const ComplexType> in)
+	{
+		if (in.empty())
+		{
+			throw std::invalid_argument("Input span is empty in Downsample");
+		}
+
+		const unsigned ratio = params::oversampleRatio();
+		unsigned filt_length = 0;
+		const auto coeffs = blackmanFir(1 / static_cast<RealType>(ratio), filt_length);
+
+		std::vector tmp(in.size() + filt_length, ComplexType{0, 0});
+		std::ranges::copy(in, tmp.begin());
+
+		const FirFilter filt(coeffs);
+		filt.filter(tmp);
+
+		const auto downsampled_size = in.size() / ratio;
+		std::vector<ComplexType> out(downsampled_size);
+		for (unsigned i = 0; i < downsampled_size; ++i)
+		{
+			out[i] = tmp[static_cast<size_t>(i * ratio + filt_length / 2)] / static_cast<RealType>(ratio);
+		}
+
+		return out;
+	}
+
+	IirFilter::IirFilter(const RealType* denCoeffs, const RealType* numCoeffs, const unsigned order) noexcept :
+		_a(denCoeffs, denCoeffs + order), _b(numCoeffs, numCoeffs + order), _w(order, 0.0), _order(order)
+	{
+	}
+
+	RealType IirFilter::filter(const RealType sample) noexcept
+	{
+		std::ranges::rotate(_w, _w.end() - 1);
+		_w[0] = sample;
+
+		for (unsigned j = 1; j < _order; ++j)
+		{
+			_w[0] -= _a[j] * _w[j];
+		}
+
+		return std::inner_product(_b.begin(), _b.end(), _w.begin(), 0.0);
+	}
+
+	void IirFilter::filter(std::span<RealType> samples) noexcept
+	{
+		for (auto& sample : samples)
+		{
+			std::ranges::rotate(_w, _w.end() - 1);
+			_w[0] = sample;
+
+			for (unsigned j = 1; j < _order; ++j)
+			{
+				_w[0] -= _a[j] * _w[j];
+			}
+
+			sample = std::inner_product(_b.begin(), _b.end(), _w.begin(), 0.0);
+		}
+	}
+
+	void FirFilter::filter(std::vector<ComplexType>& samples) const
+	{
+		std::vector line(_order, ComplexType{0.0, 0.0});
+
+		for (auto& sample : samples)
+		{
+			line[0] = sample;
+			ComplexType result{0.0, 0.0};
+
+			result = std::transform_reduce(line.begin(), line.end(), _filter.begin(), ComplexType{0.0, 0.0},
+										   std::plus<ComplexType>{},
+										   [](const ComplexType& x, const RealType coeff) { return x * coeff; });
+
+			sample = result;
+			std::ranges::rotate(std::views::reverse(line), line.rbegin() + 1);
+		}
+	}
+
+	DecadeUpsampler::DecadeUpsampler()
+	{
+		constexpr std::array den_coeffs = {1.0,
+										   -10.301102119865,
+										   48.5214567642597,
+										   -137.934509572412,
+										   262.914952985445,
+										   -352.788381841481,
+										   340.027874008585,
+										   -235.39260470286,
+										   114.698499845697,
+										   -37.4634653062448,
+										   7.38208765922137,
+										   -0.664807695826097};
+
+		constexpr std::array num_coeffs = {2.7301694322809e-06,	 -1.8508123430239e-05, 5.75739466753894e-05,
+										   -0.000104348734423658, 0.000111949190289715,  -4.9384188225528e-05,
+										   -4.9384188225522e-05,  0.00011194919028971,   -0.000104348734423656,
+										   5.75739466753884e-05,  -1.85081234302388e-05, 2.73016943228086e-06};
+
+		_filter = std::make_unique<IirFilter>(den_coeffs.data(), num_coeffs.data(), den_coeffs.size());
+	}
+
+	void DecadeUpsampler::upsample(const RealType sample, std::span<RealType> out) const
+	{
+		if (out.size() != 10)
+		{
+			throw std::invalid_argument("Output span must have a size of 10.");
+		}
+		out[0] = sample;
+		std::fill(out.begin() + 1, out.end(), 0);
+		_filter->filter(out);
+	}
+}
+

--- a/verification/oversampling/src/signal/dsp_filters.h
+++ b/verification/oversampling/src/signal/dsp_filters.h
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Copyright (c) 2007-2008 Marc Brooker and Michael Inggs
+// Copyright (c) 2008-present FERS Contributors (see AUTHORS.md).
+//
+// Upstream reference:
+//   packages/libfers/src/signal/dsp_filters.h
+
+#pragma once
+
+#include <memory>
+#include <span>
+#include <vector>
+
+#include "core/config.h"
+
+namespace fers_signal
+{
+	void upsample(std::span<const ComplexType> in, unsigned size, std::span<ComplexType> out);
+	std::vector<ComplexType> downsample(std::span<const ComplexType> in);
+
+	class DspFilter
+	{
+	public:
+		DspFilter() = default;
+		virtual ~DspFilter() = default;
+
+		virtual RealType filter(RealType sample) = 0;
+		virtual void filter(std::span<RealType> samples) = 0;
+
+		DspFilter(const DspFilter&) = delete;
+		DspFilter& operator=(const DspFilter&) = delete;
+		DspFilter(DspFilter&&) noexcept = default;
+		DspFilter& operator=(DspFilter&&) noexcept = default;
+	};
+
+	class IirFilter final : public DspFilter
+	{
+	public:
+		IirFilter(const RealType* denCoeffs, const RealType* numCoeffs, unsigned order) noexcept;
+		~IirFilter() override = default;
+
+		RealType filter(RealType sample) noexcept override;
+		void filter(std::span<RealType> samples) noexcept override;
+
+	private:
+		std::vector<RealType> _a;
+		std::vector<RealType> _b;
+		std::vector<RealType> _w;
+		unsigned _order{};
+	};
+
+	class FirFilter final : public DspFilter
+	{
+	public:
+		explicit FirFilter(std::span<const RealType> coeffs) :
+			_filter(coeffs.begin(), coeffs.end()), _w(coeffs.size()), _order(coeffs.size())
+		{
+		}
+
+		~FirFilter() override = default;
+
+		RealType filter(RealType) override { return 0; }
+		void filter(std::span<RealType>) noexcept override {}
+		void filter(std::vector<ComplexType>& samples) const;
+
+	private:
+		std::vector<RealType> _filter;
+		std::vector<RealType> _w;
+		unsigned _order{};
+	};
+
+	class DecadeUpsampler
+	{
+	public:
+		DecadeUpsampler();
+		~DecadeUpsampler() = default;
+
+		void upsample(RealType sample, std::span<RealType> out) const;
+
+		DecadeUpsampler(const DecadeUpsampler&) = delete;
+		DecadeUpsampler& operator=(const DecadeUpsampler&) = delete;
+		DecadeUpsampler(DecadeUpsampler&&) noexcept = default;
+		DecadeUpsampler& operator=(DecadeUpsampler&&) noexcept = default;
+
+	private:
+		std::unique_ptr<IirFilter> _filter;
+	};
+}
+

--- a/verification/oversampling/src/signal/radar_signal.cpp
+++ b/verification/oversampling/src/signal/radar_signal.cpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Copyright (c) 2006-2008 Marc Brooker and Michael Inggs
+// Copyright (c) 2008-present FERS Contributors (see AUTHORS.md).
+//
+// Upstream reference:
+//   packages/libfers/src/signal/radar_signal.cpp
+
+#include "radar_signal.h"
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <iterator>
+#include <stdexcept>
+#include <utility>
+
+#include "core/parameters.h"
+#include "dsp_filters.h"
+#include "interpolation/interpolation_filter.h"
+#include "interpolation/interpolation_point.h"
+
+namespace fers_signal
+{
+	std::vector<ComplexType> CwSignal::render(const std::vector<interp::InterpPoint>&, unsigned& size,
+											  const RealType) const
+	{
+		size = 0;
+		return {};
+	}
+
+	RadarSignal::RadarSignal(std::string name, const RealType power, const RealType carrierfreq, const RealType length,
+							 std::unique_ptr<Signal> signal) :
+		_name(std::move(name)), _power(power), _carrierfreq(carrierfreq), _length(length), _signal(std::move(signal))
+	{
+		if (!_signal)
+		{
+			throw std::runtime_error("Signal is empty");
+		}
+	}
+
+	std::vector<ComplexType> RadarSignal::render(const std::vector<interp::InterpPoint>& points, unsigned& size,
+												 const RealType fracWinDelay) const
+	{
+		auto data = _signal->render(points, size, fracWinDelay);
+		const RealType scale = std::sqrt(_power);
+
+		std::ranges::for_each(data, [scale](auto& value) { value *= scale; });
+		return data;
+	}
+
+	void Signal::clear() noexcept
+	{
+		_size = 0;
+		_rate = 0;
+	}
+
+	void Signal::load(std::span<const ComplexType> inData, const unsigned samples, const RealType sampleRate)
+	{
+		clear();
+		const unsigned ratio = params::oversampleRatio();
+		_data.resize(static_cast<size_t>(samples * ratio));
+		_size = samples * ratio;
+		_rate = sampleRate * ratio;
+
+		if (ratio == 1)
+		{
+			std::ranges::copy(inData, _data.begin());
+		}
+		else
+		{
+			upsample(inData, samples, _data);
+		}
+	}
+
+	std::vector<ComplexType> Signal::render(const std::vector<interp::InterpPoint>& points, unsigned& size,
+											const double fracWinDelay) const
+	{
+		auto out = std::vector<ComplexType>(_size);
+		size = _size;
+
+		const RealType timestep = 1.0 / _rate;
+		const int filt_length = static_cast<int>(params::renderFilterLength());
+		const auto& interp = interp::InterpFilter::getInstance();
+
+		auto iter = points.begin();
+		auto next = points.size() > 1 ? std::next(iter) : iter;
+		const RealType idelay = std::round(_rate * iter->delay);
+		RealType sample_time = iter->time;
+
+		for (int i = 0; i < static_cast<int>(_size); ++i)
+		{
+			if (sample_time > next->time && next != iter)
+			{
+				iter = next;
+				if (std::next(next) != points.end())
+				{
+					++next;
+				}
+			}
+
+			auto [amplitude, phase, fdelay, i_sample_unwrap] =
+				calculateWeightsAndDelays(iter, next, sample_time, idelay, fracWinDelay);
+			const auto& filt = interp.getFilter(fdelay);
+			ComplexType accum = performConvolution(i, filt.data(), filt_length, amplitude, i_sample_unwrap);
+			out[static_cast<size_t>(i)] = std::exp(ComplexType(0.0, 1.0) * phase) * accum;
+
+			sample_time += timestep;
+		}
+
+		return out;
+	}
+
+	constexpr std::tuple<RealType, RealType, RealType, int>
+	Signal::calculateWeightsAndDelays(const std::vector<interp::InterpPoint>::const_iterator iter,
+									  const std::vector<interp::InterpPoint>::const_iterator next,
+									  const RealType sampleTime, const RealType idelay,
+									  const RealType fracWinDelay) const noexcept
+	{
+		const RealType bw = iter < next ? (sampleTime - iter->time) / (next->time - iter->time) : 0.0;
+
+		const RealType amplitude = std::lerp(std::sqrt(iter->power), std::sqrt(next->power), bw);
+		const RealType phase = std::lerp(iter->phase, next->phase, bw);
+		RealType fdelay = -(std::lerp(iter->delay, next->delay, bw) * _rate - idelay + fracWinDelay);
+
+		const int i_sample_unwrap = static_cast<int>(std::floor(fdelay));
+		fdelay -= i_sample_unwrap;
+
+		return {amplitude, phase, fdelay, i_sample_unwrap};
+	}
+
+	ComplexType Signal::performConvolution(const int i, const RealType* filt, const int filtLength,
+										   const RealType amplitude, const int iSampleUnwrap) const noexcept
+	{
+		const int start = std::max(-filtLength / 2, -i);
+		const int end = std::min(filtLength / 2, static_cast<int>(_size) - i);
+
+		ComplexType accum(0.0, 0.0);
+
+		for (int j = start; j < end; ++j)
+		{
+			if (const unsigned sample_idx = static_cast<unsigned>(i + j + iSampleUnwrap);
+				sample_idx < _size && j + filtLength / 2 < filtLength)
+			{
+				accum += amplitude * _data[sample_idx] * filt[j + filtLength / 2];
+			}
+		}
+
+		return accum;
+	}
+}
+

--- a/verification/oversampling/src/signal/radar_signal.h
+++ b/verification/oversampling/src/signal/radar_signal.h
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Copyright (c) 2006-2008 Marc Brooker and Michael Inggs
+// Copyright (c) 2008-present FERS Contributors (see AUTHORS.md).
+//
+// Upstream reference:
+//   packages/libfers/src/signal/radar_signal.h
+//
+// Local simplification:
+//   SimId support is removed because the isolation harness only audits signal behavior.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "core/config.h"
+
+namespace interp
+{
+	struct InterpPoint;
+}
+
+namespace fers_signal
+{
+	class Signal
+	{
+	public:
+		virtual ~Signal() = default;
+		Signal() = default;
+
+		Signal(const Signal&) = delete;
+		Signal& operator=(const Signal&) = delete;
+		Signal(Signal&&) = default;
+		Signal& operator=(Signal&&) = default;
+
+		void clear() noexcept;
+		void load(std::span<const ComplexType> inData, unsigned samples, RealType sampleRate);
+		[[nodiscard]] RealType getRate() const noexcept { return _rate; }
+
+		virtual std::vector<ComplexType> render(const std::vector<interp::InterpPoint>& points, unsigned& size,
+												double fracWinDelay) const;
+
+	private:
+		std::vector<ComplexType> _data;
+		unsigned _size{0};
+		RealType _rate{0};
+
+		[[nodiscard]] constexpr std::tuple<double, double, double, int>
+		calculateWeightsAndDelays(std::vector<interp::InterpPoint>::const_iterator iter,
+								  std::vector<interp::InterpPoint>::const_iterator next, double sampleTime, double idelay,
+								  double fracWinDelay) const noexcept;
+
+		ComplexType performConvolution(int i, const double* filt, int filtLength, double amplitude,
+									   int iSampleUnwrap) const noexcept;
+	};
+
+	class RadarSignal
+	{
+	public:
+		RadarSignal(std::string name, RealType power, RealType carrierfreq, RealType length, std::unique_ptr<Signal> signal);
+
+		~RadarSignal() = default;
+		RadarSignal(const RadarSignal&) = delete;
+		RadarSignal& operator=(const RadarSignal&) = delete;
+		RadarSignal(RadarSignal&&) noexcept = delete;
+		RadarSignal& operator=(RadarSignal&&) noexcept = delete;
+
+		void setFilename(const std::string& filename) noexcept { _filename = filename; }
+		[[nodiscard]] const std::optional<std::string>& getFilename() const noexcept { return _filename; }
+		[[nodiscard]] RealType getPower() const noexcept { return _power; }
+		[[nodiscard]] RealType getCarrier() const noexcept { return _carrierfreq; }
+		[[nodiscard]] const std::string& getName() const noexcept { return _name; }
+		[[nodiscard]] RealType getRate() const noexcept { return _signal->getRate(); }
+		[[nodiscard]] RealType getLength() const noexcept { return _length; }
+		[[nodiscard]] const Signal* getSignal() const noexcept { return _signal.get(); }
+
+		std::vector<ComplexType> render(const std::vector<interp::InterpPoint>& points, unsigned& size,
+										RealType fracWinDelay) const;
+
+	private:
+		std::string _name;
+		RealType _power;
+		RealType _carrierfreq;
+		RealType _length;
+		std::unique_ptr<Signal> _signal;
+		std::optional<std::string> _filename;
+	};
+
+	class CwSignal final : public Signal
+	{
+	public:
+		CwSignal() = default;
+		~CwSignal() override = default;
+
+		std::vector<ComplexType> render(const std::vector<interp::InterpPoint>& points, unsigned& size,
+										RealType fracWinDelay) const override;
+	};
+}
+


### PR DESCRIPTION
This pull request addresses code quality and build performance by completely eliminating compiler warnings across the `libfers` core, optimizing the CMake build configuration, and upgrading build diagnostic tools.

### Key Changes

**1. Zero-Warning Codebase**
*   **Warning Elimination:** Addressed and resolved 1,752 raw compiler warnings, bringing the total warning count down to 0.
*   **Type Safety & Conversions:** Fixed implicit conversions, sign conversions (`-Wsign-conversion`), and float/double promotions (`-Wdouble-promotion`) across the math, noise, and signal processing modules by strictly enforcing type boundaries and utilizing explicit casting (`std::size_t`, `unsigned`, `RealType`).
*   **Shadowing & Initialization:** Resolved `-Wshadow` warnings by renaming conflicting constructor parameters (e.g., in `Vec3` and `SVec3`). Addressed `-Wmissing-field-initializers` by explicitly initializing struct fields (e.g., `RenderingJob`).
*   **Bounds Checking:** Added overflow checks utilizing `std::numeric_limits` when casting between signed, unsigned, and `std::size_t` types, preventing silent integer overflows.

**2. Build System Optimizations**
*   **Ninja Generator:** Updated `CMakePresets.json` and documentation to default to the Ninja build system rather than Unix Makefiles, significantly reducing build times.
*   **OBJECT Library Target:** Refactored `packages/libfers/CMakeLists.txt` to compile source files exactly once into an `OBJECT` library (`fers_objects`). Both the static (`fers_static`) and shared (`fers_shared`) targets now consume these objects, halving the core compilation workload.

**3. Test Suite Expansion**
*   **Validation Hardening:** Added tests to ensure the system correctly rejects malformed CSV waveform headers and invalid sample counts (fractional/negative).
*   **Parser & CLI Tests:** Added explicit test cases for edge-case boundary parsing in `xml_parser_utils` (e.g., out-of-range unsigned parameters) and added validation to the CLI argument parser to explicitly reject negative thread counts.

**4. Diagnostic Tooling Enhancements**
*   **Log Analysis:** Expanded the `scripts/summarize_build_log.py` utility to capture and export per-file diagnostic details (`warning_details_by_file`, `error_details_by_file`, `note_details_by_file`). This provides much finer granularity for tracking and preventing future compiler warnings in CI.