### PR TITLE
refactor: restore strict clang-tidy, improve test output, and expose target RCS controls

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -276,17 +276,11 @@ SystemHeaders: false
 
 CheckOptions:
     # ── readability-function-cognitive-complexity ──────────────────────────────
-    # Default is 25 — every radar/DSP function trips it. 50 is the right ceiling
-    # for a simulation codebase. Functions that exceed it are candidates for
-    # decomposition, not blanket suppression.
-    readability-function-cognitive-complexity.Threshold: 50
+    readability-function-cognitive-complexity.Threshold: 25
     readability-function-cognitive-complexity.DescribeBasicIncrements: true
     readability-function-cognitive-complexity.IgnoreMacros: false
 
     # ── readability-function-size ─────────────────────────────────────────────
-    # 150 lines is firm. Signal-processing kernels approach this naturally; the
-    # limit prevents gradual bloat. NestingThreshold: 6 catches deeply nested
-    # state machines that are better modelled as tables or sub-functions.
     readability-function-size.LineThreshold: 150
     readability-function-size.StatementThreshold: 150
     readability-function-size.BranchThreshold: 20

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "coverage:cpp": "bash scripts/run_tests_gen_coverage.sh",
         "coverage:rust": "cargo tarpaulin --package fers-ui --out Html",
         "version:check": "python3 scripts/verify_versions.py",
-        "clangtidy:run": "run-clang-tidy -p build/debug/ -export-fixes fixes.yaml",
+        "clangtidy:run": "run-clang-tidy -p build/coverage/ -export-fixes fixes.yaml",
         "licenses:js": "bunx generate-license-file",
         "licenses:rust": "cargo about generate --manifest-path packages/fers-ui/src-tauri/Cargo.toml about.hbs -o THIRD_PARTY_LICENSES/rust-licenses.html"
     },

--- a/packages/fers-cli/src/arg_parser.cpp
+++ b/packages/fers-cli/src/arg_parser.cpp
@@ -257,7 +257,7 @@ namespace
 	 */
 	std::expected<void, std::string> handleLogFile(const std::string& arg, core::Config& config) noexcept
 	{
-		std::string log_file_path = arg.substr(11);
+		std::string const log_file_path = arg.substr(11);
 		if (isValidLogFileExtension(log_file_path))
 		{
 			config.log_file = log_file_path;

--- a/packages/fers-cli/src/arg_parser.cpp
+++ b/packages/fers-cli/src/arg_parser.cpp
@@ -198,6 +198,33 @@ namespace
 		return {};
 	}
 
+	using ConfigValueHandler = std::expected<void, std::string> (*)(const std::string&, core::Config&) noexcept;
+
+	std::optional<ConfigValueHandler> valueOptionHandler(const std::string& arg) noexcept
+	{
+		if (arg == "--vita49")
+		{
+			return handleVita49Endpoint;
+		}
+		if (arg == "--vita49-fullscale")
+		{
+			return handleVita49Fullscale;
+		}
+		if (arg == "--vita49-epoch")
+		{
+			return handleVita49Epoch;
+		}
+		if (arg == "--vita49-max-udp-payload")
+		{
+			return handleVita49MaxUdpPayload;
+		}
+		if (arg == "--vita49-queue-depth")
+		{
+			return handleVita49QueueDepth;
+		}
+		return std::nullopt;
+	}
+
 	std::expected<void, std::string> validateVita49Options(const core::Config& config) noexcept
 	{
 		if (!config.vita49_enabled)
@@ -449,66 +476,14 @@ Make sure the script file follows the correct format to avoid errors.
 				return std::string{argv[i]};
 			};
 
-			if (arg == "--vita49")
+			if (const auto handler = valueOptionHandler(arg))
 			{
-				const auto value = require_value("--vita49");
+				const auto value = require_value(arg);
 				if (!value)
 				{
 					return std::unexpected(value.error());
 				}
-				if (const auto result = handleVita49Endpoint(*value, config); !result)
-				{
-					return std::unexpected(result.error());
-				}
-				continue;
-			}
-			if (arg == "--vita49-fullscale")
-			{
-				const auto value = require_value("--vita49-fullscale");
-				if (!value)
-				{
-					return std::unexpected(value.error());
-				}
-				if (const auto result = handleVita49Fullscale(*value, config); !result)
-				{
-					return std::unexpected(result.error());
-				}
-				continue;
-			}
-			if (arg == "--vita49-epoch")
-			{
-				const auto value = require_value("--vita49-epoch");
-				if (!value)
-				{
-					return std::unexpected(value.error());
-				}
-				if (const auto result = handleVita49Epoch(*value, config); !result)
-				{
-					return std::unexpected(result.error());
-				}
-				continue;
-			}
-			if (arg == "--vita49-max-udp-payload")
-			{
-				const auto value = require_value("--vita49-max-udp-payload");
-				if (!value)
-				{
-					return std::unexpected(value.error());
-				}
-				if (const auto result = handleVita49MaxUdpPayload(*value, config); !result)
-				{
-					return std::unexpected(result.error());
-				}
-				continue;
-			}
-			if (arg == "--vita49-queue-depth")
-			{
-				const auto value = require_value("--vita49-queue-depth");
-				if (!value)
-				{
-					return std::unexpected(value.error());
-				}
-				if (const auto result = handleVita49QueueDepth(*value, config); !result)
+				if (const auto result = (*handler)(*value, config); !result)
 				{
 					return std::unexpected(result.error());
 				}

--- a/packages/fers-cli/src/cli_paths.cpp
+++ b/packages/fers-cli/src/cli_paths.cpp
@@ -28,7 +28,7 @@ namespace core
 	{
 		if (kml_file && !kml_file->empty())
 		{
-			const std::filesystem::path provided_kml_path(*kml_file);
+			std::filesystem::path provided_kml_path(*kml_file);
 			if (provided_kml_path.has_parent_path() || provided_kml_path.is_absolute())
 			{
 				return provided_kml_path;

--- a/packages/fers-cli/src/cli_runner.cpp
+++ b/packages/fers-cli/src/cli_runner.cpp
@@ -47,6 +47,148 @@ namespace
 		const std::string message = std::format(fmt, std::forward<Args>(args)...);
 		fers_log(level, message.c_str());
 	}
+
+	class ContextHandle
+	{
+	public:
+		explicit ContextHandle(fers_context_t* context) noexcept : _context(context) {}
+		ContextHandle(const ContextHandle&) = delete;
+		ContextHandle& operator=(const ContextHandle&) = delete;
+		ContextHandle(ContextHandle&&) = delete;
+		ContextHandle& operator=(ContextHandle&&) = delete;
+		~ContextHandle()
+		{
+			if (_context != nullptr)
+			{
+				fers_context_destroy(_context);
+			}
+		}
+
+		[[nodiscard]] fers_context_t* get() const noexcept { return _context; }
+
+	private:
+		fers_context_t* _context;
+	};
+
+	bool isParseExit(const std::string& error)
+	{
+		return error == "Help requested." || error == "Version requested." || error == "No arguments provided.";
+	}
+
+	int logApiFailure(const fers_log_level_t level, const char* message, const int result)
+	{
+		char* err = fers_get_last_error_message();
+		log(level, "{}: {}", message, (err != nullptr) ? err : "Unknown error");
+		fers_free_string(err);
+		return result;
+	}
+
+	int configureLogging(const core::Config& config)
+	{
+		const char* log_file_ptr = config.log_file ? config.log_file->c_str() : nullptr;
+		if (fers_configure_logging(config.log_level, log_file_ptr) == 0)
+		{
+			return 0;
+		}
+
+		char* err = fers_get_last_error_message();
+		std::cerr << "[ERROR] Failed to configure logging: " << ((err != nullptr) ? err : "Unknown error") << '\n';
+		fers_free_string(err);
+		return 1;
+	}
+
+	int loadScenario(fers_context_t* context, const core::Config& config)
+	{
+		log(FERS_LOG_INFO, "Loading scenario from '{}'...", config.script_file);
+		if (fers_load_scenario_from_xml_file(context, config.script_file.c_str(), config.validate ? 1 : 0) == 0)
+		{
+			return 0;
+		}
+		return logApiFailure(FERS_LOG_FATAL, "Failed to load scenario", 1);
+	}
+
+	int configureVita49Output(fers_context_t* context, const core::Config& config)
+	{
+		if (!config.vita49_enabled)
+		{
+			return 0;
+		}
+		if (!config.vita49_fullscale.has_value())
+		{
+			log(FERS_LOG_FATAL, "Failed to configure VITA49 fullscale: missing required fullscale.");
+			return 1;
+		}
+		if (fers_enable_vita49_udp_output(context, config.vita49_host.c_str(), config.vita49_port) != 0)
+		{
+			return logApiFailure(FERS_LOG_FATAL, "Failed to configure VITA49 endpoint", 1);
+		}
+		if (fers_set_vita49_fullscale(context, config.vita49_fullscale.value_or(0.0)) != 0)
+		{
+			return logApiFailure(FERS_LOG_FATAL, "Failed to configure VITA49 fullscale", 1);
+		}
+		if (config.vita49_epoch_unix_nanoseconds.has_value() &&
+			fers_set_vita49_epoch_unix_nanoseconds(context, *config.vita49_epoch_unix_nanoseconds) != 0)
+		{
+			return logApiFailure(FERS_LOG_FATAL, "Failed to configure VITA49 epoch", 1);
+		}
+		if (config.vita49_max_udp_payload.has_value() &&
+			fers_set_vita49_max_udp_payload(context, *config.vita49_max_udp_payload) != 0)
+		{
+			return logApiFailure(FERS_LOG_FATAL, "Failed to configure VITA49 max UDP payload", 1);
+		}
+		if (config.vita49_queue_depth.has_value() &&
+			fers_set_vita49_queue_depth(context, *config.vita49_queue_depth) != 0)
+		{
+			return logApiFailure(FERS_LOG_FATAL, "Failed to configure VITA49 queue depth", 1);
+		}
+		return 0;
+	}
+
+	int setOutputDirectory(fers_context_t* context, const std::filesystem::path& final_out_dir)
+	{
+		if (fers_set_output_directory(context, final_out_dir.string().c_str()) == 0)
+		{
+			return 0;
+		}
+		return logApiFailure(FERS_LOG_FATAL, "Failed to set output directory", 1);
+	}
+
+	int generateKml(fers_context_t* context, const core::Config& config, const std::filesystem::path& final_out_dir)
+	{
+		const std::filesystem::path kml_output_path =
+			core::resolveKmlOutputPath(config.script_file, final_out_dir, config.kml_file);
+		const std::string kml_output_file = kml_output_path.string();
+
+		log(FERS_LOG_INFO, "Generating KML file for scenario: {}", kml_output_file);
+		if (fers_generate_kml(context, kml_output_file.c_str()) == 0)
+		{
+			log(FERS_LOG_INFO, "KML file generated successfully: {}", kml_output_file);
+			return 0;
+		}
+		return logApiFailure(FERS_LOG_FATAL, "Failed to generate KML file", 1);
+	}
+
+	void configureThreadCount(const core::Config& config)
+	{
+		if (fers_set_thread_count(config.num_threads) == 0)
+		{
+			return;
+		}
+		char* err = fers_get_last_error_message();
+		log(FERS_LOG_ERROR, "Failed to set number of threads: {}", (err != nullptr) ? err : "Unknown error");
+		fers_free_string(err);
+	}
+
+	int runSimulation(fers_context_t* context)
+	{
+		log(FERS_LOG_INFO, "Starting simulation...");
+		if (fers_run_simulation(context, nullptr, nullptr) != 0)
+		{
+			return logApiFailure(FERS_LOG_FATAL, "Simulation run failed", 1);
+		}
+		log(FERS_LOG_INFO, "Simulation completed successfully.");
+		return 0;
+	}
 }
 
 namespace core
@@ -56,8 +198,7 @@ namespace core
 		const auto config_result = parseArguments(argc, argv);
 		if (!config_result)
 		{
-			if (config_result.error() != "Help requested." && config_result.error() != "Version requested." &&
-				config_result.error() != "No arguments provided.")
+			if (!isParseExit(config_result.error()))
 			{
 				std::cerr << "[ERROR] Argument parsing error: " << config_result.error() << '\n';
 				return 1;
@@ -67,12 +208,8 @@ namespace core
 
 		const auto& config = config_result.value();
 
-		const char* log_file_ptr = config.log_file ? config.log_file->c_str() : nullptr;
-		if (fers_configure_logging(config.log_level, log_file_ptr) != 0)
+		if (configureLogging(config) != 0)
 		{
-			char* err = fers_get_last_error_message();
-			std::cerr << "[ERROR] Failed to configure logging: " << ((err != nullptr) ? err : "Unknown error") << '\n';
-			fers_free_string(err);
 			return 1;
 		}
 
@@ -85,132 +222,35 @@ namespace core
 
 		const std::filesystem::path final_out_dir = resolveOutputDir(config.script_file, config.output_dir);
 
-		fers_context_t* context = fers_context_create();
-		if (context == nullptr)
+		ContextHandle context(fers_context_create());
+		if (context.get() == nullptr)
 		{
 			log(FERS_LOG_FATAL, "Failed to create FERS simulation context.");
 			return 1;
 		}
 
-		log(FERS_LOG_INFO, "Loading scenario from '{}'...", config.script_file);
-		if (fers_load_scenario_from_xml_file(context, config.script_file.c_str(), config.validate ? 1 : 0) != 0)
+		if (loadScenario(context.get(), config) != 0)
 		{
-			char* err = fers_get_last_error_message();
-			log(FERS_LOG_FATAL, "Failed to load scenario: {}", (err != nullptr) ? err : "Unknown error");
-			fers_free_string(err);
-			fers_context_destroy(context);
 			return 1;
 		}
 
-		if (config.vita49_enabled)
+		if (configureVita49Output(context.get(), config) != 0)
 		{
-			if (!config.vita49_fullscale.has_value())
-			{
-				log(FERS_LOG_FATAL, "Failed to configure VITA49 fullscale: missing required fullscale.");
-				fers_context_destroy(context);
-				return 1;
-			}
-			if (fers_enable_vita49_udp_output(context, config.vita49_host.c_str(), config.vita49_port) != 0)
-			{
-				char* err = fers_get_last_error_message();
-				log(FERS_LOG_FATAL, "Failed to configure VITA49 endpoint: {}",
-					(err != nullptr) ? err : "Unknown error");
-				fers_free_string(err);
-				fers_context_destroy(context);
-				return 1;
-			}
-			if (fers_set_vita49_fullscale(context, config.vita49_fullscale.value_or(0.0)) != 0)
-			{
-				char* err = fers_get_last_error_message();
-				log(FERS_LOG_FATAL, "Failed to configure VITA49 fullscale: {}",
-					(err != nullptr) ? err : "Unknown error");
-				fers_free_string(err);
-				fers_context_destroy(context);
-				return 1;
-			}
-			if (config.vita49_epoch_unix_nanoseconds.has_value() &&
-				fers_set_vita49_epoch_unix_nanoseconds(context, *config.vita49_epoch_unix_nanoseconds) != 0)
-			{
-				char* err = fers_get_last_error_message();
-				log(FERS_LOG_FATAL, "Failed to configure VITA49 epoch: {}", (err != nullptr) ? err : "Unknown error");
-				fers_free_string(err);
-				fers_context_destroy(context);
-				return 1;
-			}
-			if (config.vita49_max_udp_payload.has_value() &&
-				fers_set_vita49_max_udp_payload(context, *config.vita49_max_udp_payload) != 0)
-			{
-				char* err = fers_get_last_error_message();
-				log(FERS_LOG_FATAL, "Failed to configure VITA49 max UDP payload: {}",
-					(err != nullptr) ? err : "Unknown error");
-				fers_free_string(err);
-				fers_context_destroy(context);
-				return 1;
-			}
-			if (config.vita49_queue_depth.has_value() &&
-				fers_set_vita49_queue_depth(context, *config.vita49_queue_depth) != 0)
-			{
-				char* err = fers_get_last_error_message();
-				log(FERS_LOG_FATAL, "Failed to configure VITA49 queue depth: {}",
-					(err != nullptr) ? err : "Unknown error");
-				fers_free_string(err);
-				fers_context_destroy(context);
-				return 1;
-			}
+			return 1;
 		}
 
-		if (fers_set_output_directory(context, final_out_dir.string().c_str()) != 0)
+		if (setOutputDirectory(context.get(), final_out_dir) != 0)
 		{
-			char* err = fers_get_last_error_message();
-			log(FERS_LOG_FATAL, "Failed to set output directory: {}", (err != nullptr) ? err : "Unknown error");
-			fers_free_string(err);
-			fers_context_destroy(context);
 			return 1;
 		}
 
 		if (config.generate_kml)
 		{
-			const std::filesystem::path kml_output_path =
-				resolveKmlOutputPath(config.script_file, final_out_dir, config.kml_file);
-			const std::string kml_output_file = kml_output_path.string();
-
-			log(FERS_LOG_INFO, "Generating KML file for scenario: {}", kml_output_file);
-			const int kml_result = fers_generate_kml(context, kml_output_file.c_str());
-			if (kml_result == 0)
-			{
-				log(FERS_LOG_INFO, "KML file generated successfully: {}", kml_output_file);
-			}
-			else
-			{
-				char* err = fers_get_last_error_message();
-				log(FERS_LOG_FATAL, "Failed to generate KML file: {}", (err != nullptr) ? err : "Unknown error");
-				fers_free_string(err);
-			}
-
-			fers_context_destroy(context);
-			return kml_result == 0 ? 0 : 1;
+			return generateKml(context.get(), config, final_out_dir);
 		}
 
-		if (fers_set_thread_count(config.num_threads) != 0)
-		{
-			char* err = fers_get_last_error_message();
-			log(FERS_LOG_ERROR, "Failed to set number of threads: {}", (err != nullptr) ? err : "Unknown error");
-			fers_free_string(err);
-		}
+		configureThreadCount(config);
 
-		log(FERS_LOG_INFO, "Starting simulation...");
-		if (fers_run_simulation(context, nullptr, nullptr) != 0)
-		{
-			char* err = fers_get_last_error_message();
-			log(FERS_LOG_FATAL, "Simulation run failed: {}", (err != nullptr) ? err : "Unknown error");
-			fers_free_string(err);
-			fers_context_destroy(context);
-			return 1;
-		}
-		log(FERS_LOG_INFO, "Simulation completed successfully.");
-
-		fers_context_destroy(context);
-
-		return 0;
+		return runSimulation(context.get());
 	}
 }

--- a/packages/fers-cli/src/cli_runner.cpp
+++ b/packages/fers-cli/src/cli_runner.cpp
@@ -96,7 +96,7 @@ namespace core
 		if (fers_load_scenario_from_xml_file(context, config.script_file.c_str(), config.validate ? 1 : 0) != 0)
 		{
 			char* err = fers_get_last_error_message();
-			log(FERS_LOG_FATAL, "Failed to load scenario: {}", err ? err : "Unknown error");
+			log(FERS_LOG_FATAL, "Failed to load scenario: {}", (err != nullptr) ? err : "Unknown error");
 			fers_free_string(err);
 			fers_context_destroy(context);
 			return 1;
@@ -113,7 +113,8 @@ namespace core
 			if (fers_enable_vita49_udp_output(context, config.vita49_host.c_str(), config.vita49_port) != 0)
 			{
 				char* err = fers_get_last_error_message();
-				log(FERS_LOG_FATAL, "Failed to configure VITA49 endpoint: {}", err ? err : "Unknown error");
+				log(FERS_LOG_FATAL, "Failed to configure VITA49 endpoint: {}",
+					(err != nullptr) ? err : "Unknown error");
 				fers_free_string(err);
 				fers_context_destroy(context);
 				return 1;
@@ -121,7 +122,8 @@ namespace core
 			if (fers_set_vita49_fullscale(context, config.vita49_fullscale.value_or(0.0)) != 0)
 			{
 				char* err = fers_get_last_error_message();
-				log(FERS_LOG_FATAL, "Failed to configure VITA49 fullscale: {}", err ? err : "Unknown error");
+				log(FERS_LOG_FATAL, "Failed to configure VITA49 fullscale: {}",
+					(err != nullptr) ? err : "Unknown error");
 				fers_free_string(err);
 				fers_context_destroy(context);
 				return 1;
@@ -130,7 +132,7 @@ namespace core
 				fers_set_vita49_epoch_unix_nanoseconds(context, *config.vita49_epoch_unix_nanoseconds) != 0)
 			{
 				char* err = fers_get_last_error_message();
-				log(FERS_LOG_FATAL, "Failed to configure VITA49 epoch: {}", err ? err : "Unknown error");
+				log(FERS_LOG_FATAL, "Failed to configure VITA49 epoch: {}", (err != nullptr) ? err : "Unknown error");
 				fers_free_string(err);
 				fers_context_destroy(context);
 				return 1;
@@ -139,7 +141,8 @@ namespace core
 				fers_set_vita49_max_udp_payload(context, *config.vita49_max_udp_payload) != 0)
 			{
 				char* err = fers_get_last_error_message();
-				log(FERS_LOG_FATAL, "Failed to configure VITA49 max UDP payload: {}", err ? err : "Unknown error");
+				log(FERS_LOG_FATAL, "Failed to configure VITA49 max UDP payload: {}",
+					(err != nullptr) ? err : "Unknown error");
 				fers_free_string(err);
 				fers_context_destroy(context);
 				return 1;
@@ -148,7 +151,8 @@ namespace core
 				fers_set_vita49_queue_depth(context, *config.vita49_queue_depth) != 0)
 			{
 				char* err = fers_get_last_error_message();
-				log(FERS_LOG_FATAL, "Failed to configure VITA49 queue depth: {}", err ? err : "Unknown error");
+				log(FERS_LOG_FATAL, "Failed to configure VITA49 queue depth: {}",
+					(err != nullptr) ? err : "Unknown error");
 				fers_free_string(err);
 				fers_context_destroy(context);
 				return 1;
@@ -158,7 +162,7 @@ namespace core
 		if (fers_set_output_directory(context, final_out_dir.string().c_str()) != 0)
 		{
 			char* err = fers_get_last_error_message();
-			log(FERS_LOG_FATAL, "Failed to set output directory: {}", err ? err : "Unknown error");
+			log(FERS_LOG_FATAL, "Failed to set output directory: {}", (err != nullptr) ? err : "Unknown error");
 			fers_free_string(err);
 			fers_context_destroy(context);
 			return 1;
@@ -179,7 +183,7 @@ namespace core
 			else
 			{
 				char* err = fers_get_last_error_message();
-				log(FERS_LOG_FATAL, "Failed to generate KML file: {}", err ? err : "Unknown error");
+				log(FERS_LOG_FATAL, "Failed to generate KML file: {}", (err != nullptr) ? err : "Unknown error");
 				fers_free_string(err);
 			}
 
@@ -190,7 +194,7 @@ namespace core
 		if (fers_set_thread_count(config.num_threads) != 0)
 		{
 			char* err = fers_get_last_error_message();
-			log(FERS_LOG_ERROR, "Failed to set number of threads: {}", err ? err : "Unknown error");
+			log(FERS_LOG_ERROR, "Failed to set number of threads: {}", (err != nullptr) ? err : "Unknown error");
 			fers_free_string(err);
 		}
 
@@ -198,7 +202,7 @@ namespace core
 		if (fers_run_simulation(context, nullptr, nullptr) != 0)
 		{
 			char* err = fers_get_last_error_message();
-			log(FERS_LOG_FATAL, "Simulation run failed: {}", err ? err : "Unknown error");
+			log(FERS_LOG_FATAL, "Simulation run failed: {}", (err != nullptr) ? err : "Unknown error");
 			fers_free_string(err);
 			fers_context_destroy(context);
 			return 1;

--- a/packages/fers-cli/src/cli_runner.cpp
+++ b/packages/fers-cli/src/cli_runner.cpp
@@ -104,6 +104,12 @@ namespace core
 
 		if (config.vita49_enabled)
 		{
+			if (!config.vita49_fullscale.has_value())
+			{
+				log(FERS_LOG_FATAL, "Failed to configure VITA49 fullscale: missing required fullscale.");
+				fers_context_destroy(context);
+				return 1;
+			}
 			if (fers_enable_vita49_udp_output(context, config.vita49_host.c_str(), config.vita49_port) != 0)
 			{
 				char* err = fers_get_last_error_message();
@@ -112,7 +118,7 @@ namespace core
 				fers_context_destroy(context);
 				return 1;
 			}
-			if (fers_set_vita49_fullscale(context, *config.vita49_fullscale) != 0)
+			if (fers_set_vita49_fullscale(context, config.vita49_fullscale.value_or(0.0)) != 0)
 			{
 				char* err = fers_get_last_error_message();
 				log(FERS_LOG_FATAL, "Failed to configure VITA49 fullscale: {}", err ? err : "Unknown error");

--- a/packages/fers-cli/tests/test_arg_parser.cpp
+++ b/packages/fers-cli/tests/test_arg_parser.cpp
@@ -35,7 +35,7 @@ namespace
 	template <typename Fn>
 	std::string captureStdout(Fn&& fn)
 	{
-		std::ostringstream buffer;
+		std::ostringstream const buffer;
 		auto* const original = std::cout.rdbuf(buffer.rdbuf());
 		fn();
 		std::cout.rdbuf(original);

--- a/packages/fers-cli/tests/test_arg_parser.cpp
+++ b/packages/fers-cli/tests/test_arg_parser.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "arg_parser.h"
@@ -37,7 +38,7 @@ namespace
 	{
 		std::ostringstream const buffer;
 		auto* const original = std::cout.rdbuf(buffer.rdbuf());
-		fn();
+		std::invoke(std::forward<Fn>(fn));
 		std::cout.rdbuf(original);
 		return buffer.str();
 	}

--- a/packages/fers-cli/tests/test_arg_parser.cpp
+++ b/packages/fers-cli/tests/test_arg_parser.cpp
@@ -42,6 +42,26 @@ namespace
 		std::cout.rdbuf(original);
 		return buffer.str();
 	}
+
+	void requireRecognizedOptions(const core::Config& config, const unsigned requested_threads)
+	{
+		CHECK(config.script_file == "scenario.fersxml");
+		CHECK(config.log_level == FERS_LOG_DEBUG);
+		CHECK(config.log_file == std::optional<std::string>{"runner.log"});
+		CHECK(config.num_threads == requested_threads);
+		CHECK_FALSE(config.validate);
+		CHECK(config.generate_kml);
+		CHECK(config.kml_file == std::optional<std::string>{"preview.kml"});
+		CHECK(config.output_dir == std::optional<std::string>{"results"});
+		CHECK(config.vita49_enabled);
+		CHECK(config.vita49_host == "localhost");
+		CHECK(config.vita49_port == 4991);
+		REQUIRE(config.vita49_fullscale.has_value());
+		CHECK(config.vita49_fullscale.value_or(0.0) == 2.5);
+		CHECK(config.vita49_epoch_unix_nanoseconds == std::optional<std::uint64_t>{1700000000123456789ULL});
+		CHECK(config.vita49_max_udp_payload == std::optional<std::uint16_t>{900});
+		CHECK(config.vita49_queue_depth == std::optional<std::uint32_t>{17});
+	}
 }
 
 TEST_CASE("parseArguments accepts a script file and preserves defaults", "[fers-cli][arg-parser]")
@@ -79,22 +99,7 @@ TEST_CASE("parseArguments applies recognized options", "[fers-cli][arg-parser]")
 		 "1700000000123456789", "--vita49-max-udp-payload", "900", "--vita49-queue-depth", "17"});
 
 	REQUIRE(result);
-	CHECK(result->script_file == "scenario.fersxml");
-	CHECK(result->log_level == FERS_LOG_DEBUG);
-	CHECK(result->log_file == std::optional<std::string>{"runner.log"});
-	CHECK(result->num_threads == requested_threads);
-	CHECK_FALSE(result->validate);
-	CHECK(result->generate_kml);
-	CHECK(result->kml_file == std::optional<std::string>{"preview.kml"});
-	CHECK(result->output_dir == std::optional<std::string>{"results"});
-	CHECK(result->vita49_enabled);
-	CHECK(result->vita49_host == "localhost");
-	CHECK(result->vita49_port == 4991);
-	REQUIRE(result->vita49_fullscale.has_value());
-	CHECK(result->vita49_fullscale.value_or(0.0) == 2.5);
-	CHECK(result->vita49_epoch_unix_nanoseconds == std::optional<std::uint64_t>{1700000000123456789ULL});
-	CHECK(result->vita49_max_udp_payload == std::optional<std::uint16_t>{900});
-	CHECK(result->vita49_queue_depth == std::optional<std::uint32_t>{17});
+	requireRecognizedOptions(*result, requested_threads);
 }
 
 TEST_CASE("parseArguments accepts flags before and after the script", "[fers-cli][arg-parser]")

--- a/packages/fers-cli/tests/test_arg_parser.cpp
+++ b/packages/fers-cli/tests/test_arg_parser.cpp
@@ -90,7 +90,7 @@ TEST_CASE("parseArguments applies recognized options", "[fers-cli][arg-parser]")
 	CHECK(result->vita49_host == "localhost");
 	CHECK(result->vita49_port == 4991);
 	REQUIRE(result->vita49_fullscale.has_value());
-	CHECK(*result->vita49_fullscale == 2.5);
+	CHECK(result->vita49_fullscale.value_or(0.0) == 2.5);
 	CHECK(result->vita49_epoch_unix_nanoseconds == std::optional<std::uint64_t>{1700000000123456789ULL});
 	CHECK(result->vita49_max_udp_payload == std::optional<std::uint16_t>{900});
 	CHECK(result->vita49_queue_depth == std::optional<std::uint32_t>{17});

--- a/packages/fers-cli/tests/test_cli_runner.cpp
+++ b/packages/fers-cli/tests/test_cli_runner.cpp
@@ -26,6 +26,10 @@ namespace
 		std::filesystem::path path;
 
 		explicit ScopedPath(std::filesystem::path value) : path(std::move(value)) {}
+		ScopedPath(const ScopedPath&) = delete;
+		ScopedPath& operator=(const ScopedPath&) = delete;
+		ScopedPath(ScopedPath&&) = delete;
+		ScopedPath& operator=(ScopedPath&&) = delete;
 
 		~ScopedPath()
 		{

--- a/packages/fers-cli/tests/test_cli_runner.cpp
+++ b/packages/fers-cli/tests/test_cli_runner.cpp
@@ -105,11 +105,11 @@ namespace
 TEST_CASE("runCli returns nonzero when KML generation fails", "[fers-cli][runner][kml]")
 {
 	const auto scenario_path = uniqueTempPath("fers_cli_kml_exit", ".fersxml");
-	ScopedPath scenario_guard(scenario_path);
+	ScopedPath const scenario_guard(scenario_path);
 	writeTextFile(scenario_path, minimalScenarioXml());
 
 	const auto missing_parent = uniqueTempPath("fers_cli_missing_kml_dir");
-	ScopedPath missing_parent_guard(missing_parent);
+	ScopedPath const missing_parent_guard(missing_parent);
 	std::error_code ec;
 	std::filesystem::remove_all(missing_parent, ec);
 	const auto kml_path = missing_parent / "out.kml";

--- a/packages/fers-ui/src/components/SceneTree.tsx
+++ b/packages/fers-ui/src/components/SceneTree.tsx
@@ -1,27 +1,29 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright (c) 2025-present FERS Contributors (see AUTHORS.md).
 
-import { SimpleTreeView, TreeItem } from '@mui/x-tree-view';
-import { useScenarioStore, Platform } from '@/stores/scenarioStore';
-import { Box, Typography, IconButton, Tooltip, Divider } from '@mui/material';
-import { useShallow } from 'zustand/react/shallow';
-
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import PublicIcon from '@mui/icons-material/Public';
-import WavesIcon from '@mui/icons-material/Waves';
-import TimerIcon from '@mui/icons-material/Timer';
-import SettingsInputAntennaIcon from '@mui/icons-material/SettingsInputAntenna';
-import FlightIcon from '@mui/icons-material/Flight';
 import AddIcon from '@mui/icons-material/Add';
-import RemoveIcon from '@mui/icons-material/Remove';
-import SensorsIcon from '@mui/icons-material/Sensors';
-import PodcastsIcon from '@mui/icons-material/Podcasts';
-import RssFeedIcon from '@mui/icons-material/RssFeed';
 import AdjustIcon from '@mui/icons-material/Adjust';
-
-import ScenarioIO from './ScenarioIO';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import FlightIcon from '@mui/icons-material/Flight';
+import PodcastsIcon from '@mui/icons-material/Podcasts';
+import PublicIcon from '@mui/icons-material/Public';
+import RemoveIcon from '@mui/icons-material/Remove';
+import RssFeedIcon from '@mui/icons-material/RssFeed';
+import SensorsIcon from '@mui/icons-material/Sensors';
+import SettingsInputAntennaIcon from '@mui/icons-material/SettingsInputAntenna';
+import TimerIcon from '@mui/icons-material/Timer';
+import WavesIcon from '@mui/icons-material/Waves';
+import { Box, Divider, IconButton, Tooltip, Typography } from '@mui/material';
+import { SimpleTreeView, TreeItem } from '@mui/x-tree-view';
 import React from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import {
+    Platform,
+    PlatformComponent,
+    useScenarioStore,
+} from '@/stores/scenarioStore';
+import ScenarioIO from './ScenarioIO';
 
 const SectionHeader = ({
     title,
@@ -83,6 +85,21 @@ const getPlatformIcon = (platform: Platform) => {
     return <FlightIcon sx={{ mr: 1 }} fontSize="small" />;
 };
 
+const getComponentIcon = (component: PlatformComponent) => {
+    switch (component.type) {
+        case 'monostatic':
+            return <SensorsIcon sx={{ mr: 1 }} fontSize="small" />;
+        case 'transmitter':
+            return <PodcastsIcon sx={{ mr: 1 }} fontSize="small" />;
+        case 'receiver':
+            return <RssFeedIcon sx={{ mr: 1 }} fontSize="small" />;
+        case 'target':
+            return <AdjustIcon sx={{ mr: 1 }} fontSize="small" />;
+        default:
+            return <FlightIcon sx={{ mr: 1 }} fontSize="small" />;
+    }
+};
+
 export default function SceneTree() {
     const {
         globalParameters,
@@ -98,6 +115,7 @@ export default function SceneTree() {
         addAntenna,
         addPlatform,
         removeItem,
+        removePlatformComponent,
     } = useScenarioStore(
         useShallow((state) => ({
             globalParameters: state.globalParameters,
@@ -113,6 +131,7 @@ export default function SceneTree() {
             addAntenna: state.addAntenna,
             addPlatform: state.addPlatform,
             removeItem: state.removeItem,
+            removePlatformComponent: state.removePlatformComponent,
         }))
     );
 
@@ -445,7 +464,55 @@ export default function SceneTree() {
                                             </IconButton>
                                         </Box>
                                     }
-                                />
+                                >
+                                    {platform.components.map((component) => (
+                                        <TreeItem
+                                            key={component.id}
+                                            itemId={component.id}
+                                            label={
+                                                <Box
+                                                    sx={{
+                                                        display: 'flex',
+                                                        alignItems: 'center',
+                                                        width: '100%',
+                                                    }}
+                                                >
+                                                    {getComponentIcon(
+                                                        component
+                                                    )}
+                                                    <Typography
+                                                        variant="body2"
+                                                        sx={{
+                                                            flexGrow: 1,
+                                                            whiteSpace:
+                                                                'nowrap',
+                                                            overflow: 'hidden',
+                                                            textOverflow:
+                                                                'ellipsis',
+                                                            minWidth: 0,
+                                                            pr: 1,
+                                                        }}
+                                                    >
+                                                        {component.name}
+                                                    </Typography>
+                                                    <IconButton
+                                                        size="small"
+                                                        className="remove-button"
+                                                        onClick={(e) => {
+                                                            e.stopPropagation();
+                                                            removePlatformComponent(
+                                                                platform.id,
+                                                                component.id
+                                                            );
+                                                        }}
+                                                    >
+                                                        <RemoveIcon fontSize="inherit" />
+                                                    </IconButton>
+                                                </Box>
+                                            }
+                                        />
+                                    ))}
+                                </TreeItem>
                             );
                         })}
                     </TreeItem>

--- a/packages/fers-ui/src/components/inspectors/PlatformComponentInspector.tsx
+++ b/packages/fers-ui/src/components/inspectors/PlatformComponentInspector.tsx
@@ -885,7 +885,12 @@ export function PlatformComponentInspector({
                             label="RCS File"
                             value={component.rcs_filename}
                             onChange={(v) => handleChange('rcs_filename', v)}
-                            filters={[{ name: 'RCS Data', extensions: ['*'] }]}
+                            filters={[
+                                {
+                                    name: 'Target RCS XML',
+                                    extensions: ['xml'],
+                                },
+                            ]}
                         />
                     )}
 

--- a/packages/libfers/include/libfers/api.h
+++ b/packages/libfers/include/libfers/api.h
@@ -188,7 +188,7 @@ int fers_set_vita49_packet_trace_enabled(fers_context_t* context, int enabled);
 /**
  * @brief Log levels for the FERS library.
  */
-typedef enum // NOLINT(*-use-using)
+typedef enum // NOLINT(*-use-using,performance-enum-size)
 {
 	FERS_LOG_TRACE, ///< Trace-level diagnostic logging.
 	FERS_LOG_DEBUG, ///< Debug-level diagnostic logging.
@@ -590,7 +590,7 @@ void fers_free_antenna_pattern_data(fers_antenna_pattern_data_t* data);
  * This enum provides a language-agnostic way to specify the desired
  * interpolation algorithm when calling the path generation functions.
  */
-typedef enum // NOLINT(*-use-using)
+typedef enum // NOLINT(*-use-using,performance-enum-size)
 {
 	FERS_INTERP_STATIC,
 	FERS_INTERP_LINEAR,
@@ -600,7 +600,7 @@ typedef enum // NOLINT(*-use-using)
 /**
  * @brief Units used for external rotation angles and rates.
  */
-typedef enum // NOLINT(*-use-using)
+typedef enum // NOLINT(*-use-using,performance-enum-size)
 {
 	FERS_ANGLE_UNIT_DEG,
 	FERS_ANGLE_UNIT_RAD
@@ -727,7 +727,7 @@ void fers_free_interpolated_rotation_path(fers_interpolated_rotation_path_t* pat
 /**
  * @brief Quality of the radio link based on SNR.
  */
-typedef enum // NOLINT(*-use-using)
+typedef enum // NOLINT(*-use-using,performance-enum-size)
 {
 	FERS_LINK_STRONG, // SNR > 0 dB
 	FERS_LINK_WEAK // SNR < 0 dB (Geometric possibility but sub-noise)
@@ -736,7 +736,7 @@ typedef enum // NOLINT(*-use-using)
 /**
  * @brief Type of visual link to render.
  */
-typedef enum // NOLINT(*-use-using)
+typedef enum // NOLINT(*-use-using,performance-enum-size)
 {
 	FERS_LINK_MONOSTATIC, // Combined Tx/Rx path
 	FERS_LINK_BISTATIC_TX_TGT, // Illuminator path

--- a/packages/libfers/include/libfers/api.h
+++ b/packages/libfers/include/libfers/api.h
@@ -37,8 +37,8 @@ typedef struct fers_context fers_context_t; // NOLINT(*-use-using)
  * @param user_data An opaque pointer passed back to the caller, useful for
  *                  maintaining state (e.g., a class instance or application handle).
  */
-typedef void (*fers_progress_callback_t)(const char* message, int current, int total,
-										 void* user_data); // NOLINT(*-use-using)
+// NOLINTNEXTLINE(*-use-using): Public C API callback typedef.
+typedef void (*fers_progress_callback_t)(const char* message, int current, int total, void* user_data);
 
 /**
  * @brief A function pointer type for cooperative simulation cancellation.
@@ -61,8 +61,9 @@ typedef int (*fers_cancel_callback_t)(void* user_data); // NOLINT(*-use-using)
  * @param packet_batch_json Packet trace batch JSON array, or NULL.
  * @param user_data An opaque pointer passed back to the caller.
  */
+// NOLINTNEXTLINE(*-use-using): Public C API callback typedef.
 typedef void (*fers_vita49_telemetry_callback_t)(const char* stats_json, const char* packet_batch_json,
-												 void* user_data); // NOLINT(*-use-using)
+												 void* user_data);
 
 
 // --- Context Lifecycle ---

--- a/packages/libfers/src/antenna/antenna_factory.cpp
+++ b/packages/libfers/src/antenna/antenna_factory.cpp
@@ -16,6 +16,7 @@
 #include <cctype>
 #include <cmath>
 #include <complex>
+#include <cstdint>
 #include <limits>
 #include <optional>
 #include <stdexcept>
@@ -35,14 +36,14 @@ using math::Vec3;
 namespace
 {
 	/// Unit used for XML antenna axis sample angles.
-	enum class AxisUnit
+	enum class AxisUnit : std::uint8_t
 	{
 		Radians, ///< Axis samples are expressed in radians.
 		Degrees, ///< Axis samples are expressed in degrees.
 	};
 
 	/// Gain format used for XML antenna axis sample values.
-	enum class AxisGainFormat
+	enum class AxisGainFormat : std::uint8_t
 	{
 		Linear, ///< Gain samples are already linear.
 		DBi, ///< Gain samples are expressed in dBi.
@@ -239,9 +240,9 @@ namespace
 
 		while (sample.isValid())
 		{
-			XmlElement angle_element = sample.childElement("angle", 0);
+			XmlElement const angle_element = sample.childElement("angle", 0);
 
-			if (XmlElement gain_element = sample.childElement("gain", 0);
+			if (XmlElement const gain_element = sample.childElement("gain", 0);
 				angle_element.isValid() && gain_element.isValid())
 			{
 				const RealType raw_angle = parseRealValue(angle_element.getText(), "<" + axis_name + "> sample angle");

--- a/packages/libfers/src/antenna/antenna_factory.cpp
+++ b/packages/libfers/src/antenna/antenna_factory.cpp
@@ -72,8 +72,8 @@ namespace
 	/// Returns a lowercase copy of a string.
 	std::string toLowerCopy(std::string value)
 	{
-		std::transform(value.begin(), value.end(), value.begin(),
-					   [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+		std::ranges::transform(value, value.begin(),
+							   [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
 		return value;
 	}
 

--- a/packages/libfers/src/antenna/antenna_factory.cpp
+++ b/packages/libfers/src/antenna/antenna_factory.cpp
@@ -282,6 +282,7 @@ namespace
 		result.max_gain = max_gain;
 		result.symmetry = metadata.symmetry;
 		result.sample_count = sample_count;
+		const bool spans_zero = min_angle < 0.0 && max_angle > 0.0;
 
 		if (metadata.symmetry_explicit)
 		{
@@ -290,7 +291,7 @@ namespace
 				throw std::runtime_error("XML antenna <" + axis_name +
 										 "> axis uses symmetry='mirrored' but defines negative sample angles.");
 			}
-			if (result.symmetry == antenna::XmlAntenna::AxisSymmetry::None && !(min_angle < 0.0 && max_angle > 0.0))
+			if (result.symmetry == antenna::XmlAntenna::AxisSymmetry::None && !spans_zero)
 			{
 				throw std::runtime_error(
 					"XML antenna <" + axis_name +
@@ -299,7 +300,7 @@ namespace
 		}
 		else if (min_angle < 0.0)
 		{
-			if (!(min_angle < 0.0 && max_angle > 0.0))
+			if (!spans_zero)
 			{
 				throw std::runtime_error("XML antenna <" + axis_name +
 										 "> axis contains negative sample angles but does not span both sides of zero "

--- a/packages/libfers/src/antenna/antenna_factory.cpp
+++ b/packages/libfers/src/antenna/antenna_factory.cpp
@@ -69,6 +69,14 @@ namespace
 		std::size_t sample_count{}; ///< Number of parsed samples.
 	};
 
+	struct AxisSampleStats
+	{
+		RealType min_angle{std::numeric_limits<RealType>::max()};
+		RealType max_angle{std::numeric_limits<RealType>::lowest()};
+		RealType max_gain{};
+		std::size_t sample_count{};
+	};
+
 	/// Returns a lowercase copy of a string.
 	std::string toLowerCopy(std::string value)
 	{
@@ -212,6 +220,78 @@ namespace
 	 */
 	RealType j1C(const RealType x) noexcept { return x == 0 ? 1.0 : core::besselJ1(x) / x; }
 
+	void loadAntennaGainSample(const interp::InterpSet* set, const AxisMetadata& metadata, const std::string& axis_name,
+							   const XmlElement& sample, AxisSampleStats& stats)
+	{
+		XmlElement const angle_element = sample.childElement("angle", 0);
+		XmlElement const gain_element = sample.childElement("gain", 0);
+		if (!angle_element.isValid() || !gain_element.isValid())
+		{
+			if (sample.name() == "gainsample")
+			{
+				throw std::runtime_error("Each <gainsample> in <" + axis_name + "> must contain <angle> and <gain>.");
+			}
+			return;
+		}
+
+		const RealType raw_angle = parseRealValue(angle_element.getText(), "<" + axis_name + "> sample angle");
+		const RealType raw_gain = parseRealValue(gain_element.getText(), "<" + axis_name + "> sample gain");
+		const RealType angle = metadata.unit == AxisUnit::Degrees ? raw_angle * (PI / 180.0) : raw_angle;
+		const RealType gain = metadata.format == AxisGainFormat::DBi ? std::pow(10.0, raw_gain / 10.0) : raw_gain;
+
+		if (!std::isfinite(angle))
+		{
+			throw std::runtime_error("Converted <" + axis_name + "> sample angle is non-finite.");
+		}
+		if (!std::isfinite(gain))
+		{
+			throw std::runtime_error("Converted <" + axis_name + "> sample gain is non-finite.");
+		}
+		if (gain < 0.0)
+		{
+			throw std::runtime_error("Converted <" + axis_name + "> sample gain must be non-negative.");
+		}
+
+		set->insertSample(angle, gain);
+		stats.min_angle = std::min(stats.min_angle, angle);
+		stats.max_angle = std::max(stats.max_angle, angle);
+		stats.max_gain = std::max(stats.max_gain, gain);
+		++stats.sample_count;
+	}
+
+	void validateAxisSymmetry(const AxisMetadata& metadata, AxisLoadResult& result, const std::string& axis_name,
+							  const RealType min_angle, const RealType max_angle)
+	{
+		const bool spans_zero = min_angle < 0.0 && max_angle > 0.0;
+
+		if (metadata.symmetry_explicit)
+		{
+			if (result.symmetry == antenna::XmlAntenna::AxisSymmetry::Mirrored && min_angle < 0.0)
+			{
+				throw std::runtime_error("XML antenna <" + axis_name +
+										 "> axis uses symmetry='mirrored' but defines negative sample angles.");
+			}
+			if (result.symmetry == antenna::XmlAntenna::AxisSymmetry::None && !spans_zero)
+			{
+				throw std::runtime_error(
+					"XML antenna <" + axis_name +
+					"> axis uses symmetry='none' but does not span both negative and positive angles.");
+			}
+			return;
+		}
+
+		if (min_angle < 0.0)
+		{
+			if (!spans_zero)
+			{
+				throw std::runtime_error("XML antenna <" + axis_name +
+										 "> axis contains negative sample angles but does not span both sides of zero "
+										 "for direct signed-angle lookup.");
+			}
+			result.symmetry = antenna::XmlAntenna::AxisSymmetry::None;
+		}
+	}
+
 	/**
 	 * @brief Load antenna gain axis data from an XML element.
 	 *
@@ -233,81 +313,19 @@ namespace
 			throw std::runtime_error("XML antenna <" + axis_name + "> axis must contain at least one <gainsample>.");
 		}
 
-		RealType min_angle = std::numeric_limits<RealType>::max();
-		RealType max_angle = std::numeric_limits<RealType>::lowest();
-		RealType max_gain = 0.0;
-		std::size_t sample_count = 0;
+		AxisSampleStats stats;
 
 		while (sample.isValid())
 		{
-			XmlElement const angle_element = sample.childElement("angle", 0);
-
-			if (XmlElement const gain_element = sample.childElement("gain", 0);
-				angle_element.isValid() && gain_element.isValid())
-			{
-				const RealType raw_angle = parseRealValue(angle_element.getText(), "<" + axis_name + "> sample angle");
-				const RealType raw_gain = parseRealValue(gain_element.getText(), "<" + axis_name + "> sample gain");
-				const RealType angle = metadata.unit == AxisUnit::Degrees ? raw_angle * (PI / 180.0) : raw_angle;
-				const RealType gain =
-					metadata.format == AxisGainFormat::DBi ? std::pow(10.0, raw_gain / 10.0) : raw_gain;
-
-				if (!std::isfinite(angle))
-				{
-					throw std::runtime_error("Converted <" + axis_name + "> sample angle is non-finite.");
-				}
-				if (!std::isfinite(gain))
-				{
-					throw std::runtime_error("Converted <" + axis_name + "> sample gain is non-finite.");
-				}
-				if (gain < 0.0)
-				{
-					throw std::runtime_error("Converted <" + axis_name + "> sample gain must be non-negative.");
-				}
-
-				set->insertSample(angle, gain);
-				min_angle = std::min(min_angle, angle);
-				max_angle = std::max(max_angle, angle);
-				max_gain = std::max(max_gain, gain);
-				++sample_count;
-			}
-			else if (sample.name() == "gainsample")
-			{
-				throw std::runtime_error("Each <gainsample> in <" + axis_name + "> must contain <angle> and <gain>.");
-			}
-
+			loadAntennaGainSample(set, metadata, axis_name, sample, stats);
 			sample = XmlElement(sample.getNode()->next);
 		}
 
 		AxisLoadResult result;
-		result.max_gain = max_gain;
+		result.max_gain = stats.max_gain;
 		result.symmetry = metadata.symmetry;
-		result.sample_count = sample_count;
-		const bool spans_zero = min_angle < 0.0 && max_angle > 0.0;
-
-		if (metadata.symmetry_explicit)
-		{
-			if (result.symmetry == antenna::XmlAntenna::AxisSymmetry::Mirrored && min_angle < 0.0)
-			{
-				throw std::runtime_error("XML antenna <" + axis_name +
-										 "> axis uses symmetry='mirrored' but defines negative sample angles.");
-			}
-			if (result.symmetry == antenna::XmlAntenna::AxisSymmetry::None && !spans_zero)
-			{
-				throw std::runtime_error(
-					"XML antenna <" + axis_name +
-					"> axis uses symmetry='none' but does not span both negative and positive angles.");
-			}
-		}
-		else if (min_angle < 0.0)
-		{
-			if (!spans_zero)
-			{
-				throw std::runtime_error("XML antenna <" + axis_name +
-										 "> axis contains negative sample angles but does not span both sides of zero "
-										 "for direct signed-angle lookup.");
-			}
-			result.symmetry = antenna::XmlAntenna::AxisSymmetry::None;
-		}
+		result.sample_count = stats.sample_count;
+		validateAxisSymmetry(metadata, result, axis_name, stats.min_angle, stats.max_angle);
 
 		const char* unit_source = metadata.unit_explicit ? "explicit" : "legacy default";
 		const char* format_source = metadata.format_explicit ? "explicit" : "legacy default";

--- a/packages/libfers/src/antenna/antenna_factory.h
+++ b/packages/libfers/src/antenna/antenna_factory.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -438,7 +439,7 @@ namespace antenna
 	{
 	public:
 		/// Symmetry mode for one-dimensional XML antenna gain axes.
-		enum class AxisSymmetry
+		enum class AxisSymmetry : std::uint8_t
 		{
 			Mirrored, ///< Mirror positive-axis samples onto negative angles.
 			None, ///< Use the axis samples exactly as provided.

--- a/packages/libfers/src/antenna/antenna_factory.h
+++ b/packages/libfers/src/antenna/antenna_factory.h
@@ -47,8 +47,7 @@ namespace antenna
 		 * @param name The name of the antenna.
 		 */
 		explicit Antenna(std::string name, const SimId id = 0) noexcept :
-			_loss_factor(1), _id(id == 0 ? SimIdGenerator::instance().generateId(ObjectType::Antenna) : id),
-			_name(std::move(name))
+			_id(id == 0 ? SimIdGenerator::instance().generateId(ObjectType::Antenna) : id), _name(std::move(name))
 		{
 		}
 
@@ -128,7 +127,7 @@ namespace antenna
 		static RealType getAngle(const math::SVec3& angle, const math::SVec3& refangle) noexcept;
 
 	private:
-		RealType _loss_factor; ///< Efficiency factor of the antenna.
+		RealType _loss_factor{1}; ///< Efficiency factor of the antenna.
 		SimId _id; ///< Unique ID for this antenna.
 		std::string _name; ///< Name of the antenna.
 	};

--- a/packages/libfers/src/api.cpp
+++ b/packages/libfers/src/api.cpp
@@ -413,7 +413,7 @@ int fers_set_output_directory(fers_context_t* context, const char* out_dir)
 		set_api_error("Invalid arguments: context or out_dir is NULL.");
 		return -1;
 	}
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	try
 	{
 		ctx->setOutputDir(out_dir);
@@ -435,7 +435,7 @@ int fers_use_hdf5_output(fers_context_t* context)
 		return -1;
 	}
 
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	try
 	{
 		core::OutputConfig config = ctx->getOutputConfig();
@@ -474,7 +474,7 @@ int fers_enable_vita49_udp_output(fers_context_t* context, const char* host, con
 		return 1;
 	}
 
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	try
 	{
 		core::OutputConfig config = ctx->getOutputConfig();
@@ -505,7 +505,7 @@ int fers_set_vita49_fullscale(fers_context_t* context, const double fullscale)
 		return 1;
 	}
 
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	core::OutputConfig config = ctx->getOutputConfig();
 	config.vita49.adc_fullscale = static_cast<RealType>(fullscale);
 	ctx->setOutputConfig(std::move(config));
@@ -526,7 +526,7 @@ int fers_set_vita49_epoch_unix_nanoseconds(fers_context_t* context, const std::u
 		return 1;
 	}
 
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	core::OutputConfig config = ctx->getOutputConfig();
 	config.vita49.epoch_unix_nanoseconds = epoch_unix_nanoseconds;
 	ctx->setOutputConfig(std::move(config));
@@ -547,7 +547,7 @@ int fers_set_vita49_max_udp_payload(fers_context_t* context, const std::uint16_t
 		return 1;
 	}
 
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	core::OutputConfig config = ctx->getOutputConfig();
 	config.vita49.max_udp_payload = max_udp_payload;
 	ctx->setOutputConfig(std::move(config));
@@ -568,7 +568,7 @@ int fers_set_vita49_queue_depth(fers_context_t* context, const std::uint32_t que
 		return 1;
 	}
 
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	core::OutputConfig config = ctx->getOutputConfig();
 	config.vita49.queue_depth = queue_depth;
 	ctx->setOutputConfig(std::move(config));
@@ -584,7 +584,7 @@ int fers_set_vita49_packet_trace_enabled(fers_context_t* context, const int enab
 		return -1;
 	}
 
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	core::OutputConfig config = ctx->getOutputConfig();
 	config.vita49.packet_trace_enabled = enabled != 0;
 	ctx->setOutputConfig(std::move(config));
@@ -603,7 +603,7 @@ int fers_load_scenario_from_xml_file(fers_context_t* context, const char* xml_fi
 		return -1;
 	}
 
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	try
 	{
 		// Set default output directory to the scenario file's directory
@@ -654,7 +654,7 @@ int fers_load_scenario_from_xml_string(fers_context_t* context, const char* xml_
 		return -1;
 	}
 
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	try
 	{
 		serial::parseSimulationFromString(xml_content, ctx->getWorld(), static_cast<bool>(validate),
@@ -697,7 +697,7 @@ char* fers_get_scenario_as_json(fers_context_t* context)
 		return nullptr;
 	}
 
-	const auto* ctx = reinterpret_cast<FersContext*>(context);
+	const auto* ctx = context;
 	try
 	{
 		const nlohmann::json j = serial::world_to_json(*ctx->getWorld());
@@ -724,7 +724,7 @@ char* fers_get_scenario_as_xml(fers_context_t* context)
 		return nullptr;
 	}
 
-	const auto* ctx = reinterpret_cast<FersContext*>(context);
+	const auto* ctx = context;
 	try
 	{
 		const std::string xml_str = serial::world_to_xml_string(*ctx->getWorld());
@@ -754,7 +754,7 @@ char* fers_get_last_output_metadata_json(fers_context_t* context)
 		return nullptr;
 	}
 
-	const auto* ctx = reinterpret_cast<FersContext*>(context);
+	const auto* ctx = context;
 	try
 	{
 		const std::string json_str = ctx->getLastOutputMetadataJson();
@@ -777,7 +777,7 @@ char* fers_get_memory_projection_json(fers_context_t* context)
 		return nullptr;
 	}
 
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 
 	try
 	{
@@ -801,7 +801,7 @@ int fers_update_platform_from_json(fers_context_t* context, uint64_t id, const c
 		discard_warning_capture();
 		return -1;
 	}
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	try
 	{
 		auto* p = ctx->getWorld()->findPlatform(id);
@@ -837,7 +837,7 @@ int fers_update_parameters_from_json(fers_context_t* context, const char* json)
 		discard_warning_capture();
 		return -1;
 	}
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	try
 	{
 		auto j = nlohmann::json::parse(json);
@@ -858,7 +858,7 @@ int fers_update_antenna_from_json(fers_context_t* context, const char* json)
 	last_error_message.clear();
 	if ((context == nullptr) || (json == nullptr))
 		return -1;
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	try
 	{
 		auto j = nlohmann::json::parse(json);
@@ -884,7 +884,7 @@ int fers_update_waveform_from_json(fers_context_t* context, const char* json)
 	last_error_message.clear();
 	if ((context == nullptr) || (json == nullptr))
 		return -1;
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	try
 	{
 		auto j = nlohmann::json::parse(json);
@@ -907,7 +907,7 @@ int fers_update_transmitter_from_json(fers_context_t* context, uint64_t id, cons
 	last_error_message.clear();
 	if ((context == nullptr) || (json == nullptr))
 		return -1;
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	try
 	{
 		auto* tx = ctx->getWorld()->findTransmitter(id);
@@ -932,7 +932,7 @@ int fers_update_receiver_from_json(fers_context_t* context, uint64_t id, const c
 	last_error_message.clear();
 	if ((context == nullptr) || (json == nullptr))
 		return -1;
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	try
 	{
 		auto* rx = ctx->getWorld()->findReceiver(id);
@@ -957,7 +957,7 @@ int fers_update_target_from_json(fers_context_t* context, uint64_t id, const cha
 	last_error_message.clear();
 	if ((context == nullptr) || (json == nullptr))
 		return -1;
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	try
 	{
 		auto* tgt = ctx->getWorld()->findTarget(id);
@@ -982,7 +982,7 @@ int fers_update_monostatic_from_json(fers_context_t* context, const char* json)
 	last_error_message.clear();
 	if ((context == nullptr) || (json == nullptr))
 		return -1;
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	try
 	{
 		auto j = nlohmann::json::parse(json);
@@ -1012,7 +1012,7 @@ int fers_update_timing_from_json(fers_context_t* context, uint64_t id, const cha
 	last_error_message.clear();
 	if ((context == nullptr) || (json == nullptr))
 		return -1;
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	try
 	{
 		if (ctx->getWorld()->findTiming(id) == nullptr)
@@ -1043,7 +1043,7 @@ int fers_update_scenario_from_json(fers_context_t* context, const char* scenario
 		return -1;
 	}
 
-	auto* ctx = reinterpret_cast<FersContext*>(context);
+	auto* ctx = context;
 	try
 	{
 		const nlohmann::json j = nlohmann::json::parse(scenario_json);
@@ -1118,7 +1118,7 @@ namespace
 			return -1;
 		}
 
-		auto* ctx = reinterpret_cast<FersContext*>(context);
+		auto* ctx = context;
 
 		std::function<void(const std::string&, int, int)> progress_fn;
 		if (progress_callback != nullptr)
@@ -1213,7 +1213,7 @@ int fers_generate_kml(const fers_context_t* context, const char* output_kml_file
 		return -1;
 	}
 
-	const auto* ctx = reinterpret_cast<const FersContext*>(context);
+	const auto* ctx = context;
 
 	try
 	{
@@ -1460,7 +1460,7 @@ fers_antenna_pattern_data_t* fers_get_antenna_pattern(const fers_context_t* cont
 
 	try
 	{
-		const auto* ctx = reinterpret_cast<const FersContext*>(context);
+		const auto* ctx = context;
 		antenna::Antenna const* ant = ctx->getWorld()->findAntenna(static_cast<SimId>(antenna_id));
 
 		if (ant == nullptr)
@@ -1555,7 +1555,7 @@ fers_visual_link_list_t* fers_calculate_preview_links(const fers_context_t* cont
 
 	try
 	{
-		const auto* ctx = reinterpret_cast<const FersContext*>(context);
+		const auto* ctx = context;
 		// Call the core physics logic in channel_model.cpp
 		const auto cpp_links = simulation::calculatePreviewLinks(*ctx->getWorld(), time);
 

--- a/packages/libfers/src/api.cpp
+++ b/packages/libfers/src/api.cpp
@@ -15,11 +15,12 @@
 #include <core/logging.h>
 #include <core/parameters.h>
 #include <core/sim_id.h>
+#include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <filesystem>
 #include <format>
 #include <functional>
+#include <iterator>
 #include <libfers/api.h>
 #include <limits>
 #include <math/path.h>
@@ -229,6 +230,14 @@ namespace
 			return "VITA49 epoch must fit the VRT 32-bit UTC seconds timestamp field.";
 		}
 		return std::nullopt;
+	}
+
+	void copy_visual_link_label(fers_visual_link_t& destination, const std::string& source) noexcept
+	{
+		const std::size_t count = std::min(source.size(), sizeof(destination.label) - 1);
+		std::copy_n(source.begin(), count, std::begin(destination.label));
+		destination.label[count] = '\0';
+		destination.label[sizeof(destination.label) - 1] = '\0';
 	}
 
 	[[nodiscard]] nlohmann::json stream_stats_to_json(const core::ReceiverStreamStats& stream)
@@ -1591,9 +1600,7 @@ fers_visual_link_list_t* fers_calculate_preview_links(const fers_context_t* cont
 
 				dst.quality = (src.quality == simulation::LinkQuality::Strong) ? FERS_LINK_STRONG : FERS_LINK_WEAK;
 
-				// Safe string copy
-				std::strncpy(dst.label, src.label.c_str(), sizeof(dst.label) - 1);
-				dst.label[sizeof(dst.label) - 1] = '\0';
+				copy_visual_link_label(dst, src.label);
 
 				dst.source_id = static_cast<uint64_t>(src.source_id);
 				dst.dest_id = static_cast<uint64_t>(src.dest_id);

--- a/packages/libfers/src/api.cpp
+++ b/packages/libfers/src/api.cpp
@@ -100,6 +100,7 @@ fers_context_t* fers_context_create()
 	discard_warning_capture();
 	try
 	{
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Public C API returns an owned handle.
 		return new fers_context_t();
 	}
 	catch (const std::bad_alloc& e)
@@ -120,6 +121,7 @@ void fers_context_destroy(fers_context_t* context)
 	{
 		return;
 	}
+	// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Frees handles allocated by `fers_context_create`.
 	delete context;
 }
 
@@ -1108,6 +1110,7 @@ void fers_free_string(char* str)
 {
 	if (str != nullptr)
 	{
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Public C API frees strings returned by this library.
 		free(str);
 	}
 }
@@ -1310,7 +1313,9 @@ fers_interpolated_path_t* fers_get_interpolated_motion_path(const fers_motion_wa
 
 		path.finalize();
 
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Public C API returns an owned path struct.
 		auto* result_path = new fers_interpolated_path_t();
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Public C API frees this array with the parent path.
 		result_path->points = new fers_interpolated_point_t[num_points];
 		result_path->count = num_points;
 
@@ -1353,7 +1358,10 @@ void fers_free_interpolated_motion_path(fers_interpolated_path_t* path)
 {
 	if (path != nullptr)
 	{
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Frees arrays owned by C API path structs.
 		delete[] path->points;
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Frees structs allocated by
+		// `fers_get_interpolated_motion_path`.
 		delete path;
 	}
 }
@@ -1401,7 +1409,9 @@ fers_interpolated_rotation_path_t* fers_get_interpolated_rotation_path(const fer
 
 		path.finalize();
 
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Public C API returns an owned path struct.
 		auto* result_path = new fers_interpolated_rotation_path_t();
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Public C API frees this array with the parent path.
 		result_path->points = new fers_interpolated_rotation_point_t[num_points];
 		result_path->count = num_points;
 
@@ -1449,7 +1459,10 @@ void fers_free_interpolated_rotation_path(fers_interpolated_rotation_path_t* pat
 {
 	if (path != nullptr)
 	{
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Frees arrays owned by C API path structs.
 		delete[] path->points;
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Frees structs allocated by
+		// `fers_get_interpolated_rotation_path`.
 		delete path;
 	}
 }
@@ -1493,10 +1506,12 @@ fers_antenna_pattern_data_t* fers_get_antenna_pattern(const fers_context_t* cont
 			wavelength = params::c() / frequency_hz;
 		}
 
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Public C API returns owned antenna pattern data.
 		auto* data = new fers_antenna_pattern_data_t();
 		data->az_count = az_samples;
 		data->el_count = el_samples;
 		const size_t total_samples = az_samples * el_samples;
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Public C API frees this array with the parent data.
 		data->gains = new double[total_samples];
 
 		// The reference angle (boresight) is implicitly the local X-axis in the FERS engine.
@@ -1546,7 +1561,9 @@ void fers_free_antenna_pattern_data(fers_antenna_pattern_data_t* data)
 {
 	if (data != nullptr)
 	{
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Frees arrays owned by C API pattern structs.
 		delete[] data->gains;
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Frees structs allocated by `fers_get_antenna_pattern`.
 		delete data;
 	}
 }
@@ -1570,11 +1587,13 @@ fers_visual_link_list_t* fers_calculate_preview_links(const fers_context_t* cont
 		const auto cpp_links = simulation::calculatePreviewLinks(*ctx->getWorld(), time);
 
 		// Convert C++ vector to C-API struct
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Public C API returns owned preview-link lists.
 		auto* result = new fers_visual_link_list_t();
 		result->count = cpp_links.size();
 
 		if (!cpp_links.empty())
 		{
+			// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Public C API frees this array with the parent list.
 			result->links = new fers_visual_link_t[result->count];
 			for (size_t i = 0; i < result->count; ++i)
 			{
@@ -1627,7 +1646,9 @@ void fers_free_preview_links(fers_visual_link_list_t* list)
 {
 	if (list != nullptr)
 	{
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Frees arrays owned by C API preview-link lists.
 		delete[] list->links;
+		// NOLINTNEXTLINE(cppcoreguidelines-owning-memory): Frees structs allocated by `fers_calculate_preview_links`.
 		delete list;
 	}
 }

--- a/packages/libfers/src/api.cpp
+++ b/packages/libfers/src/api.cpp
@@ -1117,42 +1117,49 @@ void fers_free_string(char* str)
 
 namespace
 {
-	int run_simulation_common(fers_context_t* context, fers_progress_callback_t progress_callback,
-							  void* progress_user_data, fers_cancel_callback_t cancel_callback, void* cancel_user_data,
-							  fers_vita49_telemetry_callback_t vita49_telemetry_callback,
-							  void* vita49_telemetry_user_data, const char* function_name,
-							  const char* invalid_context_message)
+	struct SimulationRunRequest
+	{
+		fers_context_t* context;
+		fers_progress_callback_t progress_callback;
+		void* progress_user_data;
+		fers_cancel_callback_t cancel_callback;
+		void* cancel_user_data;
+		fers_vita49_telemetry_callback_t vita49_telemetry_callback;
+		void* vita49_telemetry_user_data;
+		const char* function_name;
+		const char* invalid_context_message;
+	};
+
+	int run_simulation_common(const SimulationRunRequest& request)
 	{
 		last_error_message.clear();
-		if (context == nullptr)
+		if (request.context == nullptr)
 		{
-			last_error_message = invalid_context_message;
+			last_error_message = request.invalid_context_message;
 			LOG(logging::Level::ERROR, last_error_message);
 			return -1;
 		}
 
-		auto* ctx = context;
+		auto* ctx = request.context;
 
 		std::function<void(const std::string&, int, int)> progress_fn;
-		if (progress_callback != nullptr)
+		if (request.progress_callback != nullptr)
 		{
-			progress_fn =
-				[progress_callback, progress_user_data](const std::string& msg, const int current, const int total)
-			{ progress_callback(msg.c_str(), current, total, progress_user_data); };
+			progress_fn = [&request](const std::string& msg, const int current, const int total)
+			{ request.progress_callback(msg.c_str(), current, total, request.progress_user_data); };
 		}
 
 		std::function<bool()> cancel_fn;
-		if (cancel_callback != nullptr)
+		if (request.cancel_callback != nullptr)
 		{
-			cancel_fn = [cancel_callback, cancel_user_data] { return cancel_callback(cancel_user_data) != 0; };
+			cancel_fn = [&request] { return request.cancel_callback(request.cancel_user_data) != 0; };
 		}
 
 		core::ReceiverOutputTelemetryCallback telemetry_fn;
-		if (vita49_telemetry_callback != nullptr)
+		if (request.vita49_telemetry_callback != nullptr)
 		{
-			telemetry_fn = [vita49_telemetry_callback,
-							vita49_telemetry_user_data](const std::optional<core::OutputStats>& stats,
-														std::span<const core::ReceiverOutputPacketTrace> packets)
+			telemetry_fn = [&request](const std::optional<core::OutputStats>& stats,
+									  std::span<const core::ReceiverOutputPacketTrace> packets)
 			{
 				std::string stats_json;
 				std::string packet_batch_json;
@@ -1170,7 +1177,7 @@ namespace
 					packet_batch_ptr = packet_batch_json.c_str();
 				}
 
-				vita49_telemetry_callback(stats_ptr, packet_batch_ptr, vita49_telemetry_user_data);
+				request.vita49_telemetry_callback(stats_ptr, packet_batch_ptr, request.vita49_telemetry_user_data);
 			};
 		}
 
@@ -1195,7 +1202,7 @@ namespace
 		}
 		catch (const std::exception& e)
 		{
-			handle_api_exception(e, function_name);
+			handle_api_exception(e, request.function_name);
 			return 1;
 		}
 	}
@@ -1203,17 +1210,32 @@ namespace
 
 int fers_run_simulation(fers_context_t* context, fers_progress_callback_t callback, void* user_data)
 {
-	return run_simulation_common(context, callback, user_data, nullptr, nullptr, nullptr, nullptr,
-								 "fers_run_simulation", "Invalid context provided to fers_run_simulation.");
+	return run_simulation_common(
+		SimulationRunRequest{.context = context,
+							 .progress_callback = callback,
+							 .progress_user_data = user_data,
+							 .cancel_callback = nullptr,
+							 .cancel_user_data = nullptr,
+							 .vita49_telemetry_callback = nullptr,
+							 .vita49_telemetry_user_data = nullptr,
+							 .function_name = "fers_run_simulation",
+							 .invalid_context_message = "Invalid context provided to fers_run_simulation."});
 }
 
 int fers_run_simulation_ex(fers_context_t* context, fers_progress_callback_t progress_callback,
 						   void* progress_user_data, fers_cancel_callback_t cancel_callback, void* cancel_user_data,
 						   fers_vita49_telemetry_callback_t vita49_telemetry_callback, void* vita49_telemetry_user_data)
 {
-	return run_simulation_common(context, progress_callback, progress_user_data, cancel_callback, cancel_user_data,
-								 vita49_telemetry_callback, vita49_telemetry_user_data, "fers_run_simulation_ex",
-								 "Invalid context provided to fers_run_simulation_ex.");
+	return run_simulation_common(
+		SimulationRunRequest{.context = context,
+							 .progress_callback = progress_callback,
+							 .progress_user_data = progress_user_data,
+							 .cancel_callback = cancel_callback,
+							 .cancel_user_data = cancel_user_data,
+							 .vita49_telemetry_callback = vita49_telemetry_callback,
+							 .vita49_telemetry_user_data = vita49_telemetry_user_data,
+							 .function_name = "fers_run_simulation_ex",
+							 .invalid_context_message = "Invalid context provided to fers_run_simulation_ex."});
 }
 
 int fers_generate_kml(const fers_context_t* context, const char* output_kml_filepath)

--- a/packages/libfers/src/api.cpp
+++ b/packages/libfers/src/api.cpp
@@ -1079,6 +1079,7 @@ char* fers_get_last_error_message()
 	// `strdup` allocates with `malloc`, which is part of the C standard ABI,
 	// making it safe to transfer ownership across the FFI boundary. The caller
 	// must then free this memory using `fers_free_string`.
+	// NOLINTNEXTLINE(cppcoreguidelines-no-malloc): C ABI string ownership is freed by `fers_free_string`.
 	return strdup(last_error_message.c_str());
 }
 

--- a/packages/libfers/src/api.cpp
+++ b/packages/libfers/src/api.cpp
@@ -1494,8 +1494,8 @@ fers_antenna_pattern_data_t* fers_get_antenna_pattern(const fers_context_t* cont
 		const math::SVec3 ref_angle(1.0, 0.0, 0.0);
 		double max_gain = 0.0;
 
-		const RealType az_denominator = static_cast<RealType>(az_samples - 1);
-		const RealType el_denominator = static_cast<RealType>(el_samples - 1);
+		const auto az_denominator = static_cast<RealType>(az_samples - 1);
+		const auto el_denominator = static_cast<RealType>(el_samples - 1);
 
 		for (size_t i = 0; i < el_samples; ++i)
 		{

--- a/packages/libfers/src/api.cpp
+++ b/packages/libfers/src/api.cpp
@@ -327,7 +327,7 @@ namespace
 		void* user_data = nullptr;
 
 		{
-			std::scoped_lock lock(log_callback_mutex);
+			std::scoped_lock const lock(log_callback_mutex);
 			callback = log_callback;
 			user_data = log_callback_user_data;
 		}
@@ -370,7 +370,7 @@ fers_log_level_t fers_get_log_level() { return map_internal_log_level(logging::l
 void fers_set_log_callback(fers_log_callback_t callback, void* user_data)
 {
 	{
-		std::scoped_lock lock(log_callback_mutex);
+		std::scoped_lock const lock(log_callback_mutex);
 		log_callback = callback;
 		log_callback_user_data = user_data;
 	}
@@ -607,7 +607,7 @@ int fers_load_scenario_from_xml_file(fers_context_t* context, const char* xml_fi
 	try
 	{
 		// Set default output directory to the scenario file's directory
-		std::filesystem::path p(xml_filepath);
+		std::filesystem::path const p(xml_filepath);
 		auto parent = p.parent_path();
 		if (parent.empty())
 			parent = ".";
@@ -986,9 +986,9 @@ int fers_update_monostatic_from_json(fers_context_t* context, const char* json)
 	try
 	{
 		auto j = nlohmann::json::parse(json);
-		uint64_t tx_id =
+		uint64_t const tx_id =
 			j.at("tx_id").is_string() ? std::stoull(j.at("tx_id").get<std::string>()) : j.at("tx_id").get<uint64_t>();
-		uint64_t rx_id =
+		uint64_t const rx_id =
 			j.at("rx_id").is_string() ? std::stoull(j.at("rx_id").get<std::string>()) : j.at("rx_id").get<uint64_t>();
 		auto* tx = ctx->getWorld()->findTransmitter(tx_id);
 		auto* rx = ctx->getWorld()->findReceiver(rx_id);
@@ -1461,7 +1461,7 @@ fers_antenna_pattern_data_t* fers_get_antenna_pattern(const fers_context_t* cont
 	try
 	{
 		const auto* ctx = reinterpret_cast<const FersContext*>(context);
-		antenna::Antenna* ant = ctx->getWorld()->findAntenna(static_cast<SimId>(antenna_id));
+		antenna::Antenna const* ant = ctx->getWorld()->findAntenna(static_cast<SimId>(antenna_id));
 
 		if (ant == nullptr)
 		{

--- a/packages/libfers/src/core/logging.cpp
+++ b/packages/libfers/src/core/logging.cpp
@@ -51,7 +51,7 @@ namespace logging
 			std::string line;
 
 			{
-				std::scoped_lock lock(_log_mutex);
+				std::scoped_lock const lock(_log_mutex);
 
 				const std::string filename = std::filesystem::path(location.file_name()).filename().string();
 				const std::string file_line = filename + ":" + std::to_string(location.line());
@@ -82,14 +82,14 @@ namespace logging
 
 	void Logger::setCallback(Callback callback, void* user_data) noexcept
 	{
-		std::scoped_lock lock(_log_mutex);
+		std::scoped_lock const lock(_log_mutex);
 		_callback = callback;
 		_callback_user_data = user_data;
 	}
 
 	std::expected<void, std::string> Logger::logToFile(const std::string& filePath) noexcept
 	{
-		std::scoped_lock lock(_log_mutex);
+		std::scoped_lock const lock(_log_mutex);
 
 		std::ofstream file(filePath, std::ios::out | std::ios::trunc);
 		if (!file)

--- a/packages/libfers/src/core/logging.h
+++ b/packages/libfers/src/core/logging.h
@@ -98,7 +98,7 @@ namespace logging
 		 */
 		template <typename... Args>
 		void log(const Level level, const std::source_location& location, const std::string& formatStr,
-				 Args&&... args) noexcept
+				 const Args&... args) noexcept
 		{
 			if (level != Level::OFF && level >= getLevel())
 			{

--- a/packages/libfers/src/core/logging.h
+++ b/packages/libfers/src/core/logging.h
@@ -19,6 +19,7 @@
 #define LOG(level, ...) log(level, std::source_location::current(), __VA_ARGS__)
 
 #include <atomic>
+#include <cstdint>
 #include <expected>
 #include <format>
 #include <fstream>
@@ -34,7 +35,7 @@ namespace logging
 	 * @class Level
 	 * @brief Enum class representing the log levels.
 	 */
-	enum class Level
+	enum class Level : std::uint8_t
 	{
 		TRACE, ///< Trace level for detailed debugging information.
 		DEBUG, ///< Debug level for general debugging information.

--- a/packages/libfers/src/core/memory_projection.cpp
+++ b/packages/libfers/src/core/memory_projection.cpp
@@ -384,9 +384,10 @@ namespace core
 			{
 				++projection.streaming_receiver_count;
 				bool if_count_overflowed = false;
-				const bool if_rate_dechirped = receiver.isDechirpEnabled() && receiver.hasFmcwIfSampleRate();
+				const auto if_sample_rate = receiver.getIfSampleRate();
+				const bool if_rate_dechirped = receiver.isDechirpEnabled() && if_sample_rate.has_value();
 				const auto if_sample_count = if_rate_dechirped
-					? countSamplesForDuration(projection.duration_seconds, *receiver.getIfSampleRate(),
+					? countSamplesForDuration(projection.duration_seconds, if_sample_rate.value_or(0.0),
 											  if_count_overflowed)
 					: std::uint64_t{0};
 				const auto rendered_samples = if_rate_dechirped

--- a/packages/libfers/src/core/memory_projection.cpp
+++ b/packages/libfers/src/core/memory_projection.cpp
@@ -10,8 +10,8 @@
 #include <array>
 #include <cmath>
 #include <cstdint>
-#include <cstdio>
 #include <format>
+#include <fstream>
 #include <limits>
 #include <nlohmann/json.hpp>
 #include <optional>
@@ -244,16 +244,16 @@ namespace core
 				return std::nullopt;
 			}
 
-			FILE* statm = std::fopen("/proc/self/statm", "r");
-			if (statm == nullptr)
+			std::ifstream statm("/proc/self/statm");
+			if (!statm)
 			{
 				return std::nullopt;
 			}
 
+			std::string ignored_total_pages;
 			unsigned long resident_pages = 0;
-			const int scanned = std::fscanf(statm, "%*s %lu", &resident_pages);
-			std::fclose(statm);
-			if (scanned != 1)
+			statm >> ignored_total_pages >> resident_pages;
+			if (!statm)
 			{
 				return std::nullopt;
 			}

--- a/packages/libfers/src/core/memory_projection.cpp
+++ b/packages/libfers/src/core/memory_projection.cpp
@@ -337,6 +337,50 @@ namespace core
 		return timings;
 	}
 
+	void addStreamingReceiverProjection(SimulationMemoryProjection& projection, const radar::Receiver& receiver,
+										const bool sample_count_overflowed)
+	{
+		++projection.streaming_receiver_count;
+		bool if_count_overflowed = false;
+		const auto if_sample_rate = receiver.getIfSampleRate();
+		const bool if_rate_dechirped = receiver.isDechirpEnabled() && if_sample_rate.has_value();
+		const auto if_sample_count = if_rate_dechirped
+			? countSamplesForDuration(projection.duration_seconds, if_sample_rate.value_or(0.0), if_count_overflowed)
+			: std::uint64_t{0};
+		const auto rendered_samples = if_rate_dechirped
+			? if_sample_count
+			: (receiver.isDechirpEnabled() ? projection.streaming_sample_count
+										   : downsampledSampleCount(projection.streaming_sample_count));
+		projection.rendered_hdf5_sample_count =
+			addBytes({.bytes = projection.rendered_hdf5_sample_count},
+					 {.bytes = rendered_samples, .overflowed = sample_count_overflowed || if_count_overflowed})
+				.bytes;
+		const auto resident_samples = if_rate_dechirped ? if_sample_count : projection.streaming_sample_count;
+		projection.streaming_iq_buffers =
+			addBytes(projection.streaming_iq_buffers,
+					 multiplyBytes(resident_samples, static_cast<std::uint64_t>(sizeof(ComplexType)),
+								   sample_count_overflowed || if_count_overflowed));
+	}
+
+	void addPulsedReceiverProjection(SimulationMemoryProjection& projection, const radar::Receiver& receiver)
+	{
+		++projection.pulsed_receiver_count;
+		bool window_count_overflowed = false;
+		const auto windows = countPulsedWindows(receiver, window_count_overflowed);
+		projection.pulsed_window_count = addBytes({.bytes = projection.pulsed_window_count},
+												  {.bytes = windows, .overflowed = window_count_overflowed})
+											 .bytes;
+
+		bool pulsed_sample_count_overflowed = false;
+		const auto raw_window_samples = countSamplesForDuration(
+			receiver.getWindowLength(), projection.simulation_sample_rate_hz, pulsed_sample_count_overflowed);
+		const auto rendered_window_samples = downsampledSampleCount(raw_window_samples);
+		const auto rendered_samples =
+			multiplyBytes(windows, rendered_window_samples, window_count_overflowed || pulsed_sample_count_overflowed);
+		projection.rendered_hdf5_sample_count =
+			addBytes({.bytes = projection.rendered_hdf5_sample_count}, rendered_samples).bytes;
+	}
+
 	SimulationMemoryProjection projectSimulationMemory(const World& world)
 	{
 		SimulationMemoryProjection projection{};
@@ -382,47 +426,13 @@ namespace core
 			const auto& receiver = *receiver_ptr;
 			if (isStreamingReceiver(receiver))
 			{
-				++projection.streaming_receiver_count;
-				bool if_count_overflowed = false;
-				const auto if_sample_rate = receiver.getIfSampleRate();
-				const bool if_rate_dechirped = receiver.isDechirpEnabled() && if_sample_rate.has_value();
-				const auto if_sample_count = if_rate_dechirped
-					? countSamplesForDuration(projection.duration_seconds, if_sample_rate.value_or(0.0),
-											  if_count_overflowed)
-					: std::uint64_t{0};
-				const auto rendered_samples = if_rate_dechirped
-					? if_sample_count
-					: (receiver.isDechirpEnabled() ? projection.streaming_sample_count
-												   : downsampledSampleCount(projection.streaming_sample_count));
-				projection.rendered_hdf5_sample_count =
-					addBytes({.bytes = projection.rendered_hdf5_sample_count},
-							 {.bytes = rendered_samples, .overflowed = sample_count_overflowed || if_count_overflowed})
-						.bytes;
-				const auto resident_samples = if_rate_dechirped ? if_sample_count : projection.streaming_sample_count;
-				projection.streaming_iq_buffers =
-					addBytes(projection.streaming_iq_buffers,
-							 multiplyBytes(resident_samples, static_cast<std::uint64_t>(sizeof(ComplexType)),
-										   sample_count_overflowed || if_count_overflowed));
+				addStreamingReceiverProjection(projection, receiver, sample_count_overflowed);
 				continue;
 			}
 
 			if (receiver.getMode() == OperationMode::PULSED_MODE)
 			{
-				++projection.pulsed_receiver_count;
-				bool window_count_overflowed = false;
-				const auto windows = countPulsedWindows(receiver, window_count_overflowed);
-				projection.pulsed_window_count = addBytes({.bytes = projection.pulsed_window_count},
-														  {.bytes = windows, .overflowed = window_count_overflowed})
-													 .bytes;
-
-				bool pulsed_sample_count_overflowed = false;
-				const auto raw_window_samples = countSamplesForDuration(
-					receiver.getWindowLength(), projection.simulation_sample_rate_hz, pulsed_sample_count_overflowed);
-				const auto rendered_window_samples = downsampledSampleCount(raw_window_samples);
-				const auto rendered_samples = multiplyBytes(windows, rendered_window_samples,
-															window_count_overflowed || pulsed_sample_count_overflowed);
-				projection.rendered_hdf5_sample_count =
-					addBytes({.bytes = projection.rendered_hdf5_sample_count}, rendered_samples).bytes;
+				addPulsedReceiverProjection(projection, receiver);
 			}
 		}
 

--- a/packages/libfers/src/core/memory_projection.cpp
+++ b/packages/libfers/src/core/memory_projection.cpp
@@ -238,7 +238,7 @@ namespace core
 		[[nodiscard]] std::optional<std::uint64_t> currentResidentSetBytes() noexcept
 		{
 #if defined(__linux__)
-			long page_size = sysconf(_SC_PAGESIZE);
+			long const page_size = sysconf(_SC_PAGESIZE);
 			if (page_size <= 0)
 			{
 				return std::nullopt;

--- a/packages/libfers/src/core/memory_projection.cpp
+++ b/packages/libfers/src/core/memory_projection.cpp
@@ -454,9 +454,9 @@ namespace core
 		}
 		if (unit_index == 0)
 		{
-			return std::format("{} {}", bytes, units[unit_index]);
+			return std::format("{} {}", bytes, units.at(unit_index));
 		}
-		return std::format("{:.2f} {}", static_cast<double>(value), units[unit_index]);
+		return std::format("{:.2f} {}", static_cast<double>(value), units.at(unit_index));
 	}
 
 	std::string memoryProjectionToJsonString(const SimulationMemoryProjection& projection)

--- a/packages/libfers/src/core/output_config.h
+++ b/packages/libfers/src/core/output_config.h
@@ -14,7 +14,7 @@
 
 namespace core
 {
-	enum class OutputMode
+	enum class OutputMode : std::uint8_t
 	{
 		Hdf5,
 		Vita49Udp

--- a/packages/libfers/src/core/output_metadata.cpp
+++ b/packages/libfers/src/core/output_metadata.cpp
@@ -389,13 +389,13 @@ namespace core
 
 	void OutputMetadataCollector::addFile(OutputFileMetadata file_metadata)
 	{
-		std::scoped_lock lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		_metadata.files.push_back(std::move(file_metadata));
 	}
 
 	OutputMetadata OutputMetadataCollector::snapshot() const
 	{
-		std::scoped_lock lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		return _metadata;
 	}
 

--- a/packages/libfers/src/core/output_metadata.cpp
+++ b/packages/libfers/src/core/output_metadata.cpp
@@ -128,6 +128,54 @@ namespace core
 			return result;
 		}
 
+		template <typename T>
+		void addOptional(nlohmann::json& result, const char* key, const std::optional<T>& value)
+		{
+			if (value.has_value())
+			{
+				result[key] = *value;
+			}
+		}
+
+		void addDechirpReferenceJson(nlohmann::json& result, const OutputFileMetadata& file)
+		{
+			addOptional(result, "fmcw_dechirp_reference_transmitter_id", file.fmcw_dechirp_reference_transmitter_id);
+			addOptional(result, "fmcw_dechirp_reference_transmitter_name",
+						file.fmcw_dechirp_reference_transmitter_name);
+			addOptional(result, "fmcw_dechirp_reference_waveform_id", file.fmcw_dechirp_reference_waveform_id);
+			addOptional(result, "fmcw_dechirp_reference_waveform_name", file.fmcw_dechirp_reference_waveform_name);
+			if (file.fmcw_dechirp_reference_waveform.has_value())
+			{
+				result["fmcw_dechirp_reference_waveform"] = fmcwToJson(*file.fmcw_dechirp_reference_waveform);
+			}
+		}
+
+		void addFmcwIfJson(nlohmann::json& result, const OutputFileMetadata& file)
+		{
+			result["fmcw_if_decimation_enabled"] = file.fmcw_if_decimation_enabled;
+			result["fmcw_if_legacy_full_rate"] = file.fmcw_if_legacy_full_rate;
+			addOptional(result, "fmcw_if_requested_sample_rate", file.fmcw_if_requested_sample_rate);
+			addOptional(result, "fmcw_if_sample_rate", file.fmcw_if_sample_rate);
+			addOptional(result, "fmcw_if_input_sample_rate", file.fmcw_if_input_sample_rate);
+			addOptional(result, "fmcw_if_resample_numerator", file.fmcw_if_resample_numerator);
+			addOptional(result, "fmcw_if_resample_denominator", file.fmcw_if_resample_denominator);
+			addOptional(result, "fmcw_if_decimation_factor", file.fmcw_if_decimation_factor);
+			addOptional(result, "fmcw_if_filter_bandwidth", file.fmcw_if_filter_bandwidth);
+			addOptional(result, "fmcw_if_filter_transition_width", file.fmcw_if_filter_transition_width);
+			addOptional(result, "fmcw_if_filter_stopband", file.fmcw_if_filter_stopband);
+			addOptional(result, "fmcw_if_filter_group_delay_seconds", file.fmcw_if_filter_group_delay_seconds);
+			addOptional(result, "fmcw_if_compensated_integer_delay_samples",
+						file.fmcw_if_compensated_integer_delay_samples);
+			addOptional(result, "fmcw_if_compensated_fractional_delay_samples",
+						file.fmcw_if_compensated_fractional_delay_samples);
+			addOptional(result, "fmcw_if_warmup_discard_samples", file.fmcw_if_warmup_discard_samples);
+			addOptional(result, "fmcw_if_phase_refinement", file.fmcw_if_phase_refinement);
+			addOptional(result, "fmcw_if_timing_error_seconds", file.fmcw_if_timing_error_seconds);
+			addOptional(result, "fmcw_if_phase_error_radians", file.fmcw_if_phase_error_radians);
+			addOptional(result, "fmcw_if_noise_variance", file.fmcw_if_noise_variance);
+			result["fmcw_if_group_delay_compensated"] = file.fmcw_if_group_delay_compensated;
+		}
+
 		/// Converts one output file metadata entry to JSON.
 		nlohmann::json fileToJson(const OutputFileMetadata& file)
 		{
@@ -170,98 +218,8 @@ namespace core
 			{
 				result["fmcw"] = fmcwToJson(*file.fmcw);
 			}
-			if (file.fmcw_dechirp_reference_transmitter_id.has_value())
-			{
-				result["fmcw_dechirp_reference_transmitter_id"] = *file.fmcw_dechirp_reference_transmitter_id;
-			}
-			if (file.fmcw_dechirp_reference_transmitter_name.has_value())
-			{
-				result["fmcw_dechirp_reference_transmitter_name"] = *file.fmcw_dechirp_reference_transmitter_name;
-			}
-			if (file.fmcw_dechirp_reference_waveform_id.has_value())
-			{
-				result["fmcw_dechirp_reference_waveform_id"] = *file.fmcw_dechirp_reference_waveform_id;
-			}
-			if (file.fmcw_dechirp_reference_waveform_name.has_value())
-			{
-				result["fmcw_dechirp_reference_waveform_name"] = *file.fmcw_dechirp_reference_waveform_name;
-			}
-			if (file.fmcw_dechirp_reference_waveform.has_value())
-			{
-				result["fmcw_dechirp_reference_waveform"] = fmcwToJson(*file.fmcw_dechirp_reference_waveform);
-			}
-			result["fmcw_if_decimation_enabled"] = file.fmcw_if_decimation_enabled;
-			result["fmcw_if_legacy_full_rate"] = file.fmcw_if_legacy_full_rate;
-			if (file.fmcw_if_requested_sample_rate.has_value())
-			{
-				result["fmcw_if_requested_sample_rate"] = *file.fmcw_if_requested_sample_rate;
-			}
-			if (file.fmcw_if_sample_rate.has_value())
-			{
-				result["fmcw_if_sample_rate"] = *file.fmcw_if_sample_rate;
-			}
-			if (file.fmcw_if_input_sample_rate.has_value())
-			{
-				result["fmcw_if_input_sample_rate"] = *file.fmcw_if_input_sample_rate;
-			}
-			if (file.fmcw_if_resample_numerator.has_value())
-			{
-				result["fmcw_if_resample_numerator"] = *file.fmcw_if_resample_numerator;
-			}
-			if (file.fmcw_if_resample_denominator.has_value())
-			{
-				result["fmcw_if_resample_denominator"] = *file.fmcw_if_resample_denominator;
-			}
-			if (file.fmcw_if_decimation_factor.has_value())
-			{
-				result["fmcw_if_decimation_factor"] = *file.fmcw_if_decimation_factor;
-			}
-			if (file.fmcw_if_filter_bandwidth.has_value())
-			{
-				result["fmcw_if_filter_bandwidth"] = *file.fmcw_if_filter_bandwidth;
-			}
-			if (file.fmcw_if_filter_transition_width.has_value())
-			{
-				result["fmcw_if_filter_transition_width"] = *file.fmcw_if_filter_transition_width;
-			}
-			if (file.fmcw_if_filter_stopband.has_value())
-			{
-				result["fmcw_if_filter_stopband"] = *file.fmcw_if_filter_stopband;
-			}
-			if (file.fmcw_if_filter_group_delay_seconds.has_value())
-			{
-				result["fmcw_if_filter_group_delay_seconds"] = *file.fmcw_if_filter_group_delay_seconds;
-			}
-			if (file.fmcw_if_compensated_integer_delay_samples.has_value())
-			{
-				result["fmcw_if_compensated_integer_delay_samples"] = *file.fmcw_if_compensated_integer_delay_samples;
-			}
-			if (file.fmcw_if_compensated_fractional_delay_samples.has_value())
-			{
-				result["fmcw_if_compensated_fractional_delay_samples"] =
-					*file.fmcw_if_compensated_fractional_delay_samples;
-			}
-			if (file.fmcw_if_warmup_discard_samples.has_value())
-			{
-				result["fmcw_if_warmup_discard_samples"] = *file.fmcw_if_warmup_discard_samples;
-			}
-			if (file.fmcw_if_phase_refinement.has_value())
-			{
-				result["fmcw_if_phase_refinement"] = *file.fmcw_if_phase_refinement;
-			}
-			if (file.fmcw_if_timing_error_seconds.has_value())
-			{
-				result["fmcw_if_timing_error_seconds"] = *file.fmcw_if_timing_error_seconds;
-			}
-			if (file.fmcw_if_phase_error_radians.has_value())
-			{
-				result["fmcw_if_phase_error_radians"] = *file.fmcw_if_phase_error_radians;
-			}
-			if (file.fmcw_if_noise_variance.has_value())
-			{
-				result["fmcw_if_noise_variance"] = *file.fmcw_if_noise_variance;
-			}
-			result["fmcw_if_group_delay_compensated"] = file.fmcw_if_group_delay_compensated;
+			addDechirpReferenceJson(result, file);
+			addFmcwIfJson(result, file);
 			return result;
 		}
 

--- a/packages/libfers/src/core/parameters.h
+++ b/packages/libfers/src/core/parameters.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <expected>
 #include <optional>
 #include <string>
@@ -26,7 +27,7 @@ namespace params
 	 * @enum CoordinateFrame
 	 * @brief Defines the coordinate systems supported for KML/geospatial export.
 	 */
-	enum class CoordinateFrame
+	enum class CoordinateFrame : std::uint8_t
 	{
 		ENU, ///< East-North-Up local tangent plane (default)
 		UTM, ///< Universal Transverse Mercator
@@ -37,7 +38,7 @@ namespace params
 	 * @enum RotationAngleUnit
 	 * @brief Defines the units used at external rotation-path boundaries.
 	 */
-	enum class RotationAngleUnit
+	enum class RotationAngleUnit : std::uint8_t
 	{
 		Degrees, ///< Compass azimuth and elevation expressed in degrees
 		Radians ///< Compass azimuth and elevation expressed in radians

--- a/packages/libfers/src/core/receiver_output.h
+++ b/packages/libfers/src/core/receiver_output.h
@@ -38,7 +38,7 @@ namespace core
 		struct PlatformState
 		{
 			SimId platform_id = 0;
-			std::string platform_name;
+			std::string platform_name = {};
 			RealType position_x = 0.0;
 			RealType position_y = 0.0;
 			RealType position_z = 0.0;
@@ -52,13 +52,13 @@ namespace core
 		struct FmcwContext
 		{
 			bool present = false;
-			std::string waveform_shape;
+			std::string waveform_shape = {};
 			RealType chirp_bandwidth = 0.0;
 			RealType chirp_duration = 0.0;
 			RealType chirp_period = 0.0;
 			RealType chirp_rate = 0.0;
 			RealType chirp_rate_signed = 0.0;
-			std::string sweep_direction;
+			std::string sweep_direction = {};
 			RealType start_frequency_offset = 0.0;
 			std::optional<RealType> triangle_period = std::nullopt;
 			std::optional<std::uint64_t> chirp_count = std::nullopt;
@@ -66,9 +66,9 @@ namespace core
 			std::string dechirp_mode = "none";
 			std::string dechirp_reference_source = "none";
 			SimId dechirp_reference_transmitter_id = 0;
-			std::string dechirp_reference_transmitter_name;
+			std::string dechirp_reference_transmitter_name = {};
 			SimId dechirp_reference_waveform_id = 0;
-			std::string dechirp_reference_waveform_name;
+			std::string dechirp_reference_waveform_name = {};
 		};
 
 		struct PulsedContext
@@ -79,7 +79,7 @@ namespace core
 			RealType window_skip = 0.0;
 			std::uint64_t window_count = 0;
 			SimId waveform_id = 0;
-			std::string waveform_name;
+			std::string waveform_name = {};
 			RealType carrier_frequency = 0.0;
 			RealType power = 0.0;
 			RealType pulse_width = 0.0;
@@ -91,14 +91,14 @@ namespace core
 		{
 			bool present = false;
 			SimId waveform_id = 0;
-			std::string waveform_name;
+			std::string waveform_name = {};
 			RealType carrier_frequency = 0.0;
 			RealType power = 0.0;
 		};
 
 		SimId receiver_id = 0;
-		std::string receiver_name;
-		std::string mode;
+		std::string receiver_name = {};
+		std::string mode = {};
 		RealType sample_rate = 0.0;
 		RealType reference_frequency = 0.0;
 		RealType if_offset = 0.0;
@@ -106,11 +106,11 @@ namespace core
 		bool dechirped = false;
 		bool if_resampled = false;
 		unsigned adc_bits = 0;
-		CoordinateContext coordinate;
-		PlatformState initial_platform_state;
-		PulsedContext pulsed;
-		CwContext cw;
-		FmcwContext fmcw;
+		CoordinateContext coordinate = {};
+		PlatformState initial_platform_state = {};
+		PulsedContext pulsed = {};
+		CwContext cw = {};
+		FmcwContext fmcw = {};
 	};
 
 	struct ReceiverSampleBlock

--- a/packages/libfers/src/core/sim_events.h
+++ b/packages/libfers/src/core/sim_events.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "config.h"
 
 namespace radar
@@ -24,7 +26,7 @@ namespace core
 	 * @enum EventType
 	 * @brief Enumerates the types of events that can occur in the simulation.
 	 */
-	enum class EventType
+	enum class EventType : std::uint8_t
 	{
 		TX_PULSED_START, ///< A pulsed transmitter begins emitting a pulse.
 		RX_PULSED_WINDOW_START, ///< A pulsed receiver opens its listening window.

--- a/packages/libfers/src/core/sim_threading.cpp
+++ b/packages/libfers/src/core/sim_threading.cpp
@@ -166,6 +166,32 @@ namespace core
 			}
 		}
 
+		[[nodiscard]] RealType axisValue(const std::array<RealType, 3>& values, const std::size_t axis) noexcept
+		{
+			switch (axis)
+			{
+			case 0:
+				return values[0];
+			case 1:
+				return values[1];
+			default:
+				return values[2];
+			}
+		}
+
+		[[nodiscard]] RealType& axisValue(std::array<RealType, 3>& values, const std::size_t axis) noexcept
+		{
+			switch (axis)
+			{
+			case 0:
+				return values[0];
+			case 1:
+				return values[1];
+			default:
+				return values[2];
+			}
+		}
+
 		[[nodiscard]] RealType axisDistanceBound(const PositionBounds& lhs, const PositionBounds& rhs,
 												 const std::size_t axis) noexcept
 		{
@@ -222,9 +248,12 @@ namespace core
 
 			for (std::size_t axis = 0; axis < 3; ++axis)
 			{
-				const RealType a = 0.5 * h2 * (dd_right[axis] - dd_left[axis]);
-				const RealType b = h2 * dd_left[axis];
-				const RealType c = (right[axis] - left[axis]) + (h2 / 6.0) * (-2.0 * dd_left[axis] - dd_right[axis]);
+				const RealType dd_right_axis = axisValue(dd_right, axis);
+				const RealType dd_left_axis = axisValue(dd_left, axis);
+				const RealType a = 0.5 * h2 * (dd_right_axis - dd_left_axis);
+				const RealType b = h2 * dd_left_axis;
+				const RealType c = (axisValue(right, axis) - axisValue(left, axis)) +
+					(h2 / 6.0) * (-2.0 * dd_left_axis - dd_right_axis);
 
 				if (std::abs(a) <= EPSILON)
 				{
@@ -333,11 +362,12 @@ namespace core
 			const RealType velocity = (a * root_u * root_u + b * root_u + c) / segment_length;
 			if (std::isfinite(velocity))
 			{
-				max_abs_velocity[axis] = std::max(max_abs_velocity[axis], std::abs(velocity));
+				RealType& axis_max_velocity = axisValue(max_abs_velocity, axis);
+				axis_max_velocity = std::max(axis_max_velocity, std::abs(velocity));
 			}
 			else
 			{
-				max_abs_velocity[axis] = std::numeric_limits<RealType>::infinity();
+				axisValue(max_abs_velocity, axis) = std::numeric_limits<RealType>::infinity();
 			}
 		}
 
@@ -359,9 +389,12 @@ namespace core
 
 			for (std::size_t axis = 0; axis < 3; ++axis)
 			{
-				const RealType a = 0.5 * h2 * (dd_right[axis] - dd_left[axis]);
-				const RealType b = h2 * dd_left[axis];
-				const RealType c = (right[axis] - left[axis]) + (h2 / 6.0) * (-2.0 * dd_left[axis] - dd_right[axis]);
+				const RealType dd_right_axis = axisValue(dd_right, axis);
+				const RealType dd_left_axis = axisValue(dd_left, axis);
+				const RealType a = 0.5 * h2 * (dd_right_axis - dd_left_axis);
+				const RealType b = h2 * dd_left_axis;
+				const RealType c = (axisValue(right, axis) - axisValue(left, axis)) +
+					(h2 / 6.0) * (-2.0 * dd_left_axis - dd_right_axis);
 				includeQuadraticVelocityExtremum(max_abs_velocity, axis, a, b, c, segment_length, lower_u, lower_u,
 												 upper_u);
 				includeQuadraticVelocityExtremum(max_abs_velocity, axis, a, b, c, segment_length, upper_u, lower_u,
@@ -587,7 +620,8 @@ namespace core
 		_world(world), _pool(pool), _reporter(std::move(reporter)), _metadata_collector(std::move(metadata_collector)),
 		_output_sink(output_sink), _cancel_callback(std::move(cancel_callback)),
 		_eager_context_stream_open(eager_context_stream_open), _last_report_time(std::chrono::steady_clock::now()),
-		_next_context_heartbeat_time(params::startTime() + 1.0), _output_dir(std::move(output_dir))
+		_next_context_heartbeat_time(params::startTime() + 1.0), _output_dir(std::move(output_dir)),
+		_internal_stop_time(params::endTime())
 	{
 		_streaming_tracker_caches.resize(_world->getReceivers().size());
 		_if_pulse_tracker_caches.resize(_world->getReceivers().size());
@@ -612,7 +646,6 @@ namespace core
 		{
 			block.reserve(streaming_output_block_size);
 		}
-		_internal_stop_time = params::endTime();
 	}
 
 	void SimulationEngine::run()

--- a/packages/libfers/src/core/sim_threading.cpp
+++ b/packages/libfers/src/core/sim_threading.cpp
@@ -350,16 +350,28 @@ namespace core
 			return bounds;
 		}
 
-		void includeQuadraticVelocityExtremum(std::array<RealType, 3>& max_abs_velocity, const std::size_t axis,
-											  const RealType a, const RealType b, const RealType c,
-											  const RealType segment_length, const RealType root_u,
-											  const RealType lower_u, const RealType upper_u) noexcept
+		struct QuadraticVelocityExtremum
 		{
-			if (root_u < lower_u || root_u > upper_u || segment_length <= EPSILON)
+			RealType a;
+			RealType b;
+			RealType c;
+			RealType segment_length;
+			RealType root_u;
+			RealType lower_u;
+			RealType upper_u;
+		};
+
+		void includeQuadraticVelocityExtremum(std::array<RealType, 3>& max_abs_velocity, const std::size_t axis,
+											  const QuadraticVelocityExtremum& extremum) noexcept
+		{
+			if (extremum.root_u < extremum.lower_u || extremum.root_u > extremum.upper_u ||
+				extremum.segment_length <= EPSILON)
 			{
 				return;
 			}
-			const RealType velocity = (a * root_u * root_u + b * root_u + c) / segment_length;
+			const RealType velocity =
+				(extremum.a * extremum.root_u * extremum.root_u + extremum.b * extremum.root_u + extremum.c) /
+				extremum.segment_length;
 			if (std::isfinite(velocity))
 			{
 				RealType& axis_max_velocity = axisValue(max_abs_velocity, axis);
@@ -395,15 +407,33 @@ namespace core
 				const RealType b = h2 * dd_left_axis;
 				const RealType c = (axisValue(right, axis) - axisValue(left, axis)) +
 					(h2 / 6.0) * (-2.0 * dd_left_axis - dd_right_axis);
-				includeQuadraticVelocityExtremum(max_abs_velocity, axis, a, b, c, segment_length, lower_u, lower_u,
-												 upper_u);
-				includeQuadraticVelocityExtremum(max_abs_velocity, axis, a, b, c, segment_length, upper_u, lower_u,
-												 upper_u);
+				includeQuadraticVelocityExtremum(max_abs_velocity, axis,
+												 QuadraticVelocityExtremum{.a = a,
+																		   .b = b,
+																		   .c = c,
+																		   .segment_length = segment_length,
+																		   .root_u = lower_u,
+																		   .lower_u = lower_u,
+																		   .upper_u = upper_u});
+				includeQuadraticVelocityExtremum(max_abs_velocity, axis,
+												 QuadraticVelocityExtremum{.a = a,
+																		   .b = b,
+																		   .c = c,
+																		   .segment_length = segment_length,
+																		   .root_u = upper_u,
+																		   .lower_u = lower_u,
+																		   .upper_u = upper_u});
 
 				if (std::abs(a) > EPSILON)
 				{
-					includeQuadraticVelocityExtremum(max_abs_velocity, axis, a, b, c, segment_length, -b / (2.0 * a),
-													 lower_u, upper_u);
+					includeQuadraticVelocityExtremum(max_abs_velocity, axis,
+													 QuadraticVelocityExtremum{.a = a,
+																			   .b = b,
+																			   .c = c,
+																			   .segment_length = segment_length,
+																			   .root_u = -b / (2.0 * a),
+																			   .lower_u = lower_u,
+																			   .upper_u = upper_u});
 				}
 			}
 		}

--- a/packages/libfers/src/core/sim_threading.cpp
+++ b/packages/libfers/src/core/sim_threading.cpp
@@ -1944,7 +1944,7 @@ namespace core
 				auto vita49_metadata = vita49MetadataFromConfig(output_config.vita49);
 				if (stats.epoch_unix_nanoseconds.has_value())
 				{
-					vita49_metadata.epoch_unix_nanoseconds = *stats.epoch_unix_nanoseconds;
+					vita49_metadata.epoch_unix_nanoseconds = stats.epoch_unix_nanoseconds;
 				}
 				for (const auto& stream : stats.streams)
 				{

--- a/packages/libfers/src/core/sim_threading.cpp
+++ b/packages/libfers/src/core/sim_threading.cpp
@@ -1095,7 +1095,7 @@ namespace core
 			return;
 		}
 
-		auto& receiver = _world->getReceivers()[receiver_index];
+		const auto& receiver = _world->getReceivers()[receiver_index];
 		const bool dechirped = receiver->isDechirpEnabled();
 		const RealType input_sample_rate = params::rate() * static_cast<RealType>(params::oversampleRatio());
 		const RealType block_start_time = _streaming_output_block_start_times[receiver_index];
@@ -1191,7 +1191,7 @@ namespace core
 			return;
 		}
 
-		auto& receiver = _world->getReceivers()[receiver_index];
+		const auto& receiver = _world->getReceivers()[receiver_index];
 		auto streaming_sources = collectStreamingSourcesForWindow(params::startTime(), params::endTime());
 		if (_streaming_output_stream_ids[receiver_index] == 0)
 		{
@@ -1221,7 +1221,7 @@ namespace core
 			return;
 		}
 
-		auto& receiver = _world->getReceivers()[receiver_index];
+		const auto& receiver = _world->getReceivers()[receiver_index];
 		auto& processed = _streaming_output_processed_buffers[receiver_index];
 		processed.assign(samples.begin(), samples.end());
 		processing::applyThermalNoiseAtSampleRate(processed, receiver->getNoiseTemperature(), receiver->getRngEngine(),
@@ -1278,7 +1278,7 @@ namespace core
 		{
 			return;
 		}
-		auto& receiver = _world->getReceivers()[receiver_index];
+		const auto& receiver = _world->getReceivers()[receiver_index];
 		if (!receiver->hasFmcwIfResamplingSink())
 		{
 			block.clear();
@@ -1309,7 +1309,7 @@ namespace core
 			return;
 		}
 
-		auto& receiver = _world->getReceivers()[receiver_index];
+		const auto& receiver = _world->getReceivers()[receiver_index];
 		if (!std::isfinite(sample_rate) || sample_rate <= 0.0)
 		{
 			return;

--- a/packages/libfers/src/core/sim_threading.cpp
+++ b/packages/libfers/src/core/sim_threading.cpp
@@ -89,6 +89,115 @@ namespace core
 										.end_timestamp = stats.end_timestamp};
 		}
 
+		[[nodiscard]] std::string fmcwCountToken(const std::optional<std::size_t>& count)
+		{
+			return count.has_value() ? std::format("{}", *count) : std::string("unbounded");
+		}
+
+		void logUnscheduledFmcwChirpSummary(const Transmitter& transmitter, const fers_signal::FmcwChirpSignal& fmcw,
+											const std::string& direction, const std::string& configured_count,
+											const RealType duty_cycle, const RealType average_power)
+		{
+			const RealType active_start = params::startTime();
+			const auto source = makeActiveSource(&transmitter, active_start, params::endTime());
+			const auto total_chirp_count = countFmcwChirpStarts(source, active_start, source.segment_end);
+			LOG(Level::INFO,
+				"FMCW transmitter '{}' shape=linear {} B={} Hz T_c={} s T_rep={} s f_0={} Hz alpha={} Hz/s "
+				"duty_cycle={} chirp_count={} total_chirp_count={} average_power={} W",
+				transmitter.getName(), direction, fmcw.getChirpBandwidth(), fmcw.getChirpDuration(),
+				fmcw.getChirpPeriod(), fmcw.getStartFrequencyOffset(), fmcw.getChirpRate(), duty_cycle,
+				configured_count, total_chirp_count, average_power);
+		}
+
+		void logScheduledFmcwChirpSummary(const Transmitter& transmitter, const fers_signal::FmcwChirpSignal& fmcw,
+										  const std::string& direction, const std::string& configured_count,
+										  const RealType duty_cycle, const RealType average_power)
+		{
+			std::uint64_t total_chirp_count = 0;
+			for (const auto& period : transmitter.getSchedule())
+			{
+				const RealType active_start = std::max(params::startTime(), period.start);
+				const auto source =
+					makeActiveSource(&transmitter, period.start, std::min(params::endTime(), period.end));
+				const auto segment_chirp_count = countFmcwChirpStarts(source, active_start, source.segment_end);
+				total_chirp_count += segment_chirp_count;
+				LOG(Level::INFO,
+					"FMCW transmitter '{}' segment [{}, {}] shape=linear {} B={} Hz T_c={} s T_rep={} s f_0={} "
+					"Hz alpha={} Hz/s duty_cycle={} chirp_count={} segment_chirp_count={} total_chirp_count={} "
+					"average_power={} W",
+					transmitter.getName(), period.start, source.segment_end, direction, fmcw.getChirpBandwidth(),
+					fmcw.getChirpDuration(), fmcw.getChirpPeriod(), fmcw.getStartFrequencyOffset(), fmcw.getChirpRate(),
+					duty_cycle, configured_count, segment_chirp_count, total_chirp_count, average_power);
+			}
+		}
+
+		void logFmcwChirpSummary(const Transmitter& transmitter, const fers_signal::RadarSignal& waveform,
+								 const fers_signal::FmcwChirpSignal& fmcw)
+		{
+			const RealType duty_cycle = fmcw.getChirpDuration() / fmcw.getChirpPeriod();
+			const RealType average_power = waveform.getPower() * duty_cycle;
+			const std::string direction(fers_signal::fmcwChirpDirectionToken(fmcw.getDirection()));
+			const auto configured_count = fmcwCountToken(fmcw.getChirpCount());
+			if (transmitter.getSchedule().empty())
+			{
+				logUnscheduledFmcwChirpSummary(transmitter, fmcw, direction, configured_count, duty_cycle,
+											   average_power);
+				return;
+			}
+			logScheduledFmcwChirpSummary(transmitter, fmcw, direction, configured_count, duty_cycle, average_power);
+		}
+
+		void logUnscheduledFmcwTriangleSummary(const Transmitter& transmitter,
+											   const fers_signal::FmcwTriangleSignal& triangle,
+											   const std::string& configured_count, const RealType average_power)
+		{
+			const RealType active_start = params::startTime();
+			const auto source = makeActiveSource(&transmitter, active_start, params::endTime());
+			const auto total_triangle_count = countFmcwTriangleStarts(source, active_start, source.segment_end);
+			LOG(Level::INFO,
+				"FMCW transmitter '{}' shape=triangle B={} Hz T_c={} s T_tri={} s f_0={} Hz alpha={} Hz/s "
+				"duty_cycle=1 triangle_count={} total_triangle_count={} average_power={} W",
+				transmitter.getName(), triangle.getChirpBandwidth(), triangle.getChirpDuration(),
+				triangle.getTrianglePeriod(), triangle.getStartFrequencyOffset(), triangle.getChirpRate(),
+				configured_count, total_triangle_count, average_power);
+		}
+
+		void logScheduledFmcwTriangleSummary(const Transmitter& transmitter,
+											 const fers_signal::FmcwTriangleSignal& triangle,
+											 const std::string& configured_count, const RealType average_power)
+		{
+			std::uint64_t total_triangle_count = 0;
+			for (const auto& period : transmitter.getSchedule())
+			{
+				const RealType active_start = std::max(params::startTime(), period.start);
+				const auto source =
+					makeActiveSource(&transmitter, period.start, std::min(params::endTime(), period.end));
+				const auto segment_triangle_count = countFmcwTriangleStarts(source, active_start, source.segment_end);
+				total_triangle_count += segment_triangle_count;
+				LOG(Level::INFO,
+					"FMCW transmitter '{}' segment [{}, {}] shape=triangle B={} Hz T_c={} s T_tri={} s f_0={} "
+					"Hz alpha={} Hz/s duty_cycle=1 triangle_count={} segment_triangle_count={} "
+					"total_triangle_count={} average_power={} W",
+					transmitter.getName(), period.start, source.segment_end, triangle.getChirpBandwidth(),
+					triangle.getChirpDuration(), triangle.getTrianglePeriod(), triangle.getStartFrequencyOffset(),
+					triangle.getChirpRate(), configured_count, segment_triangle_count, total_triangle_count,
+					average_power);
+			}
+		}
+
+		void logFmcwTriangleSummary(const Transmitter& transmitter, const fers_signal::RadarSignal& waveform,
+									const fers_signal::FmcwTriangleSignal& triangle)
+		{
+			const RealType average_power = waveform.getPower();
+			const auto configured_count = fmcwCountToken(triangle.getTriangleCount());
+			if (transmitter.getSchedule().empty())
+			{
+				logUnscheduledFmcwTriangleSummary(transmitter, triangle, configured_count, average_power);
+				return;
+			}
+			logScheduledFmcwTriangleSummary(transmitter, triangle, configured_count, average_power);
+		}
+
 		[[nodiscard]] bool isStreamingReceiver(const Receiver* const receiver) noexcept
 		{
 			return receiver != nullptr &&
@@ -746,84 +855,11 @@ namespace core
 
 			if (const auto* fmcw = waveform->getFmcwChirpSignal(); fmcw != nullptr)
 			{
-				const RealType duty_cycle = fmcw->getChirpDuration() / fmcw->getChirpPeriod();
-				const RealType average_power = waveform->getPower() * duty_cycle;
-				const auto direction = fers_signal::fmcwChirpDirectionToken(fmcw->getDirection());
-				const auto configured_count = fmcw->getChirpCount().has_value()
-					? std::format("{}", *fmcw->getChirpCount())
-					: std::string("unbounded");
-				if (transmitter_ptr->getSchedule().empty())
-				{
-					const RealType active_start = params::startTime();
-					const auto source = makeActiveSource(transmitter_ptr.get(), active_start, params::endTime());
-					const auto total_chirp_count = countFmcwChirpStarts(source, active_start, source.segment_end);
-					LOG(Level::INFO,
-						"FMCW transmitter '{}' shape=linear {} B={} Hz T_c={} s T_rep={} s f_0={} Hz alpha={} Hz/s "
-						"duty_cycle={} chirp_count={} total_chirp_count={} average_power={} W",
-						transmitter_ptr->getName(), direction, fmcw->getChirpBandwidth(), fmcw->getChirpDuration(),
-						fmcw->getChirpPeriod(), fmcw->getStartFrequencyOffset(), fmcw->getChirpRate(), duty_cycle,
-						configured_count, total_chirp_count, average_power);
-				}
-				else
-				{
-					std::uint64_t total_chirp_count = 0;
-					for (const auto& period : transmitter_ptr->getSchedule())
-					{
-						const RealType active_start = std::max(params::startTime(), period.start);
-						const auto source = makeActiveSource(transmitter_ptr.get(), period.start,
-															 std::min(params::endTime(), period.end));
-						const auto segment_chirp_count = countFmcwChirpStarts(source, active_start, source.segment_end);
-						total_chirp_count += segment_chirp_count;
-						LOG(Level::INFO,
-							"FMCW transmitter '{}' segment [{}, {}] shape=linear {} B={} Hz T_c={} s T_rep={} s f_0={} "
-							"Hz alpha={} Hz/s duty_cycle={} chirp_count={} segment_chirp_count={} total_chirp_count={} "
-							"average_power={} W",
-							transmitter_ptr->getName(), period.start, source.segment_end, direction,
-							fmcw->getChirpBandwidth(), fmcw->getChirpDuration(), fmcw->getChirpPeriod(),
-							fmcw->getStartFrequencyOffset(), fmcw->getChirpRate(), duty_cycle, configured_count,
-							segment_chirp_count, total_chirp_count, average_power);
-					}
-				}
+				logFmcwChirpSummary(*transmitter_ptr, *waveform, *fmcw);
 			}
 			else if (const auto* triangle = waveform->getFmcwTriangleSignal(); triangle != nullptr)
 			{
-				const RealType average_power = waveform->getPower();
-				const auto configured_count = triangle->getTriangleCount().has_value()
-					? std::format("{}", *triangle->getTriangleCount())
-					: std::string("unbounded");
-				if (transmitter_ptr->getSchedule().empty())
-				{
-					const RealType active_start = params::startTime();
-					const auto source = makeActiveSource(transmitter_ptr.get(), active_start, params::endTime());
-					const auto total_triangle_count = countFmcwTriangleStarts(source, active_start, source.segment_end);
-					LOG(Level::INFO,
-						"FMCW transmitter '{}' shape=triangle B={} Hz T_c={} s T_tri={} s f_0={} Hz alpha={} Hz/s "
-						"duty_cycle=1 triangle_count={} total_triangle_count={} average_power={} W",
-						transmitter_ptr->getName(), triangle->getChirpBandwidth(), triangle->getChirpDuration(),
-						triangle->getTrianglePeriod(), triangle->getStartFrequencyOffset(), triangle->getChirpRate(),
-						configured_count, total_triangle_count, average_power);
-				}
-				else
-				{
-					std::uint64_t total_triangle_count = 0;
-					for (const auto& period : transmitter_ptr->getSchedule())
-					{
-						const RealType active_start = std::max(params::startTime(), period.start);
-						const auto source = makeActiveSource(transmitter_ptr.get(), period.start,
-															 std::min(params::endTime(), period.end));
-						const auto segment_triangle_count =
-							countFmcwTriangleStarts(source, active_start, source.segment_end);
-						total_triangle_count += segment_triangle_count;
-						LOG(Level::INFO,
-							"FMCW transmitter '{}' segment [{}, {}] shape=triangle B={} Hz T_c={} s T_tri={} s f_0={} "
-							"Hz alpha={} Hz/s duty_cycle=1 triangle_count={} segment_triangle_count={} "
-							"total_triangle_count={} average_power={} W",
-							transmitter_ptr->getName(), period.start, source.segment_end, triangle->getChirpBandwidth(),
-							triangle->getChirpDuration(), triangle->getTrianglePeriod(),
-							triangle->getStartFrequencyOffset(), triangle->getChirpRate(), configured_count,
-							segment_triangle_count, total_triangle_count, average_power);
-					}
-				}
+				logFmcwTriangleSummary(*transmitter_ptr, *waveform, *triangle);
 			}
 		}
 	}
@@ -850,61 +886,66 @@ namespace core
 		_internal_stop_time = params::endTime();
 		for (std::size_t receiver_index = 0; receiver_index < _world->getReceivers().size(); ++receiver_index)
 		{
-			const auto& receiver_ptr = _world->getReceivers()[receiver_index];
-			if (!receiver_ptr->isDechirpEnabled() || !receiver_ptr->hasFmcwIfSampleRate())
-			{
-				continue;
-			}
-
-			const auto& request = receiver_ptr->getFmcwIfChainRequest();
-			const RealType output_rate = request.sample_rate_hz.value_or(0.0);
-			const RealType bandwidth = request.filter_bandwidth_hz.value_or(0.40 * output_rate);
-			const fers_signal::FmcwIfResamplerRequest resampler_request{
-				.input_sample_rate_hz = params::rate() * static_cast<RealType>(params::oversampleRatio()),
-				.output_sample_rate_hz = output_rate,
-				.filter_bandwidth_hz = bandwidth,
-				.filter_transition_width_hz = request.filter_transition_width_hz};
-			auto plan = fers_signal::planFmcwIfResampler(resampler_request);
-			const RealType block_time =
-				static_cast<RealType>(fmcw_if_block_size) / resampler_request.input_sample_rate_hz;
-			const RealType over_render =
-				plan.group_delay_seconds + 1.0 / plan.actual_output_sample_rate_hz + block_time;
-			_internal_stop_time = std::max(_internal_stop_time, params::endTime() + over_render);
-			if (_output_sink != nullptr)
-			{
-				receiver_ptr->setFmcwIfOutputCallback(
-					[this, receiver_index](const std::span<const ComplexType> samples, const std::uint64_t sample_start)
-					{
-						const auto& receiver = _world->getReceivers()[receiver_index];
-						const auto& if_plan = receiver->getFmcwIfResamplerPlan();
-						if (!if_plan.has_value())
-						{
-							return;
-						}
-						const RealType first_sample_time = params::startTime() +
-							static_cast<RealType>(sample_start) / if_plan->actual_output_sample_rate_hz;
-						emitStreamingOutputBlock(receiver_index, first_sample_time,
-												 if_plan->actual_output_sample_rate_hz, samples, sample_start);
-					});
-			}
-			const RealType actual_output_sample_rate_hz = plan.actual_output_sample_rate_hz;
-			const auto overall_ratio = plan.overall_ratio;
-			const RealType filter_bandwidth_hz = plan.filter_bandwidth_hz;
-			const RealType filter_transition_width_hz = plan.filter_transition_width_hz;
-			receiver_ptr->initializeFmcwIfResampling(std::move(plan));
-			LOG(Level::INFO,
-				"Receiver '{}' enabled FMCW IF resampling: input_rate={} Hz requested_output_rate={} Hz "
-				"actual_output_rate={} Hz ratio={}/{} passband={} Hz transition={} Hz.",
-				receiver_ptr->getName(), resampler_request.input_sample_rate_hz, output_rate,
-				actual_output_sample_rate_hz, overall_ratio.numerator, overall_ratio.denominator, filter_bandwidth_hz,
-				filter_transition_width_hz);
+			initializeFmcwIfResampler(receiver_index);
 		}
 
-		if (_internal_stop_time <= params::endTime())
+		if (_internal_stop_time > params::endTime())
+		{
+			extendDechirpSourcesForIfOverrender();
+		}
+	}
+
+	void SimulationEngine::initializeFmcwIfResampler(const std::size_t receiver_index)
+	{
+		const auto& receiver_ptr = _world->getReceivers()[receiver_index];
+		if (!receiver_ptr->isDechirpEnabled() || !receiver_ptr->hasFmcwIfSampleRate())
 		{
 			return;
 		}
 
+		const auto& request = receiver_ptr->getFmcwIfChainRequest();
+		const RealType output_rate = request.sample_rate_hz.value_or(0.0);
+		const RealType bandwidth = request.filter_bandwidth_hz.value_or(0.40 * output_rate);
+		const fers_signal::FmcwIfResamplerRequest resampler_request{
+			.input_sample_rate_hz = params::rate() * static_cast<RealType>(params::oversampleRatio()),
+			.output_sample_rate_hz = output_rate,
+			.filter_bandwidth_hz = bandwidth,
+			.filter_transition_width_hz = request.filter_transition_width_hz};
+		auto plan = fers_signal::planFmcwIfResampler(resampler_request);
+		const RealType block_time = static_cast<RealType>(fmcw_if_block_size) / resampler_request.input_sample_rate_hz;
+		const RealType over_render = plan.group_delay_seconds + 1.0 / plan.actual_output_sample_rate_hz + block_time;
+		_internal_stop_time = std::max(_internal_stop_time, params::endTime() + over_render);
+		if (_output_sink != nullptr)
+		{
+			receiver_ptr->setFmcwIfOutputCallback(
+				[this, receiver_index](const std::span<const ComplexType> samples, const std::uint64_t sample_start)
+				{
+					const auto& receiver = _world->getReceivers()[receiver_index];
+					const auto& if_plan = receiver->getFmcwIfResamplerPlan();
+					if (!if_plan.has_value())
+					{
+						return;
+					}
+					const RealType first_sample_time = params::startTime() +
+						static_cast<RealType>(sample_start) / if_plan->actual_output_sample_rate_hz;
+					emitStreamingOutputBlock(receiver_index, first_sample_time, if_plan->actual_output_sample_rate_hz,
+											 samples, sample_start);
+				});
+		}
+		const RealType actual_output_sample_rate_hz = plan.actual_output_sample_rate_hz;
+		const auto overall_ratio = plan.overall_ratio;
+		const RealType filter_bandwidth_hz = plan.filter_bandwidth_hz;
+		const RealType filter_transition_width_hz = plan.filter_transition_width_hz;
+		receiver_ptr->initializeFmcwIfResampling(std::move(plan));
+		LOG(Level::INFO,
+			"Receiver '{}' enabled FMCW IF resampling: input_rate={} Hz requested_output_rate={} Hz "
+			"actual_output_rate={} Hz ratio={}/{} passband={} Hz transition={} Hz.",
+			receiver_ptr->getName(), resampler_request.input_sample_rate_hz, output_rate, actual_output_sample_rate_hz,
+			overall_ratio.numerator, overall_ratio.denominator, filter_bandwidth_hz, filter_transition_width_hz);
+	}
+
+	void SimulationEngine::extendDechirpSourcesForIfOverrender()
+	{
 		for (const auto& receiver_ptr : _world->getReceivers())
 		{
 			if (!receiver_ptr->hasFmcwIfSampleRate())
@@ -1359,6 +1400,37 @@ namespace core
 												true);
 	}
 
+	void SimulationEngine::addPulsedInterferenceSamples(std::span<ComplexType> block,
+														std::span<const ComplexType> rendered_pulse,
+														const long long dest_begin, const long long dest_end,
+														const std::size_t crop_offset, const RealType block_start_time,
+														const RealType sample_rate, const bool dechirp_mix,
+														Receiver* receiver, ReceiverTrackerCache& tracker_cache) const
+	{
+		for (long long dest = dest_begin; dest < dest_end; ++dest)
+		{
+			const RealType t_sample = block_start_time + static_cast<RealType>(dest) / sample_rate;
+			const auto source_index = crop_offset + static_cast<std::size_t>(dest - dest_begin);
+			if (source_index >= rendered_pulse.size())
+			{
+				continue;
+			}
+			if (dechirp_mix)
+			{
+				const auto mixer = calculateDechirpMixer(receiver, t_sample, tracker_cache);
+				if (!mixer.has_value())
+				{
+					continue;
+				}
+				block[static_cast<std::size_t>(dest)] += *mixer * std::conj(rendered_pulse[source_index]);
+			}
+			else
+			{
+				block[static_cast<std::size_t>(dest)] += rendered_pulse[source_index];
+			}
+		}
+	}
+
 	void SimulationEngine::applyPulsedInterferenceToStreamingBlock(const std::size_t receiver_index,
 																   std::span<ComplexType> block,
 																   const RealType block_start_time,
@@ -1412,30 +1484,8 @@ namespace core
 			const auto render_count = static_cast<std::size_t>(padded_end - padded_begin);
 			const auto rendered_pulse = response->renderSlice(sample_rate, render_start, render_count, 0.0);
 			const auto crop_offset = static_cast<std::size_t>(dest_begin - padded_begin);
-
-			for (long long dest = dest_begin; dest < dest_end; ++dest)
-			{
-				const RealType t_sample = block_start_time + static_cast<RealType>(dest) / sample_rate;
-				const auto source_index = crop_offset + static_cast<std::size_t>(dest - dest_begin);
-				if (source_index >= rendered_pulse.size())
-				{
-					continue;
-				}
-				if (dechirp_mix)
-				{
-					const auto mixer = calculateDechirpMixer(receiver.get(), t_sample, tracker_cache);
-					if (!mixer.has_value())
-					{
-						continue;
-					}
-					block[static_cast<std::size_t>(dest)] +=
-						*mixer * std::conj(rendered_pulse[static_cast<std::size_t>(source_index)]);
-				}
-				else
-				{
-					block[static_cast<std::size_t>(dest)] += rendered_pulse[static_cast<std::size_t>(source_index)];
-				}
-			}
+			addPulsedInterferenceSamples(block, rendered_pulse, dest_begin, dest_end, crop_offset, block_start_time,
+										 sample_rate, dechirp_mix, receiver.get(), tracker_cache);
 		}
 	}
 

--- a/packages/libfers/src/core/sim_threading.cpp
+++ b/packages/libfers/src/core/sim_threading.cpp
@@ -794,7 +794,7 @@ namespace core
 			}
 
 			const auto& request = receiver_ptr->getFmcwIfChainRequest();
-			const RealType output_rate = *request.sample_rate_hz;
+			const RealType output_rate = request.sample_rate_hz.value_or(0.0);
 			const RealType bandwidth = request.filter_bandwidth_hz.value_or(0.40 * output_rate);
 			fers_signal::FmcwIfResamplerRequest resampler_request{
 				.input_sample_rate_hz = params::rate() * static_cast<RealType>(params::oversampleRatio()),
@@ -824,16 +824,17 @@ namespace core
 												 if_plan->actual_output_sample_rate_hz, samples, sample_start);
 					});
 			}
+			const RealType actual_output_sample_rate_hz = plan.actual_output_sample_rate_hz;
+			const auto overall_ratio = plan.overall_ratio;
+			const RealType filter_bandwidth_hz = plan.filter_bandwidth_hz;
+			const RealType filter_transition_width_hz = plan.filter_transition_width_hz;
 			receiver_ptr->initializeFmcwIfResampling(std::move(plan));
 			LOG(Level::INFO,
 				"Receiver '{}' enabled FMCW IF resampling: input_rate={} Hz requested_output_rate={} Hz "
 				"actual_output_rate={} Hz ratio={}/{} passband={} Hz transition={} Hz.",
 				receiver_ptr->getName(), resampler_request.input_sample_rate_hz, output_rate,
-				receiver_ptr->getFmcwIfResamplerPlan()->actual_output_sample_rate_hz,
-				receiver_ptr->getFmcwIfResamplerPlan()->overall_ratio.numerator,
-				receiver_ptr->getFmcwIfResamplerPlan()->overall_ratio.denominator,
-				receiver_ptr->getFmcwIfResamplerPlan()->filter_bandwidth_hz,
-				receiver_ptr->getFmcwIfResamplerPlan()->filter_transition_width_hz);
+				actual_output_sample_rate_hz, overall_ratio.numerator, overall_ratio.denominator, filter_bandwidth_hz,
+				filter_transition_width_hz);
 		}
 
 		if (_internal_stop_time <= params::endTime())

--- a/packages/libfers/src/core/sim_threading.cpp
+++ b/packages/libfers/src/core/sim_threading.cpp
@@ -829,7 +829,7 @@ namespace core
 			const auto& request = receiver_ptr->getFmcwIfChainRequest();
 			const RealType output_rate = request.sample_rate_hz.value_or(0.0);
 			const RealType bandwidth = request.filter_bandwidth_hz.value_or(0.40 * output_rate);
-			fers_signal::FmcwIfResamplerRequest resampler_request{
+			const fers_signal::FmcwIfResamplerRequest resampler_request{
 				.input_sample_rate_hz = params::rate() * static_cast<RealType>(params::oversampleRatio()),
 				.output_sample_rate_hz = output_rate,
 				.filter_bandwidth_hz = bandwidth,

--- a/packages/libfers/src/core/sim_threading.cpp
+++ b/packages/libfers/src/core/sim_threading.cpp
@@ -958,7 +958,6 @@ namespace core
 	{
 		auto& state = _world->getSimulationState();
 		auto& t_current = state.t_current;
-		auto& active_streaming_transmitters = state.active_streaming_transmitters;
 
 		if (t_event <= t_current)
 		{
@@ -973,35 +972,11 @@ namespace core
 
 		ensureCwPhaseNoiseLookup();
 
-		const auto next_cleanup_deadline = [&](const RealType from_time) -> std::optional<RealType>
-		{
-			std::optional<RealType> next_deadline;
-			for (const auto& source : active_streaming_transmitters)
-			{
-				if (source.segment_end > from_time)
-				{
-					continue;
-				}
-				const auto cleanup_deadline = streamingSourceCleanupDeadline(source, from_time);
-				if (cleanup_deadline.has_value() && *cleanup_deadline > from_time &&
-					(!next_deadline.has_value() || *cleanup_deadline < *next_deadline))
-				{
-					next_deadline = cleanup_deadline;
-				}
-			}
-			return next_deadline;
-		};
-
 		while (t_current < t_event && !isCancellationRequested())
 		{
 			cleanupInactiveStreamingSources(t_current);
 
-			RealType chunk_end = t_event;
-			if (const auto cleanup_deadline = next_cleanup_deadline(t_current);
-				cleanup_deadline.has_value() && *cleanup_deadline < chunk_end)
-			{
-				chunk_end = *cleanup_deadline;
-			}
+			const RealType chunk_end = streamingChunkEnd(t_current, t_event);
 			if (chunk_end <= t_current)
 			{
 				break;
@@ -1011,46 +986,101 @@ namespace core
 			const auto end_index = streamingSampleIndexAtOrAfter(chunk_end, dt_sim);
 			for (size_t sample_index = start_index; sample_index < end_index; ++sample_index)
 			{
-				if (((sample_index - start_index) % 1024) == 0 && isCancellationRequested())
+				if (shouldStopStreamingChunk(sample_index, start_index))
 				{
 					break;
 				}
-				const RealType t_step = params::startTime() + static_cast<RealType>(sample_index) * dt_sim;
-
-				for (std::size_t receiver_index = 0; receiver_index < _world->getReceivers().size(); ++receiver_index)
-				{
-					const auto& receiver_ptr = _world->getReceivers()[receiver_index];
-					if ((receiver_ptr->getMode() == OperationMode::CW_MODE ||
-						 receiver_ptr->getMode() == OperationMode::FMCW_MODE) &&
-						receiver_ptr->isActive())
-					{
-						ComplexType const sample =
-							calculateStreamingSample(receiver_ptr.get(), t_step, active_streaming_transmitters,
-													 _streaming_tracker_caches[receiver_index]);
-						if (receiver_ptr->hasFmcwIfResamplingSink())
-						{
-							appendFmcwIfSample(receiver_index, t_step, sample);
-						}
-						else if (_output_sink != nullptr)
-						{
-							appendStreamingOutputSample(receiver_index, sample_index, t_step, sample);
-						}
-					}
-				}
-				if (_output_sink != nullptr && t_step >= _next_context_heartbeat_time)
-				{
-					emitContextHeartbeatsThrough(t_step);
-				}
-				if (((sample_index - first_index) % progress_report_stride) == 0 || sample_index + 1 == final_index)
-				{
-					reportSimulationProgress(t_step);
-				}
+				processStreamingSample(sample_index, first_index, final_index, progress_report_stride, dt_sim);
 			}
 
 			t_current = chunk_end;
 			emitContextHeartbeatsThrough(t_current);
 		}
 		cleanupInactiveStreamingSources(t_current);
+	}
+
+	std::optional<RealType> SimulationEngine::nextStreamingCleanupDeadline(const RealType from_time)
+	{
+		const auto& active_streaming_transmitters = _world->getSimulationState().active_streaming_transmitters;
+		std::optional<RealType> next_deadline;
+		for (const auto& source : active_streaming_transmitters)
+		{
+			if (source.segment_end > from_time)
+			{
+				continue;
+			}
+			const auto cleanup_deadline = streamingSourceCleanupDeadline(source, from_time);
+			if (cleanup_deadline.has_value() && *cleanup_deadline > from_time &&
+				(!next_deadline.has_value() || *cleanup_deadline < *next_deadline))
+			{
+				next_deadline = cleanup_deadline;
+			}
+		}
+		return next_deadline;
+	}
+
+	RealType SimulationEngine::streamingChunkEnd(const RealType from_time, const RealType event_time)
+	{
+		if (const auto cleanup_deadline = nextStreamingCleanupDeadline(from_time);
+			cleanup_deadline.has_value() && *cleanup_deadline < event_time)
+		{
+			return *cleanup_deadline;
+		}
+		return event_time;
+	}
+
+	bool SimulationEngine::shouldStopStreamingChunk(const std::size_t sample_index, const std::size_t chunk_start_index)
+	{
+		return ((sample_index - chunk_start_index) % 1024) == 0 && isCancellationRequested();
+	}
+
+	void SimulationEngine::processStreamingSample(const std::size_t sample_index, const std::size_t first_index,
+												  const std::size_t final_index,
+												  const std::size_t progress_report_stride, const RealType dt_sim)
+	{
+		const RealType t_step = params::startTime() + static_cast<RealType>(sample_index) * dt_sim;
+		appendActiveReceiverStreamingSamples(sample_index, t_step);
+
+		if (_output_sink != nullptr && t_step >= _next_context_heartbeat_time)
+		{
+			emitContextHeartbeatsThrough(t_step);
+		}
+		if (((sample_index - first_index) % progress_report_stride) == 0 || sample_index + 1 == final_index)
+		{
+			reportSimulationProgress(t_step);
+		}
+	}
+
+	void SimulationEngine::appendActiveReceiverStreamingSamples(const std::size_t sample_index, const RealType t_step)
+	{
+		for (std::size_t receiver_index = 0; receiver_index < _world->getReceivers().size(); ++receiver_index)
+		{
+			appendReceiverStreamingSample(receiver_index, sample_index, t_step);
+		}
+	}
+
+	void SimulationEngine::appendReceiverStreamingSample(const std::size_t receiver_index,
+														 const std::size_t sample_index, const RealType t_step)
+	{
+		const auto& receiver_ptr = _world->getReceivers()[receiver_index];
+		if ((receiver_ptr->getMode() != OperationMode::CW_MODE &&
+			 receiver_ptr->getMode() != OperationMode::FMCW_MODE) ||
+			!receiver_ptr->isActive())
+		{
+			return;
+		}
+
+		const auto& active_streaming_transmitters = _world->getSimulationState().active_streaming_transmitters;
+		ComplexType const sample = calculateStreamingSample(receiver_ptr.get(), t_step, active_streaming_transmitters,
+															_streaming_tracker_caches[receiver_index]);
+		if (receiver_ptr->hasFmcwIfResamplingSink())
+		{
+			appendFmcwIfSample(receiver_index, t_step, sample);
+		}
+		else if (_output_sink != nullptr)
+		{
+			appendStreamingOutputSample(receiver_index, sample_index, t_step, sample);
+		}
 	}
 
 	void SimulationEngine::appendFmcwIfSample(const std::size_t receiver_index, const RealType t_step,

--- a/packages/libfers/src/core/sim_threading.cpp
+++ b/packages/libfers/src/core/sim_threading.cpp
@@ -1392,8 +1392,7 @@ namespace core
 		if (!tracker_cache.last_dechirp_time.has_value() || t_step < *tracker_cache.last_dechirp_time)
 		{
 			tracker_cache.active_dechirp_source_index = 0;
-			std::fill(tracker_cache.dechirp_reference.begin(), tracker_cache.dechirp_reference.end(),
-					  FmcwChirpBoundaryTracker{});
+			std::ranges::fill(tracker_cache.dechirp_reference, FmcwChirpBoundaryTracker{});
 		}
 		tracker_cache.last_dechirp_time = t_step;
 

--- a/packages/libfers/src/core/sim_threading.cpp
+++ b/packages/libfers/src/core/sim_threading.cpp
@@ -960,7 +960,7 @@ namespace core
 						 receiver_ptr->getMode() == OperationMode::FMCW_MODE) &&
 						receiver_ptr->isActive())
 					{
-						ComplexType sample =
+						ComplexType const sample =
 							calculateStreamingSample(receiver_ptr.get(), t_step, active_streaming_transmitters,
 													 _streaming_tracker_caches[receiver_index]);
 						if (receiver_ptr->hasFmcwIfResamplingSink())

--- a/packages/libfers/src/core/sim_threading.h
+++ b/packages/libfers/src/core/sim_threading.h
@@ -201,6 +201,25 @@ namespace core
 		/// Removes ended streaming sources once no future receiver sample can observe their in-flight energy.
 		void cleanupInactiveStreamingSources(RealType from_time);
 
+		/// Returns the next time at which ended streaming sources can be cleaned up.
+		[[nodiscard]] std::optional<RealType> nextStreamingCleanupDeadline(RealType from_time);
+
+		/// Returns the next streaming chunk boundary before the target event time.
+		[[nodiscard]] RealType streamingChunkEnd(RealType from_time, RealType event_time);
+
+		/// Returns true when cooperative cancellation should stop the current streaming chunk.
+		[[nodiscard]] bool shouldStopStreamingChunk(std::size_t sample_index, std::size_t chunk_start_index);
+
+		/// Processes one simulation sample for all active streaming receivers.
+		void processStreamingSample(std::size_t sample_index, std::size_t first_index, std::size_t final_index,
+									std::size_t progress_report_stride, RealType dt_sim);
+
+		/// Adds one sample to every active streaming receiver.
+		void appendActiveReceiverStreamingSamples(std::size_t sample_index, RealType t_step);
+
+		/// Adds one sample to a single active streaming receiver.
+		void appendReceiverStreamingSample(std::size_t receiver_index, std::size_t sample_index, RealType t_step);
+
 		/// Builds and attaches IF resampling sinks for configured FMCW receivers.
 		void initializeFmcwIfResamplers();
 

--- a/packages/libfers/src/core/sim_threading.h
+++ b/packages/libfers/src/core/sim_threading.h
@@ -89,7 +89,7 @@ namespace core
 		{
 			if (_callback)
 			{
-				std::scoped_lock lock(_mutex);
+				std::scoped_lock const lock(_mutex);
 				_callback(msg, current, total);
 			}
 		}

--- a/packages/libfers/src/core/sim_threading.h
+++ b/packages/libfers/src/core/sim_threading.h
@@ -223,6 +223,12 @@ namespace core
 		/// Builds and attaches IF resampling sinks for configured FMCW receivers.
 		void initializeFmcwIfResamplers();
 
+		/// Builds and attaches one receiver IF resampler when configured.
+		void initializeFmcwIfResampler(std::size_t receiver_index);
+
+		/// Extends resolved dechirp source spans to cover IF resampler over-render.
+		void extendDechirpSourcesForIfOverrender();
+
 		/// Flushes all pending high-rate samples buffered for IF resamplers.
 		void flushFmcwIfBlocks();
 
@@ -283,6 +289,12 @@ namespace core
 		/// Adds pulsed interference into a live streaming block before final noise/scaling.
 		void applyPulsedInterferenceToStreamingBlock(std::size_t receiver_index, std::span<ComplexType> block,
 													 RealType block_start_time, RealType sample_rate, bool dechirp_mix);
+
+		/// Adds one rendered pulsed-interference slice into a streaming block.
+		void addPulsedInterferenceSamples(std::span<ComplexType> block, std::span<const ComplexType> rendered_pulse,
+										  long long dest_begin, long long dest_end, std::size_t crop_offset,
+										  RealType block_start_time, RealType sample_rate, bool dechirp_mix,
+										  radar::Receiver* receiver, ReceiverTrackerCache& tracker_cache) const;
 
 		/// Emits summary logs for streaming receiver configuration.
 		void logStreamingSummaries() const;

--- a/packages/libfers/src/core/simulation_state.h
+++ b/packages/libfers/src/core/simulation_state.h
@@ -29,7 +29,7 @@ namespace fers_signal
 namespace core
 {
 	/// Streaming waveform shape cached for a currently active source.
-	enum class StreamingWaveformKind
+	enum class StreamingWaveformKind : std::uint8_t
 	{
 		Cw,
 		FmcwLinear,

--- a/packages/libfers/src/core/thread_pool.cpp
+++ b/packages/libfers/src/core/thread_pool.cpp
@@ -82,7 +82,7 @@ namespace pool
 		{
 			throw std::runtime_error("Thread pool size exceeds unsigned range.");
 		}
-		const unsigned total_threads = static_cast<unsigned>(_workers.size());
+		const auto total_threads = static_cast<unsigned>(_workers.size());
 		return total_threads > active_threads ? total_threads - active_threads : 0;
 	}
 }

--- a/packages/libfers/src/core/thread_pool.cpp
+++ b/packages/libfers/src/core/thread_pool.cpp
@@ -49,7 +49,7 @@ namespace pool
 						}
 
 						{
-							std::unique_lock lock(_queue_mutex);
+							std::unique_lock const lock(_queue_mutex);
 							--_pending_tasks;
 							if (_pending_tasks == 0)
 							{
@@ -64,7 +64,7 @@ namespace pool
 	ThreadPool::~ThreadPool()
 	{
 		{
-			std::unique_lock lock(_queue_mutex);
+			std::unique_lock const lock(_queue_mutex);
 			_stop = true;
 			_condition.notify_all();
 		}
@@ -76,7 +76,7 @@ namespace pool
 
 	unsigned ThreadPool::getAvailableThreads()
 	{
-		std::unique_lock lock(_queue_mutex);
+		std::unique_lock const lock(_queue_mutex);
 		const unsigned active_threads = _pending_tasks;
 		if (_workers.size() > static_cast<std::size_t>(std::numeric_limits<unsigned>::max()))
 		{

--- a/packages/libfers/src/core/thread_pool.h
+++ b/packages/libfers/src/core/thread_pool.h
@@ -63,7 +63,7 @@ namespace pool
 
 			std::future<ReturnType> res = task->get_future();
 			{
-				std::unique_lock lock(_queue_mutex);
+				std::unique_lock const lock(_queue_mutex);
 				if (_stop)
 				{
 					throw std::runtime_error("enqueue on stopped ThreadPool");

--- a/packages/libfers/src/core/world.cpp
+++ b/packages/libfers/src/core/world.cpp
@@ -376,81 +376,109 @@ namespace core
 
 		for (const auto& transmitter : _transmitters)
 		{
-			if (transmitter->getMode() == radar::OperationMode::PULSED_MODE)
-			{
-				// Find the first valid pulse time starting from the simulation start time.
-				if (auto start_time = transmitter->getNextPulseTime(sim_start); start_time)
-				{
-					if (*start_time <= sim_end)
-					{
-						_event_queue.push({*start_time, EventType::TX_PULSED_START, transmitter.get()});
-					}
-				}
-			}
-			else
-			{
-				const auto& schedule = transmitter->getSchedule();
-				if (schedule.empty())
-				{
-					const RealType end = makeActiveSource(transmitter.get(), sim_start, sim_end).segment_end;
-					if (sim_start < end)
-					{
-						_event_queue.push({sim_start, EventType::TX_STREAMING_START, transmitter.get()});
-						_event_queue.push({end, EventType::TX_STREAMING_END, transmitter.get()});
-					}
-				}
-				else
-				{
-					for (const auto& period : schedule)
-					{
-						const RealType start = std::max(sim_start, period.start);
-						const RealType end =
-							makeActiveSource(transmitter.get(), period.start, std::min(sim_end, period.end))
-								.segment_end;
-
-						if (start < end)
-						{
-							_event_queue.push({start, EventType::TX_STREAMING_START, transmitter.get()});
-							_event_queue.push({end, EventType::TX_STREAMING_END, transmitter.get()});
-						}
-					}
-				}
-			}
+			scheduleInitialTransmitterEvents(transmitter.get(), sim_start, sim_end);
 		}
 
 		for (const auto& receiver : _receivers)
 		{
-			if (receiver->getMode() == radar::OperationMode::PULSED_MODE)
-			{
-				// Schedule the first receive window checking against schedule
-				const RealType nominal_start = receiver->getWindowStart(0);
-				if (auto start = receiver->getNextWindowTime(nominal_start); start && *start < params::endTime())
-				{
-					_event_queue.push({*start, EventType::RX_PULSED_WINDOW_START, receiver.get()});
-				}
-			}
-			else
-			{
-				const auto& schedule = receiver->getSchedule();
-				if (schedule.empty())
-				{
-					_event_queue.push({params::startTime(), EventType::RX_STREAMING_START, receiver.get()});
-					_event_queue.push({params::endTime(), EventType::RX_STREAMING_END, receiver.get()});
-				}
-				else
-				{
-					for (const auto& period : schedule)
-					{
-						const RealType start = std::max(params::startTime(), period.start);
-						const RealType end = std::min(params::endTime(), period.end);
-						if (start < end)
-						{
-							_event_queue.push({start, EventType::RX_STREAMING_START, receiver.get()});
-							_event_queue.push({end, EventType::RX_STREAMING_END, receiver.get()});
-						}
-					}
-				}
-			}
+			scheduleInitialReceiverEvents(receiver.get(), sim_start, sim_end);
+		}
+	}
+
+	void World::scheduleInitialTransmitterEvents(Transmitter* const transmitter, const RealType sim_start,
+												 const RealType sim_end)
+	{
+		if (transmitter->getMode() == radar::OperationMode::PULSED_MODE)
+		{
+			scheduleInitialPulsedTransmitterEvent(transmitter, sim_start, sim_end);
+			return;
+		}
+		scheduleInitialStreamingTransmitterEvents(transmitter, sim_start, sim_end);
+	}
+
+	void World::scheduleInitialPulsedTransmitterEvent(Transmitter* const transmitter, const RealType sim_start,
+													  const RealType sim_end)
+	{
+		// Find the first valid pulse time starting from the simulation start time.
+		if (auto start_time = transmitter->getNextPulseTime(sim_start); start_time && *start_time <= sim_end)
+		{
+			_event_queue.push({*start_time, EventType::TX_PULSED_START, transmitter});
+		}
+	}
+
+	void World::scheduleInitialStreamingTransmitterEvents(Transmitter* const transmitter, const RealType sim_start,
+														  const RealType sim_end)
+	{
+		const auto& schedule = transmitter->getSchedule();
+		if (schedule.empty())
+		{
+			const RealType end = makeActiveSource(transmitter, sim_start, sim_end).segment_end;
+			pushStreamingTransmitterEvents(transmitter, sim_start, end);
+			return;
+		}
+
+		for (const auto& period : schedule)
+		{
+			const RealType start = std::max(sim_start, period.start);
+			const RealType end = makeActiveSource(transmitter, period.start, std::min(sim_end, period.end)).segment_end;
+			pushStreamingTransmitterEvents(transmitter, start, end);
+		}
+	}
+
+	void World::pushStreamingTransmitterEvents(Transmitter* const transmitter, const RealType start, const RealType end)
+	{
+		if (start < end)
+		{
+			_event_queue.push({start, EventType::TX_STREAMING_START, transmitter});
+			_event_queue.push({end, EventType::TX_STREAMING_END, transmitter});
+		}
+	}
+
+	void World::scheduleInitialReceiverEvents(Receiver* const receiver, const RealType sim_start,
+											  const RealType sim_end)
+	{
+		if (receiver->getMode() == radar::OperationMode::PULSED_MODE)
+		{
+			scheduleInitialPulsedReceiverEvent(receiver, sim_end);
+			return;
+		}
+		scheduleInitialStreamingReceiverEvents(receiver, sim_start, sim_end);
+	}
+
+	void World::scheduleInitialPulsedReceiverEvent(Receiver* const receiver, const RealType sim_end)
+	{
+		const RealType nominal_start = receiver->getWindowStart(0);
+		if (auto start = receiver->getNextWindowTime(nominal_start); start && *start < sim_end)
+		{
+			_event_queue.push({*start, EventType::RX_PULSED_WINDOW_START, receiver});
+		}
+	}
+
+	void World::scheduleInitialStreamingReceiverEvents(Receiver* const receiver, const RealType sim_start,
+													   const RealType sim_end)
+	{
+		const auto& schedule = receiver->getSchedule();
+		if (schedule.empty())
+		{
+			_event_queue.push({sim_start, EventType::RX_STREAMING_START, receiver});
+			_event_queue.push({sim_end, EventType::RX_STREAMING_END, receiver});
+			return;
+		}
+
+		for (const auto& period : schedule)
+		{
+			const RealType start = std::max(sim_start, period.start);
+			const RealType end = std::min(sim_end, period.end);
+			pushStreamingReceiverEvents(receiver, start, end);
+		}
+	}
+
+	void World::pushStreamingReceiverEvents(Receiver* const receiver, const RealType start, const RealType end)
+	{
+		if (start < end)
+		{
+			_event_queue.push({start, EventType::RX_STREAMING_START, receiver});
+			_event_queue.push({end, EventType::RX_STREAMING_END, receiver});
 		}
 	}
 

--- a/packages/libfers/src/core/world.cpp
+++ b/packages/libfers/src/core/world.cpp
@@ -576,9 +576,8 @@ namespace core
 			{
 				throw std::runtime_error(owner + " dechirp reference has no active LO segments in the simulation.");
 			}
-			std::sort(sources.begin(), sources.end(),
-					  [](const ActiveStreamingSource& lhs, const ActiveStreamingSource& rhs)
-					  { return lhs.segment_start < rhs.segment_start; });
+			std::ranges::sort(sources, [](const ActiveStreamingSource& lhs, const ActiveStreamingSource& rhs)
+							  { return lhs.segment_start < rhs.segment_start; });
 			rx.setDechirpReference(std::move(reference));
 			rx.setResolvedDechirpSources(std::move(sources));
 		}

--- a/packages/libfers/src/core/world.cpp
+++ b/packages/libfers/src/core/world.cpp
@@ -40,6 +40,73 @@ using timing::PrototypeTiming;
 
 namespace core
 {
+	namespace
+	{
+		std::vector<ActiveStreamingSource> transmitterDechirpSources(const Transmitter* const tx)
+		{
+			std::vector<ActiveStreamingSource> sources;
+			if (tx->getSchedule().empty())
+			{
+				auto source = makeActiveSource(tx, params::startTime(), params::endTime());
+				if (source.segment_start < source.segment_end)
+				{
+					sources.push_back(source);
+				}
+				return sources;
+			}
+
+			for (const auto& period : tx->getSchedule())
+			{
+				auto source = makeActiveSource(tx, period.start, std::min(params::endTime(), period.end));
+				if (source.segment_start < source.segment_end && source.segment_end > params::startTime())
+				{
+					sources.push_back(source);
+				}
+			}
+			return sources;
+		}
+
+		std::vector<ActiveStreamingSource> waveformDechirpSources(const RadarSignal* const waveform,
+																  const Receiver* const rx)
+		{
+			std::vector<ActiveStreamingSource> sources;
+			if (rx->getSchedule().empty())
+			{
+				auto source = makeActiveSourceFromWaveform(waveform, params::startTime(), params::endTime());
+				if (source.segment_start < source.segment_end)
+				{
+					sources.push_back(source);
+				}
+				return sources;
+			}
+
+			for (const auto& period : rx->getSchedule())
+			{
+				auto source =
+					makeActiveSourceFromWaveform(waveform, period.start, std::min(params::endTime(), period.end));
+				if (source.segment_start < source.segment_end && source.segment_end > params::startTime())
+				{
+					sources.push_back(source);
+				}
+			}
+			return sources;
+		}
+
+		void validateDechirpTransmitter(const Transmitter* const tx, const std::string& owner)
+		{
+			if (tx == nullptr)
+			{
+				throw std::runtime_error(owner + " references a missing dechirp transmitter.");
+			}
+			if (tx->getMode() != radar::OperationMode::FMCW_MODE || tx->getSignal() == nullptr ||
+				!tx->getSignal()->isFmcwFamily())
+			{
+				throw std::runtime_error(owner + " dechirp reference transmitter '" + tx->getName() +
+										 "' must be an FMCW transmitter with an FMCW waveform.");
+			}
+		}
+	}
+
 	void World::add(std::unique_ptr<Platform> plat) noexcept { _platforms.push_back(std::move(plat)); }
 
 	void World::add(std::unique_ptr<Transmitter> trans) noexcept
@@ -484,69 +551,6 @@ namespace core
 
 	void World::resolveReceiverDechirpReferences()
 	{
-		const auto append_transmitter_sources = [](const Transmitter* const tx)
-		{
-			std::vector<ActiveStreamingSource> sources;
-			if (tx->getSchedule().empty())
-			{
-				auto source = makeActiveSource(tx, params::startTime(), params::endTime());
-				if (source.segment_start < source.segment_end)
-				{
-					sources.push_back(source);
-				}
-				return sources;
-			}
-
-			for (const auto& period : tx->getSchedule())
-			{
-				auto source = makeActiveSource(tx, period.start, std::min(params::endTime(), period.end));
-				if (source.segment_start < source.segment_end && source.segment_end > params::startTime())
-				{
-					sources.push_back(source);
-				}
-			}
-			return sources;
-		};
-
-		const auto append_waveform_sources = [](const RadarSignal* const waveform, const Receiver* const rx)
-		{
-			std::vector<ActiveStreamingSource> sources;
-			if (rx->getSchedule().empty())
-			{
-				auto source = makeActiveSourceFromWaveform(waveform, params::startTime(), params::endTime());
-				if (source.segment_start < source.segment_end)
-				{
-					sources.push_back(source);
-				}
-				return sources;
-			}
-
-			for (const auto& period : rx->getSchedule())
-			{
-				auto source =
-					makeActiveSourceFromWaveform(waveform, period.start, std::min(params::endTime(), period.end));
-				if (source.segment_start < source.segment_end && source.segment_end > params::startTime())
-				{
-					sources.push_back(source);
-				}
-			}
-			return sources;
-		};
-
-		const auto validate_transmitter = [](const Transmitter* const tx, const std::string& owner)
-		{
-			if (tx == nullptr)
-			{
-				throw std::runtime_error(owner + " references a missing dechirp transmitter.");
-			}
-			if (tx->getMode() != radar::OperationMode::FMCW_MODE || tx->getSignal() == nullptr ||
-				!tx->getSignal()->isFmcwFamily())
-			{
-				throw std::runtime_error(owner + " dechirp reference transmitter '" + tx->getName() +
-										 "' must be an FMCW transmitter with an FMCW waveform.");
-			}
-		};
-
 		for (const auto& rx_ptr : _receivers)
 		{
 			auto& rx = *rx_ptr;
@@ -568,19 +572,19 @@ namespace core
 			case Receiver::DechirpReferenceSource::Attached:
 				{
 					const auto* const tx = dynamic_cast<const Transmitter*>(rx.getAttached());
-					validate_transmitter(tx, owner);
+					validateDechirpTransmitter(tx, owner);
 					reference.transmitter_id = tx->getId();
 					reference.transmitter_name = tx->getName();
-					sources = append_transmitter_sources(tx);
+					sources = transmitterDechirpSources(tx);
 					break;
 				}
 			case Receiver::DechirpReferenceSource::Transmitter:
 				{
 					auto* const tx = findTransmitterByName(reference.name);
-					validate_transmitter(tx, owner);
+					validateDechirpTransmitter(tx, owner);
 					reference.transmitter_id = tx->getId();
 					reference.transmitter_name = tx->getName();
-					sources = append_transmitter_sources(tx);
+					sources = transmitterDechirpSources(tx);
 					break;
 				}
 			case Receiver::DechirpReferenceSource::Custom:
@@ -593,7 +597,7 @@ namespace core
 					}
 					reference.waveform_id = waveform->getId();
 					reference.waveform_name = waveform->getName();
-					sources = append_waveform_sources(waveform, &rx);
+					sources = waveformDechirpSources(waveform, &rx);
 					break;
 				}
 			case Receiver::DechirpReferenceSource::None:

--- a/packages/libfers/src/core/world.h
+++ b/packages/libfers/src/core/world.h
@@ -322,6 +322,18 @@ namespace core
 		[[nodiscard]] SimulationState& getSimulationState() noexcept { return _simulation_state; }
 
 	private:
+		void scheduleInitialTransmitterEvents(radar::Transmitter* transmitter, RealType sim_start, RealType sim_end);
+		void scheduleInitialPulsedTransmitterEvent(radar::Transmitter* transmitter, RealType sim_start,
+												   RealType sim_end);
+		void scheduleInitialStreamingTransmitterEvents(radar::Transmitter* transmitter, RealType sim_start,
+													   RealType sim_end);
+		void pushStreamingTransmitterEvents(radar::Transmitter* transmitter, RealType start, RealType end);
+
+		void scheduleInitialReceiverEvents(radar::Receiver* receiver, RealType sim_start, RealType sim_end);
+		void scheduleInitialPulsedReceiverEvent(radar::Receiver* receiver, RealType sim_end);
+		void scheduleInitialStreamingReceiverEvents(radar::Receiver* receiver, RealType sim_start, RealType sim_end);
+		void pushStreamingReceiverEvents(radar::Receiver* receiver, RealType start, RealType end);
+
 		std::vector<std::unique_ptr<radar::Platform>> _platforms; ///< Owned radar platforms.
 
 		std::vector<std::unique_ptr<radar::Transmitter>> _transmitters; ///< Owned transmitters.

--- a/packages/libfers/src/interpolation/interpolation_filter.cpp
+++ b/packages/libfers/src/interpolation/interpolation_filter.cpp
@@ -93,10 +93,8 @@ namespace interp
 		return std::unexpected(kaiser.error());
 	}
 
-	InterpFilter::InterpFilter()
+	InterpFilter::InterpFilter() : _length(params::renderFilterLength()), _table_filters(1000)
 	{
-		_length = params::renderFilterLength();
-		_table_filters = 1000;
 		_filter_table = std::vector<RealType>(_table_filters * _length);
 
 		_alpha = std::floor(static_cast<RealType>(_length) / 2.0);

--- a/packages/libfers/src/interpolation/interpolation_filter.cpp
+++ b/packages/libfers/src/interpolation/interpolation_filter.cpp
@@ -93,7 +93,7 @@ namespace interp
 		return std::unexpected(kaiser.error());
 	}
 
-	InterpFilter::InterpFilter() : _length(params::renderFilterLength()), _table_filters(1000)
+	InterpFilter::InterpFilter() : _length(params::renderFilterLength())
 	{
 		_filter_table = std::vector<RealType>(_table_filters * _length);
 

--- a/packages/libfers/src/interpolation/interpolation_filter.h
+++ b/packages/libfers/src/interpolation/interpolation_filter.h
@@ -84,7 +84,7 @@ namespace interp
 		RealType _beta = 5; ///< The beta value for the Kaiser window.
 		RealType _bessel_beta; ///< The Bessel function value for the Kaiser window.
 		std::size_t _length; ///< The length of the filter.
-		std::size_t _table_filters; ///< The number of filters in the table.
+		std::size_t _table_filters{1000}; ///< The number of filters in the table.
 		std::vector<RealType> _filter_table; ///< The table of precomputed filters.
 	};
 }

--- a/packages/libfers/src/interpolation/interpolation_set.cpp
+++ b/packages/libfers/src/interpolation/interpolation_set.cpp
@@ -37,7 +37,7 @@ namespace interp
 		// return static_cast<T>(...)
 		// If the class is conceptually for real-valued interpolation,
 		// std::floating_point<T> would be a better constraint
-		const RealType x_value = static_cast<RealType>(x);
+		const auto x_value = static_cast<RealType>(x);
 		const auto iter = _data.lower_bound(x_value);
 
 		if (iter == _data.begin())

--- a/packages/libfers/src/math/coord.h
+++ b/packages/libfers/src/math/coord.h
@@ -23,7 +23,7 @@ namespace math
 	struct Coord
 	{
 		Vec3 pos; ///< 3D position
-		RealType t; ///< Time
+		RealType t{}; ///< Time
 
 		/**
 		 * @brief Comparison operator based on the time component.

--- a/packages/libfers/src/math/geometry_ops.cpp
+++ b/packages/libfers/src/math/geometry_ops.cpp
@@ -97,10 +97,9 @@ namespace math
 		return *this;
 	}
 
-	SVec3::SVec3(const Vec3& vec) noexcept : length(vec.length())
+	SVec3::SVec3(const Vec3& vec) noexcept :
+		length(vec.length()), azimuth(std::atan2(vec.y, vec.x)), elevation(std::asin(vec.z / length))
 	{
-		elevation = std::asin(vec.z / length);
-		azimuth = std::atan2(vec.y, vec.x);
 	}
 
 	SVec3& SVec3::operator*=(const RealType b) noexcept

--- a/packages/libfers/src/math/geometry_ops.h
+++ b/packages/libfers/src/math/geometry_ops.h
@@ -61,6 +61,7 @@ namespace math
 		SVec3(SVec3&&) noexcept = default;
 		SVec3& operator=(const SVec3&) noexcept = default;
 		SVec3& operator=(SVec3&&) noexcept = default;
+		~SVec3() noexcept = default;
 
 		/**
 		 * @brief Parameterized constructor for SVec3.
@@ -115,6 +116,7 @@ namespace math
 		Vec3(Vec3&&) noexcept = default;
 		Vec3& operator=(const Vec3&) noexcept = default;
 		Vec3& operator=(Vec3&&) noexcept = default;
+		~Vec3() noexcept = default;
 
 		/**
 		 * @brief Parameterized constructor for Vec3.

--- a/packages/libfers/src/math/path.cpp
+++ b/packages/libfers/src/math/path.cpp
@@ -105,7 +105,7 @@ namespace math
 		case InterpType::INTERP_CUBIC:
 			{
 				auto xrp = std::ranges::upper_bound(_coords, t, {}, &Coord::t);
-				std::ptrdiff_t xri;
+				std::ptrdiff_t xri = 0;
 				if (xrp == _coords.begin())
 					xri = 1;
 				else if (xrp == _coords.end())

--- a/packages/libfers/src/math/path.h
+++ b/packages/libfers/src/math/path.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "coord.h"
@@ -32,7 +33,7 @@ namespace math
 		/**
 		 * @brief Types of interpolation supported by the Path class.
 		 */
-		enum class InterpType
+		enum class InterpType : std::uint8_t
 		{
 			INTERP_STATIC, ///< Hold the first coordinate for all query times.
 			INTERP_LINEAR, ///< Linearly interpolate between neighboring coordinates.

--- a/packages/libfers/src/math/rotation_path.h
+++ b/packages/libfers/src/math/rotation_path.h
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "coord.h"
@@ -31,7 +32,7 @@ namespace math
 		 * @enum InterpType
 		 * @brief Enumeration for types of interpolation.
 		 */
-		enum class InterpType
+		enum class InterpType : std::uint8_t
 		{
 			INTERP_STATIC, ///< Hold the first rotation for all query times.
 			INTERP_CONSTANT, ///< Hold the most recent rotation sample.

--- a/packages/libfers/src/noise/falpha_branch.cpp
+++ b/packages/libfers/src/noise/falpha_branch.cpp
@@ -29,11 +29,10 @@ namespace noise
 {
 	FAlphaBranch::FAlphaBranch(std::mt19937& rngEngine, RealType ffrac, unsigned fint,
 							   std::unique_ptr<FAlphaBranch> pre, const bool last) :
-		_rng_engine_ref(rngEngine), _normal_dist{0.0, 1.0}, _pre(std::move(pre)), _buffer(10), _ffrac(ffrac),
-		_fint(fint), _last(last)
+		_rng_engine_ref(rngEngine), _normal_dist{0.0, 1.0}, _pre(std::move(pre)),
+		_upsample_scale(std::pow(10, ffrac + fint + 0.5)), _buffer(10), _ffrac(ffrac), _fint(fint), _last(last)
 	{
 		LOG(Level::TRACE, "Creating FAlphaBranch: ffrac={} fint={}", ffrac, fint);
-		_upsample_scale = std::pow(10, ffrac + fint + 0.5);
 		init();
 
 		if (!_last)

--- a/packages/libfers/src/noise/noise_generators.cpp
+++ b/packages/libfers/src/noise/noise_generators.cpp
@@ -90,6 +90,7 @@ namespace noise
 	void MultirateGenerator::reset() noexcept
 	{
 		std::vector<FAlphaBranch*> branches;
+		// NOLINTNEXTLINE(misc-const-correctness): Collected branches are flushed through mutable aliases below.
 		FAlphaBranch* branch = _topbranch.get();
 
 		while (branch != nullptr)

--- a/packages/libfers/src/noise/noise_generators.cpp
+++ b/packages/libfers/src/noise/noise_generators.cpp
@@ -22,7 +22,7 @@
 namespace noise
 {
 	MultirateGenerator::MultirateGenerator(std::mt19937& rngEngine, const RealType alpha, const unsigned branches) :
-		_rng_engine(rngEngine)
+		_scale(1.0 / std::pow(10.0, (-alpha + 2.0) * 2.0)), _rng_engine(rngEngine)
 	{
 		const RealType beta = -(alpha - 2) / 2.0;
 		const int fint = static_cast<int>(std::floor(beta));
@@ -30,7 +30,6 @@ namespace noise
 
 		createTree(ffrac, fint, branches);
 		// TODO: verify scale factor calculation (* 2.0 appears to be a bug)
-		_scale = 1.0 / std::pow(10.0, (-alpha + 2.0) * 2.0);
 	}
 
 	// NOLINTNEXTLINE(readability-make-member-function-const)

--- a/packages/libfers/src/processing/finalizer.cpp
+++ b/packages/libfers/src/processing/finalizer.cpp
@@ -361,7 +361,7 @@ namespace processing
 				metadata.fmcw_if_decimation_enabled = if_plan.has_value();
 				if (if_request.sample_rate_hz.has_value())
 				{
-					metadata.fmcw_if_requested_sample_rate = *if_request.sample_rate_hz;
+					metadata.fmcw_if_requested_sample_rate = if_request.sample_rate_hz;
 				}
 				if (if_plan.has_value())
 				{

--- a/packages/libfers/src/processing/finalizer.cpp
+++ b/packages/libfers/src/processing/finalizer.cpp
@@ -274,6 +274,143 @@ namespace processing
 			return spans;
 		}
 
+		void appendStreamingSegment(core::OutputFileMetadata& metadata, const std::size_t total_samples,
+									const RealType output_sample_rate, const RealType start_time,
+									const RealType end_time)
+		{
+			const auto start_sample = static_cast<std::uint64_t>(std::min<RealType>(
+				static_cast<RealType>(total_samples),
+				std::max<RealType>(0.0, std::ceil((start_time - params::startTime()) * output_sample_rate))));
+			const auto end_sample = static_cast<std::uint64_t>(std::min<RealType>(
+				static_cast<RealType>(total_samples),
+				std::max<RealType>(0.0, std::ceil((end_time - params::startTime()) * output_sample_rate))));
+			if (start_sample < end_sample)
+			{
+				const core::StreamingSegmentMetadata segment{.start_time = start_time,
+															 .end_time = end_time,
+															 .sample_count = end_sample - start_sample,
+															 .sample_start = start_sample,
+															 .sample_end_exclusive = end_sample};
+				metadata.streaming_segments.push_back(segment);
+			}
+		}
+
+		void appendScheduledStreamingSegments(core::OutputFileMetadata& metadata, const radar::Receiver* receiver,
+											  const std::size_t total_samples, const RealType output_sample_rate)
+		{
+			const auto& schedule = receiver->getSchedule();
+			if (schedule.empty())
+			{
+				appendStreamingSegment(metadata, total_samples, output_sample_rate, params::startTime(),
+									   params::endTime());
+				return;
+			}
+
+			for (const auto& period : schedule)
+			{
+				const RealType start = std::max(params::startTime(), period.start);
+				const RealType end = std::min(params::endTime(), period.end);
+				if (start < end)
+				{
+					appendStreamingSegment(metadata, total_samples, output_sample_rate, start, end);
+				}
+			}
+		}
+
+		void appendStreamingSegments(core::OutputFileMetadata& metadata, const radar::Receiver* receiver,
+									 const std::size_t total_samples, const RealType output_sample_rate,
+									 const std::vector<TimeSpan>& dechirp_time_spans)
+		{
+			if (!receiver->isDechirpEnabled())
+			{
+				appendScheduledStreamingSegments(metadata, receiver, total_samples, output_sample_rate);
+				return;
+			}
+
+			for (const auto& span : dechirp_time_spans)
+			{
+				appendStreamingSegment(metadata, total_samples, output_sample_rate, span.first, span.second);
+			}
+		}
+
+		void annotateSingleFmcwSource(core::OutputFileMetadata& metadata,
+									  const std::vector<core::ActiveStreamingSource>& streaming_sources)
+		{
+			metadata.fmcw_sources = buildFmcwSources(streaming_sources);
+			if (metadata.fmcw_sources.size() != 1)
+			{
+				return;
+			}
+
+			metadata.fmcw = metadata.fmcw_sources.front().waveform;
+			for (const auto& streaming_source : streaming_sources)
+			{
+				if (streaming_source.is_fmcw && streaming_source.transmitter != nullptr &&
+					streaming_source.transmitter->getId() == metadata.fmcw_sources.front().transmitter_id)
+				{
+					annotateStreamingSegmentsForSingleFmcwSource(metadata, streaming_source);
+				}
+			}
+		}
+
+		void populateFmcwIfMetadata(core::OutputFileMetadata& metadata, const radar::Receiver* receiver)
+		{
+			const auto& if_request = receiver->getFmcwIfChainRequest();
+			const auto& if_plan = receiver->getFmcwIfResamplerPlan();
+			metadata.fmcw_if_legacy_full_rate = !if_request.sample_rate_hz.has_value();
+			metadata.fmcw_if_decimation_enabled = if_plan.has_value();
+			if (if_request.sample_rate_hz.has_value())
+			{
+				metadata.fmcw_if_requested_sample_rate = if_request.sample_rate_hz;
+			}
+			if (!if_plan.has_value())
+			{
+				return;
+			}
+
+			metadata.fmcw_if_sample_rate = if_plan->actual_output_sample_rate_hz;
+			metadata.fmcw_if_input_sample_rate = if_plan->input_sample_rate_hz;
+			metadata.fmcw_if_resample_numerator = static_cast<unsigned>(if_plan->overall_ratio.numerator);
+			metadata.fmcw_if_resample_denominator = static_cast<unsigned>(if_plan->overall_ratio.denominator);
+			metadata.fmcw_if_decimation_factor = if_plan->actual_output_sample_rate_hz > 0.0
+				? if_plan->input_sample_rate_hz / if_plan->actual_output_sample_rate_hz
+				: 0.0;
+			metadata.fmcw_if_filter_bandwidth = if_plan->filter_bandwidth_hz;
+			metadata.fmcw_if_filter_transition_width = if_plan->filter_transition_width_hz;
+			metadata.fmcw_if_filter_stopband = if_plan->stopband_attenuation_db;
+			metadata.fmcw_if_filter_group_delay_seconds = if_plan->group_delay_seconds;
+			metadata.fmcw_if_compensated_integer_delay_samples = if_plan->warmup_discard_samples;
+			metadata.fmcw_if_compensated_fractional_delay_samples = if_plan->fractional_output_delay_samples;
+			metadata.fmcw_if_warmup_discard_samples = if_plan->warmup_discard_samples;
+			metadata.fmcw_if_phase_refinement = static_cast<unsigned>(if_plan->phase_refinement);
+			metadata.fmcw_if_timing_error_seconds = if_plan->estimated_timing_error_seconds;
+			metadata.fmcw_if_phase_error_radians = if_plan->estimated_phase_error_radians;
+			metadata.fmcw_if_noise_variance =
+				params::boltzmannK() * receiver->getNoiseTemperature() * if_plan->actual_output_sample_rate_hz;
+			metadata.fmcw_if_group_delay_compensated = if_plan->group_delay_compensated;
+		}
+
+		void populateDechirpReferenceMetadata(core::OutputFileMetadata& metadata, const radar::Receiver* receiver)
+		{
+			const auto& reference = receiver->getDechirpReference();
+			metadata.fmcw_dechirp_reference_source = std::string(radar::dechirpReferenceSourceToken(reference.source));
+			if (reference.source == radar::Receiver::DechirpReferenceSource::Attached ||
+				reference.source == radar::Receiver::DechirpReferenceSource::Transmitter)
+			{
+				metadata.fmcw_dechirp_reference_transmitter_id = reference.transmitter_id;
+				metadata.fmcw_dechirp_reference_transmitter_name = reference.transmitter_name;
+			}
+			else if (reference.source == radar::Receiver::DechirpReferenceSource::Custom)
+			{
+				metadata.fmcw_dechirp_reference_waveform_id = reference.waveform_id;
+				metadata.fmcw_dechirp_reference_waveform_name = reference.waveform_name;
+				if (!receiver->getDechirpSources().empty())
+				{
+					metadata.fmcw_dechirp_reference_waveform = buildFmcwMetadata(receiver->getDechirpSources().front());
+				}
+			}
+		}
+
 		/// Builds output metadata for a streaming receiver result file.
 		core::OutputFileMetadata
 		buildStreamingMetadata(const radar::Receiver* receiver, const std::string& hdf5_filename,
@@ -291,121 +428,14 @@ namespace processing
 											  .sample_start = 0,
 											  .sample_end_exclusive = static_cast<std::uint64_t>(total_samples)};
 
-			const auto append_segment = [&](const RealType start_time, const RealType end_time)
-			{
-				const auto start_sample = static_cast<std::uint64_t>(std::min<RealType>(
-					static_cast<RealType>(total_samples),
-					std::max<RealType>(0.0, std::ceil((start_time - params::startTime()) * output_sample_rate))));
-				const auto end_sample = static_cast<std::uint64_t>(std::min<RealType>(
-					static_cast<RealType>(total_samples),
-					std::max<RealType>(0.0, std::ceil((end_time - params::startTime()) * output_sample_rate))));
-				if (start_sample < end_sample)
-				{
-					const core::StreamingSegmentMetadata segment{.start_time = start_time,
-																 .end_time = end_time,
-																 .sample_count = end_sample - start_sample,
-																 .sample_start = start_sample,
-																 .sample_end_exclusive = end_sample};
-					metadata.streaming_segments.push_back(segment);
-				}
-			};
-
-			if (receiver->isDechirpEnabled())
-			{
-				for (const auto& span : dechirp_time_spans)
-				{
-					append_segment(span.first, span.second);
-				}
-			}
-			else
-			{
-				const auto& schedule = receiver->getSchedule();
-				if (schedule.empty())
-				{
-					append_segment(params::startTime(), params::endTime());
-				}
-				else
-				{
-					for (const auto& period : schedule)
-					{
-						const RealType start = std::max(params::startTime(), period.start);
-						const RealType end = std::min(params::endTime(), period.end);
-						if (start < end)
-						{
-							append_segment(start, end);
-						}
-					}
-				}
-			}
-
-			metadata.fmcw_sources = buildFmcwSources(streaming_sources);
-			if (metadata.fmcw_sources.size() == 1)
-			{
-				metadata.fmcw = metadata.fmcw_sources.front().waveform;
-				for (const auto& streaming_source : streaming_sources)
-				{
-					if (streaming_source.is_fmcw && streaming_source.transmitter != nullptr &&
-						streaming_source.transmitter->getId() == metadata.fmcw_sources.front().transmitter_id)
-					{
-						annotateStreamingSegmentsForSingleFmcwSource(metadata, streaming_source);
-					}
-				}
-			}
+			appendStreamingSegments(metadata, receiver, total_samples, output_sample_rate, dechirp_time_spans);
+			annotateSingleFmcwSource(metadata, streaming_sources);
 
 			metadata.fmcw_dechirp_mode = std::string(radar::dechirpModeToken(receiver->getDechirpMode()));
 			if (receiver->isDechirpEnabled())
 			{
-				const auto& if_request = receiver->getFmcwIfChainRequest();
-				const auto& if_plan = receiver->getFmcwIfResamplerPlan();
-				metadata.fmcw_if_legacy_full_rate = !if_request.sample_rate_hz.has_value();
-				metadata.fmcw_if_decimation_enabled = if_plan.has_value();
-				if (if_request.sample_rate_hz.has_value())
-				{
-					metadata.fmcw_if_requested_sample_rate = if_request.sample_rate_hz;
-				}
-				if (if_plan.has_value())
-				{
-					metadata.fmcw_if_sample_rate = if_plan->actual_output_sample_rate_hz;
-					metadata.fmcw_if_input_sample_rate = if_plan->input_sample_rate_hz;
-					metadata.fmcw_if_resample_numerator = static_cast<unsigned>(if_plan->overall_ratio.numerator);
-					metadata.fmcw_if_resample_denominator = static_cast<unsigned>(if_plan->overall_ratio.denominator);
-					metadata.fmcw_if_decimation_factor = if_plan->actual_output_sample_rate_hz > 0.0
-						? if_plan->input_sample_rate_hz / if_plan->actual_output_sample_rate_hz
-						: 0.0;
-					metadata.fmcw_if_filter_bandwidth = if_plan->filter_bandwidth_hz;
-					metadata.fmcw_if_filter_transition_width = if_plan->filter_transition_width_hz;
-					metadata.fmcw_if_filter_stopband = if_plan->stopband_attenuation_db;
-					metadata.fmcw_if_filter_group_delay_seconds = if_plan->group_delay_seconds;
-					metadata.fmcw_if_compensated_integer_delay_samples = if_plan->warmup_discard_samples;
-					metadata.fmcw_if_compensated_fractional_delay_samples = if_plan->fractional_output_delay_samples;
-					metadata.fmcw_if_warmup_discard_samples = if_plan->warmup_discard_samples;
-					metadata.fmcw_if_phase_refinement = static_cast<unsigned>(if_plan->phase_refinement);
-					metadata.fmcw_if_timing_error_seconds = if_plan->estimated_timing_error_seconds;
-					metadata.fmcw_if_phase_error_radians = if_plan->estimated_phase_error_radians;
-					metadata.fmcw_if_noise_variance =
-						params::boltzmannK() * receiver->getNoiseTemperature() * if_plan->actual_output_sample_rate_hz;
-					metadata.fmcw_if_group_delay_compensated = if_plan->group_delay_compensated;
-				}
-
-				const auto& reference = receiver->getDechirpReference();
-				metadata.fmcw_dechirp_reference_source =
-					std::string(radar::dechirpReferenceSourceToken(reference.source));
-				if (reference.source == radar::Receiver::DechirpReferenceSource::Attached ||
-					reference.source == radar::Receiver::DechirpReferenceSource::Transmitter)
-				{
-					metadata.fmcw_dechirp_reference_transmitter_id = reference.transmitter_id;
-					metadata.fmcw_dechirp_reference_transmitter_name = reference.transmitter_name;
-				}
-				else if (reference.source == radar::Receiver::DechirpReferenceSource::Custom)
-				{
-					metadata.fmcw_dechirp_reference_waveform_id = reference.waveform_id;
-					metadata.fmcw_dechirp_reference_waveform_name = reference.waveform_name;
-					if (!receiver->getDechirpSources().empty())
-					{
-						metadata.fmcw_dechirp_reference_waveform =
-							buildFmcwMetadata(receiver->getDechirpSources().front());
-					}
-				}
+				populateFmcwIfMetadata(metadata, receiver);
+				populateDechirpReferenceMetadata(metadata, receiver);
 			}
 
 			return metadata;

--- a/packages/libfers/src/processing/finalizer.cpp
+++ b/packages/libfers/src/processing/finalizer.cpp
@@ -306,7 +306,7 @@ namespace processing
 														   .sample_count = end_sample - start_sample,
 														   .sample_start = start_sample,
 														   .sample_end_exclusive = end_sample};
-					metadata.streaming_segments.push_back(std::move(segment));
+					metadata.streaming_segments.push_back(segment);
 				}
 			};
 

--- a/packages/libfers/src/processing/finalizer.cpp
+++ b/packages/libfers/src/processing/finalizer.cpp
@@ -699,8 +699,8 @@ namespace processing
 	}
 
 	void runPulsedFinalizer(radar::Receiver* receiver, const std::vector<std::unique_ptr<radar::Target>>* targets,
-							std::shared_ptr<core::ProgressReporter> reporter, const std::string& output_dir,
-							std::shared_ptr<core::OutputMetadataCollector> metadata_collector,
+							const std::shared_ptr<core::ProgressReporter>& reporter, const std::string& output_dir,
+							const std::shared_ptr<core::OutputMetadataCollector>& metadata_collector,
 							core::ReceiverOutputSink* output_sink)
 	{
 		(void)output_dir;

--- a/packages/libfers/src/processing/finalizer.cpp
+++ b/packages/libfers/src/processing/finalizer.cpp
@@ -301,11 +301,11 @@ namespace processing
 					std::max<RealType>(0.0, std::ceil((end_time - params::startTime()) * output_sample_rate))));
 				if (start_sample < end_sample)
 				{
-					core::StreamingSegmentMetadata segment{.start_time = start_time,
-														   .end_time = end_time,
-														   .sample_count = end_sample - start_sample,
-														   .sample_start = start_sample,
-														   .sample_end_exclusive = end_sample};
+					const core::StreamingSegmentMetadata segment{.start_time = start_time,
+																 .end_time = end_time,
+																 .sample_count = end_sample - start_sample,
+																 .sample_start = start_sample,
+																 .sample_end_exclusive = end_sample};
 					metadata.streaming_segments.push_back(segment);
 				}
 			};

--- a/packages/libfers/src/processing/finalizer.h
+++ b/packages/libfers/src/processing/finalizer.h
@@ -71,8 +71,8 @@ namespace processing
 	 * @param output_dir Output directory for the simulation files.
 	 */
 	void runPulsedFinalizer(radar::Receiver* receiver, const std::vector<std::unique_ptr<radar::Target>>* targets,
-							std::shared_ptr<core::ProgressReporter> reporter, const std::string& output_dir,
-							std::shared_ptr<core::OutputMetadataCollector> metadata_collector = nullptr,
+							const std::shared_ptr<core::ProgressReporter>& reporter, const std::string& output_dir,
+							const std::shared_ptr<core::OutputMetadataCollector>& metadata_collector = nullptr,
 							core::ReceiverOutputSink* output_sink = nullptr);
 
 }

--- a/packages/libfers/src/processing/finalizer_pipeline.cpp
+++ b/packages/libfers/src/processing/finalizer_pipeline.cpp
@@ -253,7 +253,7 @@ namespace processing::pipeline
 							   const RealType fullscale, const RealType ref_freq,
 							   const core::OutputFileMetadata* metadata, const RealType sample_rate)
 	{
-		std::scoped_lock lock(serial::hdf5_global_mutex);
+		std::scoped_lock const lock(serial::hdf5_global_mutex);
 		try
 		{
 			HighFive::File file(filename, HighFive::File::Truncate);

--- a/packages/libfers/src/processing/finalizer_pipeline.cpp
+++ b/packages/libfers/src/processing/finalizer_pipeline.cpp
@@ -184,8 +184,8 @@ namespace processing::pipeline
 	{
 		for (const auto& response : interference_log)
 		{
-			unsigned psize;
-			RealType prate;
+			unsigned psize = 0;
+			RealType prate = std::numeric_limits<RealType>::quiet_NaN();
 			const auto rendered_pulse = response->renderBinary(prate, psize, 0.0);
 			const RealType rate_tolerance = std::numeric_limits<RealType>::epsilon() *
 				std::max(std::abs(prate), std::abs(output_sample_rate)) * 16.0;

--- a/packages/libfers/src/processing/signal_processor.cpp
+++ b/packages/libfers/src/processing/signal_processor.cpp
@@ -94,7 +94,7 @@ namespace
 		unsigned psize;
 		RealType prate;
 		const auto array = resp->renderBinary(prate, psize, fracDelay);
-		int start_sample = static_cast<int>(std::round(rate * (resp->startTime() - start)));
+		int const start_sample = static_cast<int>(std::round(rate * (resp->startTime() - start)));
 		const auto roffset = start_sample < 0 ? static_cast<std::size_t>(-start_sample) : std::size_t{0};
 		const auto start_offset = static_cast<std::size_t>(std::max(start_sample, 0));
 

--- a/packages/libfers/src/processing/signal_processor.cpp
+++ b/packages/libfers/src/processing/signal_processor.cpp
@@ -91,8 +91,8 @@ namespace
 	void processResponse(const serial::Response* resp, std::vector<ComplexType>& localWindow, const RealType rate,
 						 const RealType start, const RealType fracDelay, const std::size_t localWindowSize)
 	{
-		unsigned psize;
-		RealType prate;
+		unsigned psize = 0;
+		RealType prate = std::numeric_limits<RealType>::quiet_NaN();
 		const auto array = resp->renderBinary(prate, psize, fracDelay);
 		int const start_sample = static_cast<int>(std::round(rate * (resp->startTime() - start)));
 		const auto roffset = start_sample < 0 ? static_cast<std::size_t>(-start_sample) : std::size_t{0};

--- a/packages/libfers/src/radar/radar_obj.h
+++ b/packages/libfers/src/radar/radar_obj.h
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "core/sim_id.h"
 #include "object.h"
 
@@ -33,7 +35,7 @@ namespace radar
 	 * @enum OperationMode
 	 * @brief Defines the operational mode of a radar component.
 	 */
-	enum class OperationMode
+	enum class OperationMode : std::uint8_t
 	{
 		PULSED_MODE, ///< The component operates in a pulsed mode.
 		CW_MODE, ///< The component operates in a continuous-wave mode.

--- a/packages/libfers/src/radar/receiver.cpp
+++ b/packages/libfers/src/radar/receiver.cpp
@@ -211,7 +211,7 @@ namespace radar
 
 	void Receiver::setFmcwIfChainRequest(FmcwIfChainRequest request) noexcept
 	{
-		_fmcw_if_chain = std::move(request);
+		_fmcw_if_chain = request;
 		_fmcw_if_plan.reset();
 		_fmcw_if_sink.reset();
 		_fmcw_if_samples_to_discard = 0;

--- a/packages/libfers/src/radar/receiver.cpp
+++ b/packages/libfers/src/radar/receiver.cpp
@@ -250,11 +250,12 @@ namespace radar
 		{
 			throw std::logic_error("FMCW IF resampling sink has not been initialized.");
 		}
+		const auto input_sample_rate_hz = _fmcw_if_plan->input_sample_rate_hz;
 		if (!_fmcw_if_segment_active)
 		{
 			beginFmcwIfResamplingSegment(block_start_time);
 		}
-		const auto block_start_index = ceilSampleIndexAtOrAfter(block_start_time, _fmcw_if_plan->input_sample_rate_hz);
+		const auto block_start_index = ceilSampleIndexAtOrAfter(block_start_time, input_sample_rate_hz);
 		if (block_start_index < _fmcw_if_input_cursor)
 		{
 			throw std::logic_error("FMCW IF resampling input blocks must be supplied in chronological order.");

--- a/packages/libfers/src/radar/receiver.cpp
+++ b/packages/libfers/src/radar/receiver.cpp
@@ -115,26 +115,26 @@ namespace radar
 
 	void Receiver::addResponseToInbox(std::unique_ptr<serial::Response> response) noexcept
 	{
-		std::scoped_lock lock(_inbox_mutex);
+		std::scoped_lock const lock(_inbox_mutex);
 		_inbox.push_back(std::move(response));
 	}
 
 	void Receiver::addInterferenceToLog(std::unique_ptr<serial::Response> response) noexcept
 	{
-		std::scoped_lock lock(_interference_log_mutex);
+		std::scoped_lock const lock(_interference_log_mutex);
 		_pulsed_interference_log.push_back(std::move(response));
 	}
 
 	void Receiver::prunePulsedInterferenceEndingBefore(const RealType cutoff_time) noexcept
 	{
-		std::scoped_lock lock(_interference_log_mutex);
+		std::scoped_lock const lock(_interference_log_mutex);
 		std::erase_if(_pulsed_interference_log,
 					  [cutoff_time](const auto& response) { return response && response->endTime() <= cutoff_time; });
 	}
 
 	std::vector<std::unique_ptr<serial::Response>> Receiver::drainInbox() noexcept
 	{
-		std::scoped_lock lock(_inbox_mutex);
+		std::scoped_lock const lock(_inbox_mutex);
 		std::vector<std::unique_ptr<serial::Response>> drained_responses;
 		drained_responses.swap(_inbox);
 		return drained_responses;
@@ -143,7 +143,7 @@ namespace radar
 	void Receiver::enqueueFinalizerJob(core::RenderingJob&& job)
 	{
 		{
-			std::scoped_lock lock(_finalizer_queue_mutex);
+			std::scoped_lock const lock(_finalizer_queue_mutex);
 			_finalizer_queue.push(std::move(job));
 		}
 		_finalizer_queue_cv.notify_one();

--- a/packages/libfers/src/radar/receiver.cpp
+++ b/packages/libfers/src/radar/receiver.cpp
@@ -157,12 +157,8 @@ namespace radar
 		job = std::move(_finalizer_queue.front());
 		_finalizer_queue.pop();
 
-		// Check for shutdown signal (negative duration)
-		if (job.duration < 0.0)
-		{
-			return false; // Shutdown signal
-		}
-		return true;
+		const bool is_shutdown_job = job.duration < 0.0;
+		return !is_shutdown_job;
 	}
 
 	RealType Receiver::getNoiseTemperature(const math::SVec3& angle) const noexcept

--- a/packages/libfers/src/radar/receiver.h
+++ b/packages/libfers/src/radar/receiver.h
@@ -52,14 +52,14 @@ namespace radar
 		 * @enum RecvFlag
 		 * @brief Enumeration for receiver configuration flags.
 		 */
-		enum class RecvFlag
+		enum class RecvFlag : std::uint8_t
 		{
 			FLAG_NODIRECT = 1, ///< Disable direct-path reception.
 			FLAG_NOPROPLOSS = 2 ///< Disable propagation-loss scaling.
 		};
 
 		/// Receiver-side FMCW dechirping mode.
-		enum class DechirpMode
+		enum class DechirpMode : std::uint8_t
 		{
 			None, ///< Output raw pre-mix streaming IQ.
 			Physical, ///< Preserve timing phase-noise decorrelation in the IF output.
@@ -67,7 +67,7 @@ namespace radar
 		};
 
 		/// Source used to construct the receiver LO reference.
-		enum class DechirpReferenceSource
+		enum class DechirpReferenceSource : std::uint8_t
 		{
 			None, ///< No reference configured.
 			Attached, ///< Use the attached transmitter.

--- a/packages/libfers/src/radar/schedule_period.cpp
+++ b/packages/libfers/src/radar/schedule_period.cpp
@@ -14,8 +14,9 @@
 namespace radar
 {
 
-	std::vector<SchedulePeriod> processRawSchedule(std::vector<SchedulePeriod> periods, const std::string& ownerName,
-												   const bool isPulsed, const RealType pri)
+	std::vector<SchedulePeriod> processRawSchedule(const std::vector<SchedulePeriod>& periods,
+												   const std::string& ownerName, const bool isPulsed,
+												   const RealType pri)
 	{
 		if (periods.empty())
 		{

--- a/packages/libfers/src/radar/schedule_period.h
+++ b/packages/libfers/src/radar/schedule_period.h
@@ -39,6 +39,6 @@ namespace radar
 	 * @param pri The Pulse Repetition Interval (only used if isPulsed is true).
 	 * @return A sorted, merged, and validated vector of periods.
 	 */
-	std::vector<SchedulePeriod> processRawSchedule(std::vector<SchedulePeriod> periods, const std::string& ownerName,
-												   bool isPulsed, RealType pri);
+	std::vector<SchedulePeriod> processRawSchedule(const std::vector<SchedulePeriod>& periods,
+												   const std::string& ownerName, bool isPulsed, RealType pri);
 }

--- a/packages/libfers/src/radar/target.cpp
+++ b/packages/libfers/src/radar/target.cpp
@@ -35,9 +35,10 @@ namespace
 		XmlElement tmp = axisXml.childElement("rcssample");
 		while (tmp.isValid())
 		{
-			XmlElement angle_element = tmp.childElement("angle", 0);
+			XmlElement const angle_element = tmp.childElement("angle", 0);
 
-			if (XmlElement gain_element = tmp.childElement("rcs", 0); angle_element.isValid() && gain_element.isValid())
+			if (XmlElement const gain_element = tmp.childElement("rcs", 0);
+				angle_element.isValid() && gain_element.isValid())
 			{
 				const RealType angle = std::stof(angle_element.getText());
 				const RealType gain = std::stof(gain_element.getText());

--- a/packages/libfers/src/serial/hdf5_handler.cpp
+++ b/packages/libfers/src/serial/hdf5_handler.cpp
@@ -18,6 +18,7 @@
 #include <format>
 #include <highfive/highfive.hpp>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "core/logging.h"
@@ -29,177 +30,125 @@ namespace serial
 {
 	std::mutex hdf5_global_mutex;
 
-	void writeOutputFileMetadataAttributes(HighFive::File& file, const core::OutputFileMetadata& metadata)
+	namespace
 	{
-		file.createAttribute("fers_metadata_schema_version", 1U);
-		file.createAttribute("fers_metadata_json", core::outputFileMetadataToJsonString(metadata));
-		file.createAttribute("receiver_id", static_cast<unsigned long long>(metadata.receiver_id));
-		file.createAttribute("receiver_name", metadata.receiver_name);
-		file.createAttribute("data_mode", metadata.mode);
-		if (metadata.sampling_rate > 0.0)
+		template <typename T>
+		void createOptionalAttribute(HighFive::File& file, const std::string& name, const std::optional<T>& value)
 		{
-			file.createAttribute("output_sampling_rate", metadata.sampling_rate);
-		}
-		file.createAttribute("total_samples", static_cast<unsigned long long>(metadata.total_samples));
-		file.createAttribute("sample_start", static_cast<unsigned long long>(metadata.sample_start));
-		file.createAttribute("sample_end_exclusive", static_cast<unsigned long long>(metadata.sample_end_exclusive));
-		file.createAttribute("streaming_segment_count",
-							 static_cast<unsigned long long>(metadata.streaming_segments.size()));
-		file.createAttribute("fmcw_source_count", static_cast<unsigned long long>(metadata.fmcw_sources.size()));
-		file.createAttribute("fmcw_dechirp_mode", metadata.fmcw_dechirp_mode);
-		file.createAttribute("fmcw_dechirp_reference_source", metadata.fmcw_dechirp_reference_source);
-		file.createAttribute("fmcw_if_decimation_enabled", metadata.fmcw_if_decimation_enabled);
-		file.createAttribute("fmcw_if_legacy_full_rate", metadata.fmcw_if_legacy_full_rate);
-		file.createAttribute("fmcw_if_group_delay_compensated", metadata.fmcw_if_group_delay_compensated);
-		if (metadata.fmcw_if_requested_sample_rate.has_value())
-		{
-			file.createAttribute("fmcw_if_requested_sample_rate", *metadata.fmcw_if_requested_sample_rate);
-		}
-		if (metadata.fmcw_if_sample_rate.has_value())
-		{
-			file.createAttribute("fmcw_if_sample_rate", *metadata.fmcw_if_sample_rate);
-		}
-		if (metadata.fmcw_if_input_sample_rate.has_value())
-		{
-			file.createAttribute("fmcw_if_input_sample_rate", *metadata.fmcw_if_input_sample_rate);
-		}
-		if (metadata.fmcw_if_resample_numerator.has_value())
-		{
-			file.createAttribute("fmcw_if_resample_numerator",
-								 static_cast<unsigned long long>(*metadata.fmcw_if_resample_numerator));
-		}
-		if (metadata.fmcw_if_resample_denominator.has_value())
-		{
-			file.createAttribute("fmcw_if_resample_denominator",
-								 static_cast<unsigned long long>(*metadata.fmcw_if_resample_denominator));
-		}
-		if (metadata.fmcw_if_decimation_factor.has_value())
-		{
-			file.createAttribute("fmcw_if_decimation_factor", *metadata.fmcw_if_decimation_factor);
-		}
-		if (metadata.fmcw_if_filter_bandwidth.has_value())
-		{
-			file.createAttribute("fmcw_if_filter_bandwidth", *metadata.fmcw_if_filter_bandwidth);
-		}
-		if (metadata.fmcw_if_filter_transition_width.has_value())
-		{
-			file.createAttribute("fmcw_if_filter_transition_width", *metadata.fmcw_if_filter_transition_width);
-		}
-		if (metadata.fmcw_if_filter_stopband.has_value())
-		{
-			file.createAttribute("fmcw_if_filter_stopband", *metadata.fmcw_if_filter_stopband);
-		}
-		if (metadata.fmcw_if_filter_group_delay_seconds.has_value())
-		{
-			file.createAttribute("fmcw_if_filter_group_delay_seconds", *metadata.fmcw_if_filter_group_delay_seconds);
-		}
-		if (metadata.fmcw_if_compensated_integer_delay_samples.has_value())
-		{
-			file.createAttribute("fmcw_if_compensated_integer_delay_samples",
-								 static_cast<unsigned long long>(*metadata.fmcw_if_compensated_integer_delay_samples));
-		}
-		if (metadata.fmcw_if_compensated_fractional_delay_samples.has_value())
-		{
-			file.createAttribute("fmcw_if_compensated_fractional_delay_samples",
-								 *metadata.fmcw_if_compensated_fractional_delay_samples);
-		}
-		if (metadata.fmcw_if_warmup_discard_samples.has_value())
-		{
-			file.createAttribute("fmcw_if_warmup_discard_samples",
-								 static_cast<unsigned long long>(*metadata.fmcw_if_warmup_discard_samples));
-		}
-		if (metadata.fmcw_if_phase_refinement.has_value())
-		{
-			file.createAttribute("fmcw_if_phase_refinement",
-								 static_cast<unsigned long long>(*metadata.fmcw_if_phase_refinement));
-		}
-		if (metadata.fmcw_if_timing_error_seconds.has_value())
-		{
-			file.createAttribute("fmcw_if_timing_error_seconds", *metadata.fmcw_if_timing_error_seconds);
-		}
-		if (metadata.fmcw_if_phase_error_radians.has_value())
-		{
-			file.createAttribute("fmcw_if_phase_error_radians", *metadata.fmcw_if_phase_error_radians);
-		}
-		if (metadata.fmcw_if_noise_variance.has_value())
-		{
-			file.createAttribute("fmcw_if_noise_variance", *metadata.fmcw_if_noise_variance);
-		}
-		if (metadata.fmcw_dechirp_reference_transmitter_id.has_value())
-		{
-			file.createAttribute("fmcw_dechirp_reference_transmitter_id",
-								 static_cast<unsigned long long>(*metadata.fmcw_dechirp_reference_transmitter_id));
-		}
-		if (metadata.fmcw_dechirp_reference_transmitter_name.has_value())
-		{
-			file.createAttribute("fmcw_dechirp_reference_transmitter_name",
-								 *metadata.fmcw_dechirp_reference_transmitter_name);
-		}
-		if (metadata.fmcw_dechirp_reference_waveform_id.has_value())
-		{
-			file.createAttribute("fmcw_dechirp_reference_waveform_id",
-								 static_cast<unsigned long long>(*metadata.fmcw_dechirp_reference_waveform_id));
-		}
-		if (metadata.fmcw_dechirp_reference_waveform_name.has_value())
-		{
-			file.createAttribute("fmcw_dechirp_reference_waveform_name",
-								 *metadata.fmcw_dechirp_reference_waveform_name);
-		}
-		if (metadata.fmcw_dechirp_reference_waveform.has_value())
-		{
-			file.createAttribute("fmcw_dechirp_reference_waveform_shape",
-								 metadata.fmcw_dechirp_reference_waveform->waveform_shape);
-			file.createAttribute("fmcw_dechirp_reference_chirp_bandwidth",
-								 metadata.fmcw_dechirp_reference_waveform->chirp_bandwidth);
-			file.createAttribute("fmcw_dechirp_reference_chirp_duration",
-								 metadata.fmcw_dechirp_reference_waveform->chirp_duration);
-			file.createAttribute("fmcw_dechirp_reference_chirp_rate",
-								 metadata.fmcw_dechirp_reference_waveform->chirp_rate);
-			file.createAttribute("fmcw_dechirp_reference_start_frequency_offset",
-								 metadata.fmcw_dechirp_reference_waveform->start_frequency_offset);
-			if (metadata.fmcw_dechirp_reference_waveform->waveform_shape == "linear")
+			if (value.has_value())
 			{
-				file.createAttribute("fmcw_dechirp_reference_chirp_period",
-									 metadata.fmcw_dechirp_reference_waveform->chirp_period);
-				file.createAttribute("fmcw_dechirp_reference_chirp_direction",
-									 metadata.fmcw_dechirp_reference_waveform->chirp_direction);
-			}
-			else if (metadata.fmcw_dechirp_reference_waveform->triangle_period.has_value())
-			{
-				file.createAttribute("fmcw_dechirp_reference_triangle_period",
-									 *metadata.fmcw_dechirp_reference_waveform->triangle_period);
+				file.createAttribute(name, *value);
 			}
 		}
-		if (metadata.fmcw.has_value())
+
+		template <typename T>
+		void createOptionalUnsignedAttribute(HighFive::File& file, const std::string& name,
+											 const std::optional<T>& value)
 		{
-			file.createAttribute("fmcw_waveform_shape", metadata.fmcw->waveform_shape);
-			file.createAttribute("fmcw_chirp_bandwidth", metadata.fmcw->chirp_bandwidth);
-			file.createAttribute("fmcw_chirp_duration", metadata.fmcw->chirp_duration);
-			file.createAttribute("fmcw_chirp_rate", metadata.fmcw->chirp_rate);
-			file.createAttribute("fmcw_start_frequency_offset", metadata.fmcw->start_frequency_offset);
-			if (metadata.fmcw->waveform_shape == "linear")
+			if (value.has_value())
 			{
-				file.createAttribute("fmcw_chirp_period", metadata.fmcw->chirp_period);
-				file.createAttribute("fmcw_chirp_rate_signed", metadata.fmcw->chirp_rate_signed);
-				file.createAttribute("fmcw_chirp_direction", metadata.fmcw->chirp_direction);
-				if (metadata.fmcw->chirp_count.has_value())
+				file.createAttribute(name, static_cast<unsigned long long>(*value));
+			}
+		}
+
+		void writeBaseMetadataAttributes(HighFive::File& file, const core::OutputFileMetadata& metadata)
+		{
+			file.createAttribute("fers_metadata_schema_version", 1U);
+			file.createAttribute("fers_metadata_json", core::outputFileMetadataToJsonString(metadata));
+			file.createAttribute("receiver_id", static_cast<unsigned long long>(metadata.receiver_id));
+			file.createAttribute("receiver_name", metadata.receiver_name);
+			file.createAttribute("data_mode", metadata.mode);
+			if (metadata.sampling_rate > 0.0)
+			{
+				file.createAttribute("output_sampling_rate", metadata.sampling_rate);
+			}
+			file.createAttribute("total_samples", static_cast<unsigned long long>(metadata.total_samples));
+			file.createAttribute("sample_start", static_cast<unsigned long long>(metadata.sample_start));
+			file.createAttribute("sample_end_exclusive",
+								 static_cast<unsigned long long>(metadata.sample_end_exclusive));
+			file.createAttribute("streaming_segment_count",
+								 static_cast<unsigned long long>(metadata.streaming_segments.size()));
+			file.createAttribute("fmcw_source_count", static_cast<unsigned long long>(metadata.fmcw_sources.size()));
+			file.createAttribute("fmcw_dechirp_mode", metadata.fmcw_dechirp_mode);
+			file.createAttribute("fmcw_dechirp_reference_source", metadata.fmcw_dechirp_reference_source);
+			file.createAttribute("fmcw_if_decimation_enabled", metadata.fmcw_if_decimation_enabled);
+			file.createAttribute("fmcw_if_legacy_full_rate", metadata.fmcw_if_legacy_full_rate);
+			file.createAttribute("fmcw_if_group_delay_compensated", metadata.fmcw_if_group_delay_compensated);
+		}
+
+		void writeFmcwIfAttributes(HighFive::File& file, const core::OutputFileMetadata& metadata)
+		{
+			createOptionalAttribute(file, "fmcw_if_requested_sample_rate", metadata.fmcw_if_requested_sample_rate);
+			createOptionalAttribute(file, "fmcw_if_sample_rate", metadata.fmcw_if_sample_rate);
+			createOptionalAttribute(file, "fmcw_if_input_sample_rate", metadata.fmcw_if_input_sample_rate);
+			createOptionalUnsignedAttribute(file, "fmcw_if_resample_numerator", metadata.fmcw_if_resample_numerator);
+			createOptionalUnsignedAttribute(file, "fmcw_if_resample_denominator",
+											metadata.fmcw_if_resample_denominator);
+			createOptionalAttribute(file, "fmcw_if_decimation_factor", metadata.fmcw_if_decimation_factor);
+			createOptionalAttribute(file, "fmcw_if_filter_bandwidth", metadata.fmcw_if_filter_bandwidth);
+			createOptionalAttribute(file, "fmcw_if_filter_transition_width", metadata.fmcw_if_filter_transition_width);
+			createOptionalAttribute(file, "fmcw_if_filter_stopband", metadata.fmcw_if_filter_stopband);
+			createOptionalAttribute(file, "fmcw_if_filter_group_delay_seconds",
+									metadata.fmcw_if_filter_group_delay_seconds);
+			createOptionalUnsignedAttribute(file, "fmcw_if_compensated_integer_delay_samples",
+											metadata.fmcw_if_compensated_integer_delay_samples);
+			createOptionalAttribute(file, "fmcw_if_compensated_fractional_delay_samples",
+									metadata.fmcw_if_compensated_fractional_delay_samples);
+			createOptionalUnsignedAttribute(file, "fmcw_if_warmup_discard_samples",
+											metadata.fmcw_if_warmup_discard_samples);
+			createOptionalUnsignedAttribute(file, "fmcw_if_phase_refinement", metadata.fmcw_if_phase_refinement);
+			createOptionalAttribute(file, "fmcw_if_timing_error_seconds", metadata.fmcw_if_timing_error_seconds);
+			createOptionalAttribute(file, "fmcw_if_phase_error_radians", metadata.fmcw_if_phase_error_radians);
+			createOptionalAttribute(file, "fmcw_if_noise_variance", metadata.fmcw_if_noise_variance);
+		}
+
+		void writeFmcwWaveformAttributes(HighFive::File& file, const std::string& prefix,
+										 const core::FmcwMetadata& waveform, const bool write_counts)
+		{
+			file.createAttribute(prefix + "waveform_shape", waveform.waveform_shape);
+			file.createAttribute(prefix + "chirp_bandwidth", waveform.chirp_bandwidth);
+			file.createAttribute(prefix + "chirp_duration", waveform.chirp_duration);
+			file.createAttribute(prefix + "chirp_rate", waveform.chirp_rate);
+			file.createAttribute(prefix + "start_frequency_offset", waveform.start_frequency_offset);
+			if (waveform.waveform_shape == "linear")
+			{
+				file.createAttribute(prefix + "chirp_period", waveform.chirp_period);
+				file.createAttribute(prefix + "chirp_direction", waveform.chirp_direction);
+				if (write_counts)
 				{
-					file.createAttribute("fmcw_chirp_count",
-										 static_cast<unsigned long long>(*metadata.fmcw->chirp_count));
+					file.createAttribute(prefix + "chirp_rate_signed", waveform.chirp_rate_signed);
+					createOptionalUnsignedAttribute(file, prefix + "chirp_count", waveform.chirp_count);
 				}
 			}
-			else if (metadata.fmcw->waveform_shape == "triangle")
+			else if (waveform.waveform_shape == "triangle" && waveform.triangle_period.has_value())
 			{
-				if (metadata.fmcw->triangle_period.has_value())
+				file.createAttribute(prefix + "triangle_period", *waveform.triangle_period);
+				if (write_counts)
 				{
-					file.createAttribute("fmcw_triangle_period", *metadata.fmcw->triangle_period);
-				}
-				if (metadata.fmcw->triangle_count.has_value())
-				{
-					file.createAttribute("fmcw_triangle_count",
-										 static_cast<unsigned long long>(*metadata.fmcw->triangle_count));
+					createOptionalUnsignedAttribute(file, prefix + "triangle_count", waveform.triangle_count);
 				}
 			}
+		}
+
+		void writeDechirpReferenceAttributes(HighFive::File& file, const core::OutputFileMetadata& metadata)
+		{
+			createOptionalUnsignedAttribute(file, "fmcw_dechirp_reference_transmitter_id",
+											metadata.fmcw_dechirp_reference_transmitter_id);
+			createOptionalAttribute(file, "fmcw_dechirp_reference_transmitter_name",
+									metadata.fmcw_dechirp_reference_transmitter_name);
+			createOptionalUnsignedAttribute(file, "fmcw_dechirp_reference_waveform_id",
+											metadata.fmcw_dechirp_reference_waveform_id);
+			createOptionalAttribute(file, "fmcw_dechirp_reference_waveform_name",
+									metadata.fmcw_dechirp_reference_waveform_name);
+			if (metadata.fmcw_dechirp_reference_waveform.has_value())
+			{
+				writeFmcwWaveformAttributes(file, "fmcw_dechirp_reference_", *metadata.fmcw_dechirp_reference_waveform,
+											false);
+			}
+		}
+
+		void writeStreamingSegmentFmcwAttributes(HighFive::File& file, const core::OutputFileMetadata& metadata)
+		{
 			std::vector<RealType> streaming_first_chirp_starts;
 			std::vector<unsigned long long> streaming_emitted_chirp_counts;
 			std::vector<RealType> streaming_first_triangle_starts;
@@ -225,7 +174,6 @@ namespace serial
 						static_cast<unsigned long long>(*segment.emitted_triangle_count));
 				}
 			}
-			// Per-segment vectors use the streaming_ prefix; scalar fmcw_ attributes describe the waveform.
 			if (!streaming_first_chirp_starts.empty())
 			{
 				auto attr = file.createAttribute<RealType>("streaming_first_chirp_start_time",
@@ -251,6 +199,24 @@ namespace serial
 				attr.write(streaming_emitted_triangle_counts);
 			}
 		}
+
+		void writeFmcwAttributes(HighFive::File& file, const core::OutputFileMetadata& metadata)
+		{
+			if (!metadata.fmcw.has_value())
+			{
+				return;
+			}
+			writeFmcwWaveformAttributes(file, "fmcw_", *metadata.fmcw, true);
+			writeStreamingSegmentFmcwAttributes(file, metadata);
+		}
+	}
+
+	void writeOutputFileMetadataAttributes(HighFive::File& file, const core::OutputFileMetadata& metadata)
+	{
+		writeBaseMetadataAttributes(file, metadata);
+		writeFmcwIfAttributes(file, metadata);
+		writeDechirpReferenceAttributes(file, metadata);
+		writeFmcwAttributes(file, metadata);
 	}
 
 	void readPulseData(const std::string& name, std::vector<ComplexType>& data)

--- a/packages/libfers/src/serial/hdf5_handler.cpp
+++ b/packages/libfers/src/serial/hdf5_handler.cpp
@@ -255,7 +255,7 @@ namespace serial
 
 	void readPulseData(const std::string& name, std::vector<ComplexType>& data)
 	{
-		std::scoped_lock lock(hdf5_global_mutex);
+		std::scoped_lock const lock(hdf5_global_mutex);
 
 		if (!std::filesystem::exists(name))
 		{
@@ -305,7 +305,7 @@ namespace serial
 	void addChunkToFile(HighFive::File& file, const std::vector<ComplexType>& data, const RealType time,
 						const RealType fullscale, const unsigned count, const core::PulseChunkMetadata* metadata)
 	{
-		std::scoped_lock lock(hdf5_global_mutex);
+		std::scoped_lock const lock(hdf5_global_mutex);
 
 		const std::size_t size = data.size();
 
@@ -365,7 +365,7 @@ namespace serial
 
 	std::vector<std::vector<RealType>> readPattern(const std::string& name, const std::string& datasetName)
 	{
-		std::scoped_lock lock(hdf5_global_mutex);
+		std::scoped_lock const lock(hdf5_global_mutex);
 		try
 		{
 			LOG(Level::TRACE, "Reading dataset '{}' from file '{}'", datasetName, name);

--- a/packages/libfers/src/serial/hdf5_output_sink.cpp
+++ b/packages/libfers/src/serial/hdf5_output_sink.cpp
@@ -76,7 +76,7 @@ namespace serial
 		{
 		}
 
-		void initializeRun(const core::OutputConfig& config, std::string /*simulation_name*/)
+		void initializeRun(const core::OutputConfig& config, const std::string& /*simulation_name*/)
 		{
 			if (config.mode != core::OutputMode::Hdf5)
 			{
@@ -265,9 +265,9 @@ namespace serial
 			{
 				state.streaming_buffer.resize(sample_end);
 			}
-			std::copy(block.samples.begin(), block.samples.end(),
-					  std::next(state.streaming_buffer.begin(),
-								static_cast<std::vector<ComplexType>::difference_type>(sample_start)));
+			std::ranges::copy(block.samples,
+							  std::next(state.streaming_buffer.begin(),
+										static_cast<std::vector<ComplexType>::difference_type>(sample_start)));
 		}
 
 		void closePulsedStream(StreamState& state)
@@ -348,7 +348,7 @@ namespace serial
 
 	void Hdf5OutputSink::initializeRun(const core::OutputConfig& config, std::string simulation_name)
 	{
-		_impl->initializeRun(config, std::move(simulation_name));
+		_impl->initializeRun(config, simulation_name);
 	}
 
 	std::uint32_t Hdf5OutputSink::registerStream(const core::ReceiverStreamDescriptor& stream)

--- a/packages/libfers/src/serial/hdf5_output_sink.cpp
+++ b/packages/libfers/src/serial/hdf5_output_sink.cpp
@@ -82,14 +82,14 @@ namespace serial
 			{
 				throw std::invalid_argument("Hdf5OutputSink requires HDF5 output mode");
 			}
-			std::scoped_lock lock(mutex);
+			std::scoped_lock const lock(mutex);
 			std::filesystem::create_directories(output_dir);
 			finalized = false;
 		}
 
 		std::uint32_t registerStream(const core::ReceiverStreamDescriptor& stream)
 		{
-			std::scoped_lock lock(mutex);
+			std::scoped_lock const lock(mutex);
 			const auto key = streamKey(stream);
 			if (const auto found = stream_ids.find(key); found != stream_ids.end())
 			{
@@ -111,7 +111,7 @@ namespace serial
 
 		void openStream(const std::uint32_t stream_id, const RealType /*first_sample_time*/)
 		{
-			std::scoped_lock lock(mutex);
+			std::scoped_lock const lock(mutex);
 			auto& state = stateFor(stream_id);
 			if (state.opened)
 			{
@@ -120,7 +120,7 @@ namespace serial
 			std::filesystem::create_directories(output_dir);
 			if (isPulsed(state))
 			{
-				std::scoped_lock hdf5_lock(hdf5_global_mutex);
+				std::scoped_lock const hdf5_lock(hdf5_global_mutex);
 				state.pulsed_file = std::make_unique<HighFive::File>(state.metadata.path, HighFive::File::Truncate);
 			}
 			else
@@ -137,7 +137,7 @@ namespace serial
 
 		void submitBlock(const core::ReceiverSampleBlock& block)
 		{
-			std::scoped_lock lock(mutex);
+			std::scoped_lock const lock(mutex);
 			const auto stream_id = registerStream(block.stream);
 			auto& state = stateFor(stream_id);
 			if (!state.opened)
@@ -159,7 +159,7 @@ namespace serial
 
 		void closeStream(const std::uint32_t stream_id)
 		{
-			std::scoped_lock lock(mutex);
+			std::scoped_lock const lock(mutex);
 			auto& state = stateFor(stream_id);
 			if (state.closed)
 			{
@@ -179,7 +179,7 @@ namespace serial
 
 		core::OutputStats finalize()
 		{
-			std::scoped_lock lock(mutex);
+			std::scoped_lock const lock(mutex);
 			if (!finalized)
 			{
 				std::vector<std::uint32_t> ids;
@@ -278,7 +278,7 @@ namespace serial
 			}
 			finalizePulsedMetadata(state.metadata);
 			{
-				std::scoped_lock hdf5_lock(hdf5_global_mutex);
+				std::scoped_lock const hdf5_lock(hdf5_global_mutex);
 				writeOutputFileMetadataAttributes(*state.pulsed_file, state.metadata);
 				state.pulsed_file.reset();
 			}

--- a/packages/libfers/src/serial/json_serializer.cpp
+++ b/packages/libfers/src/serial/json_serializer.cpp
@@ -1272,7 +1272,7 @@ namespace
 			return;
 		}
 
-		radar::OperationMode mode =
+		radar::OperationMode const mode =
 			parse_mode(comp_json, "Transmitter component '" + comp_json.value("name", "Unnamed") + "'");
 		if (mode == radar::OperationMode::FMCW_MODE && comp_json.contains("fmcw_mode") &&
 			has_dechirp_fields(comp_json.at("fmcw_mode")))
@@ -1347,7 +1347,7 @@ namespace
 			return;
 		}
 
-		radar::OperationMode mode =
+		radar::OperationMode const mode =
 			parse_mode(comp_json, "Receiver component '" + comp_json.value("name", "Unnamed") + "'");
 
 		const auto recv_id = parse_json_id(comp_json, "id", "Receiver");
@@ -1483,7 +1483,7 @@ namespace
 			return;
 		}
 
-		radar::OperationMode mode =
+		radar::OperationMode const mode =
 			parse_mode(comp_json, "Monostatic component '" + comp_json.value("name", "Unnamed") + "'");
 
 		// Transmitter part
@@ -1858,7 +1858,7 @@ namespace serial
 			auto timing_id = parse_json_id(j, "timing", "Transmitter");
 			if (auto* const timing_proto = world.findTiming(timing_id))
 			{
-				unsigned seed = tx->getTiming() ? tx->getTiming()->getSeed() : 0;
+				unsigned const seed = tx->getTiming() ? tx->getTiming()->getSeed() : 0;
 				auto timing = std::make_shared<timing::Timing>(timing_proto->getName(), seed, timing_proto->getId());
 				timing->initializeModel(timing_proto);
 				tx->setTiming(timing);
@@ -1948,7 +1948,7 @@ namespace serial
 			auto timing_id = parse_json_id(j, "timing", "Receiver");
 			if (auto* const timing_proto = world.findTiming(timing_id))
 			{
-				unsigned seed = rx->getTiming() ? rx->getTiming()->getSeed() : 0;
+				unsigned const seed = rx->getTiming() ? rx->getTiming()->getSeed() : 0;
 				auto timing = std::make_shared<timing::Timing>(timing_proto->getName(), seed, timing_proto->getId());
 				timing->initializeModel(timing_proto);
 				rx->setTiming(timing);
@@ -2020,7 +2020,7 @@ namespace serial
 			auto timing_id = parse_json_id(j, "timing", "Monostatic");
 			if (auto* const timing_proto = world.findTiming(timing_id))
 			{
-				unsigned seed = rx->getTiming() ? rx->getTiming()->getSeed() : 0;
+				unsigned const seed = rx->getTiming() ? rx->getTiming()->getSeed() : 0;
 				auto shared_timing =
 					std::make_shared<timing::Timing>(timing_proto->getName(), seed, timing_proto->getId());
 				shared_timing->initializeModel(timing_proto);
@@ -2073,7 +2073,7 @@ namespace serial
 
 		const auto target_id = existing_tgt->getId();
 		const auto name = j.value("name", existing_tgt->getName());
-		unsigned seed = existing_tgt->getSeed();
+		unsigned const seed = existing_tgt->getSeed();
 
 		if (rcs_type == "isotropic")
 		{

--- a/packages/libfers/src/serial/json_serializer.cpp
+++ b/packages/libfers/src/serial/json_serializer.cpp
@@ -327,7 +327,7 @@ namespace
 
 		receiver.setDechirpMode(mode);
 		receiver.setDechirpReference(std::move(reference));
-		receiver.setFmcwIfChainRequest(std::move(if_chain));
+		receiver.setFmcwIfChainRequest(if_chain);
 	}
 
 	/// Serializes receiver-side FMCW mode settings.

--- a/packages/libfers/src/serial/json_serializer.cpp
+++ b/packages/libfers/src/serial/json_serializer.cpp
@@ -208,6 +208,112 @@ namespace
 		return value;
 	}
 
+	bool has_if_chain_fields(const radar::Receiver::FmcwIfChainRequest& if_chain) noexcept
+	{
+		return if_chain.sample_rate_hz.has_value() || if_chain.filter_bandwidth_hz.has_value() ||
+			if_chain.filter_transition_width_hz.has_value();
+	}
+
+	void reject_disabled_json_dechirp_fields(const nlohmann::json& mode_json,
+											 const radar::Receiver::FmcwIfChainRequest& if_chain,
+											 const std::string& owner)
+	{
+		if (mode_json.contains("dechirp_reference"))
+		{
+			throw std::runtime_error(owner + " declares dechirp_reference while dechirp_mode is 'none'.");
+		}
+		if (has_if_chain_fields(if_chain))
+		{
+			throw std::runtime_error(owner + " declares IF-chain fields while dechirp_mode is 'none'.");
+		}
+	}
+
+	void validate_json_if_chain_request(const radar::Receiver::FmcwIfChainRequest& if_chain, const std::string& owner)
+	{
+		if ((if_chain.filter_bandwidth_hz.has_value() || if_chain.filter_transition_width_hz.has_value()) &&
+			!if_chain.sample_rate_hz.has_value())
+		{
+			throw std::runtime_error(owner + " IF filter fields require if_sample_rate.");
+		}
+		if (if_chain.sample_rate_hz.has_value())
+		{
+			const RealType sim_rate = params::rate() * params::oversampleRatio();
+			if (*if_chain.sample_rate_hz > sim_rate)
+			{
+				throw std::runtime_error(owner + " if_sample_rate must not exceed the simulation sample rate.");
+			}
+		}
+		if (if_chain.sample_rate_hz.has_value() && if_chain.filter_bandwidth_hz.has_value() &&
+			*if_chain.filter_bandwidth_hz >= *if_chain.sample_rate_hz / 2.0)
+		{
+			throw std::runtime_error(owner + " if_filter_bandwidth must be less than half if_sample_rate.");
+		}
+	}
+
+	std::string required_non_empty_json_string(const nlohmann::json& object, const std::string_view key,
+											   const std::string& owner, const std::string_view context)
+	{
+		const std::string key_string(key);
+		auto value = object.at(key_string).get<std::string>();
+		if (value.empty())
+		{
+			throw std::runtime_error(owner + " " + std::string(context) + " has an empty " + key_string + ".");
+		}
+		return value;
+	}
+
+	radar::Receiver::DechirpReference parse_json_dechirp_reference(const nlohmann::json& mode_json,
+																   const std::string& owner)
+	{
+		if (!mode_json.contains("dechirp_reference") || !mode_json.at("dechirp_reference").is_object())
+		{
+			throw std::runtime_error(owner + " enables dechirping but does not declare dechirp_reference.");
+		}
+
+		const auto& ref_json = mode_json.at("dechirp_reference");
+		reject_unknown_keys(ref_json, owner, "dechirp_reference", {"source", "transmitter_name", "waveform_name"});
+		if (!ref_json.contains("source"))
+		{
+			throw std::runtime_error(owner + " dechirp_reference requires source.");
+		}
+
+		radar::Receiver::DechirpReference reference;
+		reference.source = radar::parseDechirpReferenceSourceToken(ref_json.at("source").get<std::string>());
+		const bool has_transmitter_name = ref_json.contains("transmitter_name");
+		const bool has_waveform_name = ref_json.contains("waveform_name");
+
+		switch (reference.source)
+		{
+		case radar::Receiver::DechirpReferenceSource::Attached:
+			if (has_transmitter_name || has_waveform_name)
+			{
+				throw std::runtime_error(owner +
+										 " attached dechirp_reference must not set transmitter_name or waveform_name.");
+			}
+			break;
+		case radar::Receiver::DechirpReferenceSource::Transmitter:
+			if (!has_transmitter_name || has_waveform_name)
+			{
+				throw std::runtime_error(owner + " transmitter dechirp_reference requires transmitter_name only.");
+			}
+			reference.name =
+				required_non_empty_json_string(ref_json, "transmitter_name", owner, "transmitter dechirp_reference");
+			break;
+		case radar::Receiver::DechirpReferenceSource::Custom:
+			if (!has_waveform_name || has_transmitter_name)
+			{
+				throw std::runtime_error(owner + " custom dechirp_reference requires waveform_name only.");
+			}
+			reference.name =
+				required_non_empty_json_string(ref_json, "waveform_name", owner, "custom dechirp_reference");
+			break;
+		case radar::Receiver::DechirpReferenceSource::None:
+			throw std::runtime_error(owner + " dechirp_reference source must be attached, transmitter, or custom.");
+		}
+
+		return reference;
+	}
+
 	/// Parses receiver-side dechirp settings from a JSON component.
 	void parse_receiver_dechirp_config(const nlohmann::json& comp_json, radar::Receiver& receiver,
 									   const std::string& owner)
@@ -240,90 +346,13 @@ namespace
 
 		if (mode == radar::Receiver::DechirpMode::None)
 		{
-			if (mode_json.contains("dechirp_reference"))
-			{
-				throw std::runtime_error(owner + " declares dechirp_reference while dechirp_mode is 'none'.");
-			}
-			if (if_chain.sample_rate_hz.has_value() || if_chain.filter_bandwidth_hz.has_value() ||
-				if_chain.filter_transition_width_hz.has_value())
-			{
-				throw std::runtime_error(owner + " declares IF-chain fields while dechirp_mode is 'none'.");
-			}
+			reject_disabled_json_dechirp_fields(mode_json, if_chain, owner);
 			receiver.setDechirpMode(mode);
 			return;
 		}
 
-		if ((if_chain.filter_bandwidth_hz.has_value() || if_chain.filter_transition_width_hz.has_value()) &&
-			!if_chain.sample_rate_hz.has_value())
-		{
-			throw std::runtime_error(owner + " IF filter fields require if_sample_rate.");
-		}
-		if (if_chain.sample_rate_hz.has_value())
-		{
-			const RealType sim_rate = params::rate() * params::oversampleRatio();
-			if (*if_chain.sample_rate_hz > sim_rate)
-			{
-				throw std::runtime_error(owner + " if_sample_rate must not exceed the simulation sample rate.");
-			}
-		}
-		if (if_chain.sample_rate_hz.has_value() && if_chain.filter_bandwidth_hz.has_value())
-		{
-			if (*if_chain.filter_bandwidth_hz >= *if_chain.sample_rate_hz / 2.0)
-			{
-				throw std::runtime_error(owner + " if_filter_bandwidth must be less than half if_sample_rate.");
-			}
-		}
-
-		if (!mode_json.contains("dechirp_reference") || !mode_json.at("dechirp_reference").is_object())
-		{
-			throw std::runtime_error(owner + " enables dechirping but does not declare dechirp_reference.");
-		}
-
-		const auto& ref_json = mode_json.at("dechirp_reference");
-		reject_unknown_keys(ref_json, owner, "dechirp_reference", {"source", "transmitter_name", "waveform_name"});
-		if (!ref_json.contains("source"))
-		{
-			throw std::runtime_error(owner + " dechirp_reference requires source.");
-		}
-		radar::Receiver::DechirpReference reference;
-		reference.source = radar::parseDechirpReferenceSourceToken(ref_json.at("source").get<std::string>());
-
-		const bool has_transmitter_name = ref_json.contains("transmitter_name");
-		const bool has_waveform_name = ref_json.contains("waveform_name");
-		switch (reference.source)
-		{
-		case radar::Receiver::DechirpReferenceSource::Attached:
-			if (has_transmitter_name || has_waveform_name)
-			{
-				throw std::runtime_error(owner +
-										 " attached dechirp_reference must not set transmitter_name or waveform_name.");
-			}
-			break;
-		case radar::Receiver::DechirpReferenceSource::Transmitter:
-			if (!has_transmitter_name || has_waveform_name)
-			{
-				throw std::runtime_error(owner + " transmitter dechirp_reference requires transmitter_name only.");
-			}
-			reference.name = ref_json.at("transmitter_name").get<std::string>();
-			if (reference.name.empty())
-			{
-				throw std::runtime_error(owner + " transmitter dechirp_reference has an empty transmitter_name.");
-			}
-			break;
-		case radar::Receiver::DechirpReferenceSource::Custom:
-			if (!has_waveform_name || has_transmitter_name)
-			{
-				throw std::runtime_error(owner + " custom dechirp_reference requires waveform_name only.");
-			}
-			reference.name = ref_json.at("waveform_name").get<std::string>();
-			if (reference.name.empty())
-			{
-				throw std::runtime_error(owner + " custom dechirp_reference has an empty waveform_name.");
-			}
-			break;
-		case radar::Receiver::DechirpReferenceSource::None:
-			throw std::runtime_error(owner + " dechirp_reference source must be attached, transmitter, or custom.");
-		}
+		validate_json_if_chain_request(if_chain, owner);
+		auto reference = parse_json_dechirp_reference(mode_json, owner);
 
 		receiver.setDechirpMode(mode);
 		receiver.setDechirpReference(std::move(reference));
@@ -1156,74 +1185,80 @@ namespace
 		}
 	}
 
+	using JsonNameRegistry = std::unordered_map<std::string, std::string>;
+
+	void register_json_name(JsonNameRegistry& name_registry, const nlohmann::json& element, const std::string_view kind)
+	{
+		if (!element.is_object() || !element.contains("name"))
+		{
+			return;
+		}
+
+		const auto name = element.at("name").get<std::string>();
+		const auto [iter, inserted] = name_registry.emplace(name, std::string(kind));
+		if (!inserted)
+		{
+			throw std::runtime_error("Duplicate name '" + name + "' found for " + std::string(kind) +
+									 "; previously used by " + iter->second + ".");
+		}
+	}
+
+	void register_json_name_array(JsonNameRegistry& name_registry, const nlohmann::json& sim,
+								  const std::string_view key, const std::string_view kind)
+	{
+		const std::string key_string(key);
+		if (!sim.contains(key_string))
+		{
+			return;
+		}
+		for (const auto& element : sim.at(key_string))
+		{
+			register_json_name(name_registry, element, kind);
+		}
+	}
+
+	void register_platform_component_names(JsonNameRegistry& name_registry, const nlohmann::json& platform)
+	{
+		if (!platform.contains("components") || !platform.at("components").is_array())
+		{
+			return;
+		}
+
+		for (const auto& component_wrapper : platform.at("components"))
+		{
+			if (!component_wrapper.is_object())
+			{
+				continue;
+			}
+			for (const auto& [kind, component] : component_wrapper.items())
+			{
+				register_json_name(name_registry, component, kind);
+			}
+		}
+	}
+
+	void register_platform_names(JsonNameRegistry& name_registry, const nlohmann::json& sim)
+	{
+		if (!sim.contains("platforms"))
+		{
+			return;
+		}
+
+		for (const auto& platform : sim.at("platforms"))
+		{
+			register_json_name(name_registry, platform, "platform");
+			register_platform_component_names(name_registry, platform);
+		}
+	}
+
 	void validate_unique_names(const nlohmann::json& sim)
 	{
-		std::unordered_map<std::string, std::string> name_registry;
+		JsonNameRegistry name_registry;
 		name_registry.reserve(64);
-
-		const auto register_name = [&name_registry](const nlohmann::json& element, const std::string_view kind)
-		{
-			if (!element.is_object() || !element.contains("name"))
-			{
-				return;
-			}
-
-			const auto name = element.at("name").get<std::string>();
-			const auto [iter, inserted] = name_registry.emplace(name, std::string(kind));
-			if (!inserted)
-			{
-				throw std::runtime_error("Duplicate name '" + name + "' found for " + std::string(kind) +
-										 "; previously used by " + iter->second + ".");
-			}
-		};
-
-		if (sim.contains("waveforms"))
-		{
-			for (const auto& waveform : sim.at("waveforms"))
-			{
-				register_name(waveform, "waveform");
-			}
-		}
-
-		if (sim.contains("timings"))
-		{
-			for (const auto& timing : sim.at("timings"))
-			{
-				register_name(timing, "timing");
-			}
-		}
-
-		if (sim.contains("antennas"))
-		{
-			for (const auto& antenna : sim.at("antennas"))
-			{
-				register_name(antenna, "antenna");
-			}
-		}
-
-		if (sim.contains("platforms"))
-		{
-			for (const auto& platform : sim.at("platforms"))
-			{
-				register_name(platform, "platform");
-				if (!platform.contains("components") || !platform.at("components").is_array())
-				{
-					continue;
-				}
-
-				for (const auto& component_wrapper : platform.at("components"))
-				{
-					if (!component_wrapper.is_object())
-					{
-						continue;
-					}
-					for (const auto& [kind, component] : component_wrapper.items())
-					{
-						register_name(component, kind);
-					}
-				}
-			}
-		}
+		register_json_name_array(name_registry, sim, "waveforms", "waveform");
+		register_json_name_array(name_registry, sim, "timings", "timing");
+		register_json_name_array(name_registry, sim, "antennas", "antenna");
+		register_platform_names(name_registry, sim);
 	}
 
 	/// Counts operation mode blocks on a component.
@@ -1681,48 +1716,54 @@ namespace serial
 		parse_parameters(sim, masterSeeder);
 	}
 
-	void update_antenna_from_json(const nlohmann::json& j, antenna::Antenna* ant, core::World& world)
+	std::unique_ptr<antenna::Antenna> parse_required_update_antenna(const nlohmann::json& j)
 	{
-		auto new_pattern = j.value("pattern", "isotropic");
-		bool type_changed = false;
-
-		const auto parse_required_antenna = [&j]()
+		auto parsed = parse_antenna_from_json(j);
+		if (parsed == nullptr)
 		{
-			auto parsed = parse_antenna_from_json(j);
-			if (parsed == nullptr)
-			{
-				const auto name = j.value("name", std::string{});
-				const auto pattern = j.value("pattern", "isotropic");
-				throw std::runtime_error("Cannot update antenna '" + name + "' to pattern '" + pattern +
-										 "' without a filename.");
-			}
-			return parsed;
-		};
-
-		if (new_pattern == "isotropic" && (dynamic_cast<antenna::Isotropic*>(ant) == nullptr))
-			type_changed = true;
-		else if (new_pattern == "sinc" && (dynamic_cast<antenna::Sinc*>(ant) == nullptr))
-			type_changed = true;
-		else if (new_pattern == "gaussian" && (dynamic_cast<antenna::Gaussian*>(ant) == nullptr))
-			type_changed = true;
-		else if (new_pattern == "squarehorn" && (dynamic_cast<antenna::SquareHorn*>(ant) == nullptr))
-			type_changed = true;
-		else if (new_pattern == "parabolic" && (dynamic_cast<antenna::Parabolic*>(ant) == nullptr))
-			type_changed = true;
-		else if (new_pattern == "xml" && (dynamic_cast<antenna::XmlAntenna*>(ant) == nullptr))
-			type_changed = true;
-		else if (new_pattern == "file" && (dynamic_cast<antenna::H5Antenna*>(ant) == nullptr))
-			type_changed = true;
-
-		if (type_changed)
-		{
-			world.replace(parse_required_antenna());
-			return;
+			const auto name = j.value("name", std::string{});
+			const auto pattern = j.value("pattern", "isotropic");
+			throw std::runtime_error("Cannot update antenna '" + name + "' to pattern '" + pattern +
+									 "' without a filename.");
 		}
+		return parsed;
+	}
 
-		ant->setName(j.at("name").get<std::string>());
-		ant->setEfficiencyFactor(j.value("efficiency", 1.0));
+	bool antenna_pattern_requires_replacement(const std::string_view pattern, const antenna::Antenna* ant) noexcept
+	{
+		if (pattern == "isotropic")
+		{
+			return dynamic_cast<const antenna::Isotropic*>(ant) == nullptr;
+		}
+		if (pattern == "sinc")
+		{
+			return dynamic_cast<const antenna::Sinc*>(ant) == nullptr;
+		}
+		if (pattern == "gaussian")
+		{
+			return dynamic_cast<const antenna::Gaussian*>(ant) == nullptr;
+		}
+		if (pattern == "squarehorn")
+		{
+			return dynamic_cast<const antenna::SquareHorn*>(ant) == nullptr;
+		}
+		if (pattern == "parabolic")
+		{
+			return dynamic_cast<const antenna::Parabolic*>(ant) == nullptr;
+		}
+		if (pattern == "xml")
+		{
+			return dynamic_cast<const antenna::XmlAntenna*>(ant) == nullptr;
+		}
+		if (pattern == "file")
+		{
+			return dynamic_cast<const antenna::H5Antenna*>(ant) == nullptr;
+		}
+		return false;
+	}
 
+	void update_existing_antenna_pattern_fields(const nlohmann::json& j, antenna::Antenna* ant, core::World& world)
+	{
 		if (auto* sinc = dynamic_cast<antenna::Sinc*>(ant))
 		{
 			sinc->setAlpha(j.value("alpha", 1.0));
@@ -1746,16 +1787,30 @@ namespace serial
 		{
 			if (xml->getFilename() != j.value("filename", ""))
 			{
-				world.replace(parse_required_antenna());
+				world.replace(parse_required_update_antenna(j));
 			}
 		}
 		else if (auto* h5 = dynamic_cast<antenna::H5Antenna*>(ant))
 		{
 			if (h5->getFilename() != j.value("filename", ""))
 			{
-				world.replace(parse_required_antenna());
+				world.replace(parse_required_update_antenna(j));
 			}
 		}
+	}
+
+	void update_antenna_from_json(const nlohmann::json& j, antenna::Antenna* ant, core::World& world)
+	{
+		const auto new_pattern = j.value("pattern", "isotropic");
+		if (antenna_pattern_requires_replacement(new_pattern, ant))
+		{
+			world.replace(parse_required_update_antenna(j));
+			return;
+		}
+
+		ant->setName(j.at("name").get<std::string>());
+		ant->setEfficiencyFactor(j.value("efficiency", 1.0));
+		update_existing_antenna_pattern_fields(j, ant, world);
 	}
 
 	void update_platform_paths_from_json(const nlohmann::json& j, radar::Platform* plat)
@@ -1827,90 +1882,210 @@ namespace serial
 		}
 	}
 
+	void update_transmitter_mode_from_json(const nlohmann::json& j, radar::Transmitter& tx)
+	{
+		reject_conflicting_mode_blocks(j, "Transmitter '" + tx.getName() + "'");
+		if (j.contains("pulsed_mode"))
+		{
+			tx.setMode(radar::OperationMode::PULSED_MODE);
+			tx.setPrf(j.at("pulsed_mode").value("prf", 0.0));
+		}
+		else if (j.contains("fmcw_mode"))
+		{
+			if (has_dechirp_fields(j.at("fmcw_mode")))
+			{
+				throw std::runtime_error("Transmitter '" + tx.getName() +
+										 "' fmcw_mode must not contain dechirp configuration.");
+			}
+			tx.setMode(radar::OperationMode::FMCW_MODE);
+		}
+		else if (j.contains("cw_mode"))
+		{
+			tx.setMode(radar::OperationMode::CW_MODE);
+		}
+	}
+
+	void update_transmitter_waveform_from_json(const nlohmann::json& j, radar::Transmitter& tx, core::World& world)
+	{
+		if (!j.contains("waveform"))
+		{
+			return;
+		}
+		auto id = parse_json_id(j, "waveform", "Transmitter");
+		auto* wf = world.findWaveform(id);
+		if (wf == nullptr)
+		{
+			throw std::runtime_error("Waveform ID " + std::to_string(id) + " not found.");
+		}
+		validate_fmcw_waveform(*wf, "Waveform '" + wf->getName() + "'");
+		validate_waveform_mode_match(*wf, tx.getMode(), "Transmitter '" + tx.getName() + "'");
+		tx.setWave(wf);
+	}
+
+	void update_transmitter_antenna_from_json(const nlohmann::json& j, radar::Transmitter& tx, core::World& world)
+	{
+		if (!j.contains("antenna"))
+		{
+			return;
+		}
+		auto id = parse_json_id(j, "antenna", "Transmitter");
+		auto* ant = world.findAntenna(id);
+		if (ant == nullptr)
+		{
+			throw std::runtime_error("Antenna ID " + std::to_string(id) + " not found.");
+		}
+		tx.setAntenna(ant);
+	}
+
+	void update_transmitter_timing_from_json(const nlohmann::json& j, radar::Transmitter& tx, core::World& world)
+	{
+		if (!j.contains("timing"))
+		{
+			return;
+		}
+		auto timing_id = parse_json_id(j, "timing", "Transmitter");
+		auto* const timing_proto = world.findTiming(timing_id);
+		if (timing_proto == nullptr)
+		{
+			throw std::runtime_error("Timing ID " + std::to_string(timing_id) + " not found.");
+		}
+		unsigned const seed = tx.getTiming() ? tx.getTiming()->getSeed() : 0;
+		auto timing = std::make_shared<timing::Timing>(timing_proto->getName(), seed, timing_proto->getId());
+		timing->initializeModel(timing_proto);
+		tx.setTiming(timing);
+	}
+
+	void validate_transmitter_signal_state(const radar::Transmitter& tx, const std::string& owner)
+	{
+		if (tx.getSignal() == nullptr)
+		{
+			return;
+		}
+		validate_fmcw_waveform(*tx.getSignal(), "Waveform '" + tx.getSignal()->getName() + "'");
+		validate_waveform_mode_match(*tx.getSignal(), tx.getMode(), owner);
+		if (tx.getSignal()->isFmcwFamily())
+		{
+			validate_fmcw_schedule(tx.getSchedule(), *tx.getSignal(), owner);
+		}
+	}
+
+	void update_transmitter_schedule_from_json(const nlohmann::json& j, radar::Transmitter& tx,
+											   const std::string& owner)
+	{
+		if (!j.contains("schedule"))
+		{
+			return;
+		}
+		auto raw = j.at("schedule").get<std::vector<radar::SchedulePeriod>>();
+		const bool pulsed = tx.getMode() == radar::OperationMode::PULSED_MODE;
+		const RealType pri = pulsed ? 1.0 / tx.getPrf() : 0.0;
+		auto schedule = radar::processRawSchedule(raw, tx.getName(), pulsed, pri);
+		if (tx.getSignal() != nullptr && tx.getSignal()->isFmcwFamily())
+		{
+			validate_fmcw_schedule(schedule, *tx.getSignal(), owner);
+		}
+		tx.setSchedule(std::move(schedule));
+	}
+
 	void update_transmitter_from_json(const nlohmann::json& j, radar::Transmitter* tx, core::World& world,
 									  std::mt19937& /*masterSeeder*/)
 	{
 		if (j.contains("name"))
 			tx->setName(j.at("name").get<std::string>());
 
-		reject_conflicting_mode_blocks(j, "Transmitter '" + tx->getName() + "'");
+		const std::string owner = "Transmitter '" + tx->getName() + "'";
+		update_transmitter_mode_from_json(j, *tx);
+		update_transmitter_waveform_from_json(j, *tx, world);
+		update_transmitter_antenna_from_json(j, *tx, world);
+		update_transmitter_timing_from_json(j, *tx, world);
+		update_transmitter_schedule_from_json(j, *tx, owner);
+		validate_transmitter_signal_state(*tx, owner);
+	}
+
+	void update_receiver_mode_from_json(const nlohmann::json& j, radar::Receiver& rx)
+	{
+		reject_conflicting_mode_blocks(j, "Receiver '" + rx.getName() + "'");
 		if (j.contains("pulsed_mode"))
 		{
-			tx->setMode(radar::OperationMode::PULSED_MODE);
-			tx->setPrf(j.at("pulsed_mode").value("prf", 0.0));
+			rx.setMode(radar::OperationMode::PULSED_MODE);
+			const auto& mode_json = j.at("pulsed_mode");
+			rx.setWindowProperties(mode_json.value("window_length", 0.0), mode_json.value("prf", 0.0),
+								   mode_json.value("window_skip", 0.0));
 		}
 		else if (j.contains("fmcw_mode"))
 		{
-			if (has_dechirp_fields(j.at("fmcw_mode")))
-			{
-				throw std::runtime_error("Transmitter '" + tx->getName() +
-										 "' fmcw_mode must not contain dechirp configuration.");
-			}
-			tx->setMode(radar::OperationMode::FMCW_MODE);
+			rx.setMode(radar::OperationMode::FMCW_MODE);
 		}
 		else if (j.contains("cw_mode"))
 		{
-			tx->setMode(radar::OperationMode::CW_MODE);
+			rx.setMode(radar::OperationMode::CW_MODE);
 		}
+	}
 
-		if (j.contains("waveform"))
-		{
-			auto id = parse_json_id(j, "waveform", "Transmitter");
-			auto* wf = world.findWaveform(id);
-			if (wf == nullptr)
-				throw std::runtime_error("Waveform ID " + std::to_string(id) + " not found.");
-			validate_fmcw_waveform(*wf, "Waveform '" + wf->getName() + "'");
-			validate_waveform_mode_match(*wf, tx->getMode(), "Transmitter '" + tx->getName() + "'");
-			tx->setWave(wf);
-		}
+	void update_receiver_noise_and_flags_from_json(const nlohmann::json& j, radar::Receiver& rx)
+	{
+		if (j.contains("noise_temp"))
+			rx.setNoiseTemperature(j.value("noise_temp", 0.0));
 
-		if (j.contains("antenna"))
+		if (j.contains("nodirect"))
 		{
-			auto id = parse_json_id(j, "antenna", "Transmitter");
-			auto* ant = world.findAntenna(id);
-			if (ant == nullptr)
-				throw std::runtime_error("Antenna ID " + std::to_string(id) + " not found.");
-			tx->setAntenna(ant);
-		}
-
-		if (j.contains("timing"))
-		{
-			auto timing_id = parse_json_id(j, "timing", "Transmitter");
-			if (auto* const timing_proto = world.findTiming(timing_id))
-			{
-				unsigned const seed = tx->getTiming() ? tx->getTiming()->getSeed() : 0;
-				auto timing = std::make_shared<timing::Timing>(timing_proto->getName(), seed, timing_proto->getId());
-				timing->initializeModel(timing_proto);
-				tx->setTiming(timing);
-			}
+			if (j.value("nodirect", false))
+				rx.setFlag(radar::Receiver::RecvFlag::FLAG_NODIRECT);
 			else
-			{
-				throw std::runtime_error("Timing ID " + std::to_string(timing_id) + " not found.");
-			}
+				rx.clearFlag(radar::Receiver::RecvFlag::FLAG_NODIRECT);
 		}
-		if (j.contains("schedule"))
+		if (j.contains("nopropagationloss"))
 		{
-			auto raw = j.at("schedule").get<std::vector<radar::SchedulePeriod>>();
-			RealType pri = 0.0;
-			if (tx->getMode() == radar::OperationMode::PULSED_MODE)
-				pri = 1.0 / tx->getPrf();
-			auto schedule =
-				radar::processRawSchedule(raw, tx->getName(), tx->getMode() == radar::OperationMode::PULSED_MODE, pri);
-			if (tx->getSignal() != nullptr && tx->getSignal()->isFmcwFamily())
-			{
-				validate_fmcw_schedule(schedule, *tx->getSignal(), "Transmitter '" + tx->getName() + "'");
-			}
-			tx->setSchedule(std::move(schedule));
+			if (j.value("nopropagationloss", false))
+				rx.setFlag(radar::Receiver::RecvFlag::FLAG_NOPROPLOSS);
+			else
+				rx.clearFlag(radar::Receiver::RecvFlag::FLAG_NOPROPLOSS);
 		}
-		if (tx->getSignal() != nullptr)
+	}
+
+	void update_receiver_antenna_from_json(const nlohmann::json& j, radar::Receiver& rx, core::World& world)
+	{
+		if (!j.contains("antenna"))
 		{
-			validate_fmcw_waveform(*tx->getSignal(), "Waveform '" + tx->getSignal()->getName() + "'");
-			validate_waveform_mode_match(*tx->getSignal(), tx->getMode(), "Transmitter '" + tx->getName() + "'");
-			if (tx->getSignal()->isFmcwFamily())
-			{
-				validate_fmcw_schedule(tx->getSchedule(), *tx->getSignal(), "Transmitter '" + tx->getName() + "'");
-			}
+			return;
 		}
+		auto id = parse_json_id(j, "antenna", "Receiver");
+		auto* ant = world.findAntenna(id);
+		if (ant == nullptr)
+		{
+			throw std::runtime_error("Antenna ID " + std::to_string(id) + " not found.");
+		}
+		rx.setAntenna(ant);
+	}
+
+	void update_receiver_timing_from_json(const nlohmann::json& j, radar::Receiver& rx, core::World& world)
+	{
+		if (!j.contains("timing"))
+		{
+			return;
+		}
+		auto timing_id = parse_json_id(j, "timing", "Receiver");
+		auto* const timing_proto = world.findTiming(timing_id);
+		if (timing_proto == nullptr)
+		{
+			throw std::runtime_error("Timing ID " + std::to_string(timing_id) + " not found.");
+		}
+		unsigned const seed = rx.getTiming() ? rx.getTiming()->getSeed() : 0;
+		auto timing = std::make_shared<timing::Timing>(timing_proto->getName(), seed, timing_proto->getId());
+		timing->initializeModel(timing_proto);
+		rx.setTiming(timing);
+	}
+
+	void update_receiver_schedule_from_json(const nlohmann::json& j, radar::Receiver& rx)
+	{
+		if (!j.contains("schedule"))
+		{
+			return;
+		}
+		auto raw = j.at("schedule").get<std::vector<radar::SchedulePeriod>>();
+		const bool pulsed = rx.getMode() == radar::OperationMode::PULSED_MODE;
+		const RealType pri = pulsed ? 1.0 / rx.getWindowPrf() : 0.0;
+		rx.setSchedule(radar::processRawSchedule(raw, rx.getName(), pulsed, pri));
 	}
 
 	void update_receiver_from_json(const nlohmann::json& j, radar::Receiver* rx, core::World& world,
@@ -1919,74 +2094,11 @@ namespace serial
 		if (j.contains("name"))
 			rx->setName(j.at("name").get<std::string>());
 
-		reject_conflicting_mode_blocks(j, "Receiver '" + rx->getName() + "'");
-		if (j.contains("pulsed_mode"))
-		{
-			rx->setMode(radar::OperationMode::PULSED_MODE);
-			const auto& mode_json = j.at("pulsed_mode");
-			rx->setWindowProperties(mode_json.value("window_length", 0.0), mode_json.value("prf", 0.0),
-									mode_json.value("window_skip", 0.0));
-		}
-		else if (j.contains("fmcw_mode"))
-		{
-			rx->setMode(radar::OperationMode::FMCW_MODE);
-		}
-		else if (j.contains("cw_mode"))
-		{
-			rx->setMode(radar::OperationMode::CW_MODE);
-		}
-
-		if (j.contains("noise_temp"))
-			rx->setNoiseTemperature(j.value("noise_temp", 0.0));
-
-		if (j.contains("nodirect"))
-		{
-			if (j.value("nodirect", false))
-				rx->setFlag(radar::Receiver::RecvFlag::FLAG_NODIRECT);
-			else
-				rx->clearFlag(radar::Receiver::RecvFlag::FLAG_NODIRECT);
-		}
-		if (j.contains("nopropagationloss"))
-		{
-			if (j.value("nopropagationloss", false))
-				rx->setFlag(radar::Receiver::RecvFlag::FLAG_NOPROPLOSS);
-			else
-				rx->clearFlag(radar::Receiver::RecvFlag::FLAG_NOPROPLOSS);
-		}
-
-		if (j.contains("antenna"))
-		{
-			auto id = parse_json_id(j, "antenna", "Receiver");
-			auto* ant = world.findAntenna(id);
-			if (ant == nullptr)
-				throw std::runtime_error("Antenna ID " + std::to_string(id) + " not found.");
-			rx->setAntenna(ant);
-		}
-
-		if (j.contains("timing"))
-		{
-			auto timing_id = parse_json_id(j, "timing", "Receiver");
-			if (auto* const timing_proto = world.findTiming(timing_id))
-			{
-				unsigned const seed = rx->getTiming() ? rx->getTiming()->getSeed() : 0;
-				auto timing = std::make_shared<timing::Timing>(timing_proto->getName(), seed, timing_proto->getId());
-				timing->initializeModel(timing_proto);
-				rx->setTiming(timing);
-			}
-			else
-			{
-				throw std::runtime_error("Timing ID " + std::to_string(timing_id) + " not found.");
-			}
-		}
-		if (j.contains("schedule"))
-		{
-			auto raw = j.at("schedule").get<std::vector<radar::SchedulePeriod>>();
-			RealType pri = 0.0;
-			if (rx->getMode() == radar::OperationMode::PULSED_MODE)
-				pri = 1.0 / rx->getWindowPrf();
-			rx->setSchedule(
-				radar::processRawSchedule(raw, rx->getName(), rx->getMode() == radar::OperationMode::PULSED_MODE, pri));
-		}
+		update_receiver_mode_from_json(j, *rx);
+		update_receiver_noise_and_flags_from_json(j, *rx);
+		update_receiver_antenna_from_json(j, *rx, world);
+		update_receiver_timing_from_json(j, *rx, world);
+		update_receiver_schedule_from_json(j, *rx);
 		if (j.contains("fmcw_mode"))
 		{
 			parse_receiver_dechirp_config(j, *rx, "Receiver '" + rx->getName() + "'");
@@ -1994,8 +2106,7 @@ namespace serial
 		world.resolveReceiverDechirpReferences();
 	}
 
-	void update_monostatic_from_json(const nlohmann::json& j, radar::Transmitter* tx, radar::Receiver* rx,
-									 core::World& world, std::mt19937& masterSeeder)
+	nlohmann::json monostatic_transmitter_json(const nlohmann::json& j)
 	{
 		auto transmitter_json = j;
 		if (transmitter_json.contains("fmcw_mode") && transmitter_json.at("fmcw_mode").is_object())
@@ -2006,76 +2117,76 @@ namespace serial
 			transmitter_json["fmcw_mode"].erase("if_filter_bandwidth");
 			transmitter_json["fmcw_mode"].erase("if_filter_transition_width");
 		}
-		update_transmitter_from_json(transmitter_json, tx, world, masterSeeder);
+		return transmitter_json;
+	}
 
+	void update_monostatic_receiver_basics(const nlohmann::json& j, const radar::Transmitter& tx, radar::Receiver& rx,
+										   core::World& world)
+	{
 		if (j.contains("name"))
-			rx->setName(j.at("name").get<std::string>());
-		rx->setMode(tx->getMode());
-		if (rx->getMode() == radar::OperationMode::PULSED_MODE && j.contains("pulsed_mode"))
+			rx.setName(j.at("name").get<std::string>());
+		rx.setMode(tx.getMode());
+		if (rx.getMode() == radar::OperationMode::PULSED_MODE && j.contains("pulsed_mode"))
 		{
 			const auto& mode_json = j.at("pulsed_mode");
-			rx->setWindowProperties(mode_json.value("window_length", 0.0), tx->getPrf(),
-									mode_json.value("window_skip", 0.0));
+			rx.setWindowProperties(mode_json.value("window_length", 0.0), tx.getPrf(),
+								   mode_json.value("window_skip", 0.0));
 		}
-		if (j.contains("noise_temp"))
-			rx->setNoiseTemperature(j.value("noise_temp", 0.0));
-		if (j.contains("nodirect"))
-		{
-			if (j.value("nodirect", false))
-				rx->setFlag(radar::Receiver::RecvFlag::FLAG_NODIRECT);
-			else
-				rx->clearFlag(radar::Receiver::RecvFlag::FLAG_NODIRECT);
-		}
-		if (j.contains("nopropagationloss"))
-		{
-			if (j.value("nopropagationloss", false))
-				rx->setFlag(radar::Receiver::RecvFlag::FLAG_NOPROPLOSS);
-			else
-				rx->clearFlag(radar::Receiver::RecvFlag::FLAG_NOPROPLOSS);
-		}
+		update_receiver_noise_and_flags_from_json(j, rx);
 		if (j.contains("antenna"))
-			rx->setAntenna(world.findAntenna(parse_json_id(j, "antenna", "Monostatic")));
-		if (j.contains("timing"))
 		{
-			auto timing_id = parse_json_id(j, "timing", "Monostatic");
-			if (auto* const timing_proto = world.findTiming(timing_id))
-			{
-				unsigned const seed = rx->getTiming() ? rx->getTiming()->getSeed() : 0;
-				auto shared_timing =
-					std::make_shared<timing::Timing>(timing_proto->getName(), seed, timing_proto->getId());
-				shared_timing->initializeModel(timing_proto);
-				tx->setTiming(shared_timing);
-				rx->setTiming(shared_timing);
-			}
-			else
-			{
-				throw std::runtime_error("Timing ID " + std::to_string(timing_id) + " not found.");
-			}
+			rx.setAntenna(world.findAntenna(parse_json_id(j, "antenna", "Monostatic")));
 		}
-		if (j.contains("schedule"))
+	}
+
+	void update_monostatic_timing_from_json(const nlohmann::json& j, radar::Transmitter& tx, radar::Receiver& rx,
+											core::World& world)
+	{
+		if (!j.contains("timing"))
 		{
-			auto raw = j.at("schedule").get<std::vector<radar::SchedulePeriod>>();
-			RealType pri = 0.0;
-			if (tx->getMode() == radar::OperationMode::PULSED_MODE)
-				pri = 1.0 / tx->getPrf();
-			auto processed_schedule = radar::processRawSchedule(
-				std::move(raw), tx->getName(), tx->getMode() == radar::OperationMode::PULSED_MODE, pri);
-			if (tx->getSignal() != nullptr && tx->getSignal()->isFmcwFamily())
-			{
-				validate_fmcw_schedule(processed_schedule, *tx->getSignal(), "Monostatic '" + tx->getName() + "'");
-			}
-			tx->setSchedule(processed_schedule);
-			rx->setSchedule(processed_schedule);
+			return;
 		}
-		if (tx->getSignal() != nullptr)
+		auto timing_id = parse_json_id(j, "timing", "Monostatic");
+		auto* const timing_proto = world.findTiming(timing_id);
+		if (timing_proto == nullptr)
 		{
-			validate_fmcw_waveform(*tx->getSignal(), "Waveform '" + tx->getSignal()->getName() + "'");
-			validate_waveform_mode_match(*tx->getSignal(), tx->getMode(), "Monostatic '" + tx->getName() + "'");
-			if (tx->getSignal()->isFmcwFamily())
-			{
-				validate_fmcw_schedule(tx->getSchedule(), *tx->getSignal(), "Monostatic '" + tx->getName() + "'");
-			}
+			throw std::runtime_error("Timing ID " + std::to_string(timing_id) + " not found.");
 		}
+		unsigned const seed = rx.getTiming() ? rx.getTiming()->getSeed() : 0;
+		auto shared_timing = std::make_shared<timing::Timing>(timing_proto->getName(), seed, timing_proto->getId());
+		shared_timing->initializeModel(timing_proto);
+		tx.setTiming(shared_timing);
+		rx.setTiming(shared_timing);
+	}
+
+	void update_monostatic_schedule_from_json(const nlohmann::json& j, radar::Transmitter& tx, radar::Receiver& rx)
+	{
+		if (!j.contains("schedule"))
+		{
+			return;
+		}
+		auto raw = j.at("schedule").get<std::vector<radar::SchedulePeriod>>();
+		const bool pulsed = tx.getMode() == radar::OperationMode::PULSED_MODE;
+		const RealType pri = pulsed ? 1.0 / tx.getPrf() : 0.0;
+		auto processed_schedule = radar::processRawSchedule(raw, tx.getName(), pulsed, pri);
+		if (tx.getSignal() != nullptr && tx.getSignal()->isFmcwFamily())
+		{
+			validate_fmcw_schedule(processed_schedule, *tx.getSignal(), "Monostatic '" + tx.getName() + "'");
+		}
+		tx.setSchedule(processed_schedule);
+		rx.setSchedule(processed_schedule);
+	}
+
+	void update_monostatic_from_json(const nlohmann::json& j, radar::Transmitter* tx, radar::Receiver* rx,
+									 core::World& world, std::mt19937& masterSeeder)
+	{
+		auto transmitter_json = monostatic_transmitter_json(j);
+		update_transmitter_from_json(transmitter_json, tx, world, masterSeeder);
+
+		update_monostatic_receiver_basics(j, *tx, *rx, world);
+		update_monostatic_timing_from_json(j, *tx, *rx, world);
+		update_monostatic_schedule_from_json(j, *tx, *rx);
+		validate_transmitter_signal_state(*tx, "Monostatic '" + tx->getName() + "'");
 		if (j.contains("fmcw_mode"))
 		{
 			parse_receiver_dechirp_config(j, *rx, "Monostatic '" + tx->getName() + "'");

--- a/packages/libfers/src/serial/json_serializer.cpp
+++ b/packages/libfers/src/serial/json_serializer.cpp
@@ -1313,8 +1313,8 @@ namespace
 			{
 				pri = 1.0 / trans->getPrf();
 			}
-			auto schedule = radar::processRawSchedule(std::move(raw), trans->getName(),
-													  mode == radar::OperationMode::PULSED_MODE, pri);
+			auto schedule =
+				radar::processRawSchedule(raw, trans->getName(), mode == radar::OperationMode::PULSED_MODE, pri);
 			if (waveform->isFmcwFamily())
 			{
 				validate_fmcw_schedule(schedule, *waveform, "Transmitter component '" + trans->getName() + "'");
@@ -1391,8 +1391,8 @@ namespace
 			{
 				pri = 1.0 / recv->getWindowPrf();
 			}
-			recv->setSchedule(radar::processRawSchedule(std::move(raw), recv->getName(),
-														mode == radar::OperationMode::PULSED_MODE, pri));
+			recv->setSchedule(
+				radar::processRawSchedule(raw, recv->getName(), mode == radar::OperationMode::PULSED_MODE, pri));
 		}
 
 		parse_receiver_dechirp_config(comp_json, *recv,
@@ -1547,8 +1547,8 @@ namespace
 			}
 
 			// Process once, apply to both
-			auto processed_schedule = radar::processRawSchedule(std::move(raw), trans->getName(),
-																mode == radar::OperationMode::PULSED_MODE, pri);
+			auto processed_schedule =
+				radar::processRawSchedule(raw, trans->getName(), mode == radar::OperationMode::PULSED_MODE, pri);
 			if (waveform->isFmcwFamily())
 			{
 				validate_fmcw_schedule(processed_schedule, *waveform,
@@ -1879,8 +1879,8 @@ namespace serial
 			RealType pri = 0.0;
 			if (tx->getMode() == radar::OperationMode::PULSED_MODE)
 				pri = 1.0 / tx->getPrf();
-			auto schedule = radar::processRawSchedule(std::move(raw), tx->getName(),
-													  tx->getMode() == radar::OperationMode::PULSED_MODE, pri);
+			auto schedule =
+				radar::processRawSchedule(raw, tx->getName(), tx->getMode() == radar::OperationMode::PULSED_MODE, pri);
 			if (tx->getSignal() != nullptr && tx->getSignal()->isFmcwFamily())
 			{
 				validate_fmcw_schedule(schedule, *tx->getSignal(), "Transmitter '" + tx->getName() + "'");
@@ -1969,8 +1969,8 @@ namespace serial
 			RealType pri = 0.0;
 			if (rx->getMode() == radar::OperationMode::PULSED_MODE)
 				pri = 1.0 / rx->getWindowPrf();
-			rx->setSchedule(radar::processRawSchedule(std::move(raw), rx->getName(),
-													  rx->getMode() == radar::OperationMode::PULSED_MODE, pri));
+			rx->setSchedule(
+				radar::processRawSchedule(raw, rx->getName(), rx->getMode() == radar::OperationMode::PULSED_MODE, pri));
 		}
 		if (j.contains("fmcw_mode"))
 		{

--- a/packages/libfers/src/serial/json_serializer.cpp
+++ b/packages/libfers/src/serial/json_serializer.cpp
@@ -987,91 +987,106 @@ namespace params
 
 namespace
 {
+	void addMonostaticReceiverFields(nlohmann::json& monostatic_comp, const radar::Transmitter& transmitter,
+									 const radar::Receiver& receiver)
+	{
+		monostatic_comp["noise_temp"] = receiver.getNoiseTemperature();
+		monostatic_comp["nodirect"] = receiver.checkFlag(radar::Receiver::RecvFlag::FLAG_NODIRECT);
+		monostatic_comp["nopropagationloss"] = receiver.checkFlag(radar::Receiver::RecvFlag::FLAG_NOPROPLOSS);
+
+		if (!transmitter.getSchedule().empty())
+		{
+			monostatic_comp["schedule"] = transmitter.getSchedule();
+		}
+
+		if (transmitter.getMode() == radar::OperationMode::PULSED_MODE)
+		{
+			monostatic_comp["pulsed_mode"] = {{"prf", transmitter.getPrf()},
+											  {"window_skip", receiver.getWindowSkip()},
+											  {"window_length", receiver.getWindowLength()}};
+		}
+		else if (transmitter.getMode() == radar::OperationMode::FMCW_MODE)
+		{
+			monostatic_comp["fmcw_mode"] = receiver_fmcw_mode_to_json(receiver);
+		}
+		else
+		{
+			monostatic_comp["cw_mode"] = nlohmann::json::object();
+		}
+	}
+
+	nlohmann::json monostaticComponentToJson(const radar::Transmitter& transmitter)
+	{
+		const auto* attached = transmitter.getAttached();
+		nlohmann::json monostatic_comp;
+		monostatic_comp["name"] = transmitter.getName();
+		monostatic_comp["tx_id"] = sim_id_to_json(transmitter.getId());
+		monostatic_comp["rx_id"] = sim_id_to_json(attached->getId());
+		monostatic_comp["waveform"] =
+			sim_id_to_json((transmitter.getSignal() != nullptr) ? transmitter.getSignal()->getId() : 0);
+		monostatic_comp["antenna"] =
+			sim_id_to_json((transmitter.getAntenna() != nullptr) ? transmitter.getAntenna()->getId() : 0);
+		monostatic_comp["timing"] = sim_id_to_json(transmitter.getTiming() ? transmitter.getTiming()->getId() : 0);
+
+		if (const auto* receiver = dynamic_cast<const radar::Receiver*>(attached))
+		{
+			addMonostaticReceiverFields(monostatic_comp, transmitter, *receiver);
+		}
+		return nlohmann::json{{"monostatic", monostatic_comp}};
+	}
+
+	void appendTransmitterComponents(nlohmann::json& components, const radar::Platform* platform,
+									 const core::World& world)
+	{
+		for (const auto& transmitter : world.getTransmitters())
+		{
+			if (transmitter->getPlatform() != platform)
+			{
+				continue;
+			}
+			if (transmitter->getAttached() != nullptr)
+			{
+				components.push_back(monostaticComponentToJson(*transmitter));
+			}
+			else
+			{
+				components.push_back(nlohmann::json{{"transmitter", *transmitter}});
+			}
+		}
+	}
+
+	void appendReceiverComponents(nlohmann::json& components, const radar::Platform* platform, const core::World& world)
+	{
+		for (const auto& receiver : world.getReceivers())
+		{
+			if (receiver->getPlatform() == platform && receiver->getAttached() == nullptr)
+			{
+				components.push_back(nlohmann::json{{"receiver", *receiver}});
+			}
+		}
+	}
+
+	void appendTargetComponents(nlohmann::json& components, const radar::Platform* platform, const core::World& world)
+	{
+		for (const auto& target : world.getTargets())
+		{
+			if (target->getPlatform() == platform)
+			{
+				components.push_back(nlohmann::json{{"target", *target}});
+			}
+		}
+	}
+
 	/// Serializes a platform and its attached components to JSON.
 	nlohmann::json serialize_platform(const radar::Platform* p, const core::World& world)
 	{
 		nlohmann::json plat_json = *p;
-
-		// Initialize components array to ensure it exists even if empty
 		plat_json["components"] = nlohmann::json::array();
+		auto& components = plat_json["components"];
 
-		// Add Transmitters and Monostatic Radars
-		for (const auto& t : world.getTransmitters())
-		{
-			if (t->getPlatform() == p)
-			{
-				if (t->getAttached() != nullptr)
-				{
-					nlohmann::json monostatic_comp;
-					monostatic_comp["name"] = t->getName();
-					monostatic_comp["tx_id"] = sim_id_to_json(t->getId());
-					monostatic_comp["rx_id"] = sim_id_to_json(t->getAttached()->getId());
-					monostatic_comp["waveform"] =
-						sim_id_to_json((t->getSignal() != nullptr) ? t->getSignal()->getId() : 0);
-					monostatic_comp["antenna"] =
-						sim_id_to_json((t->getAntenna() != nullptr) ? t->getAntenna()->getId() : 0);
-					monostatic_comp["timing"] = sim_id_to_json(t->getTiming() ? t->getTiming()->getId() : 0);
-
-					if (const auto* recv = dynamic_cast<const radar::Receiver*>(t->getAttached()))
-					{
-						monostatic_comp["noise_temp"] = recv->getNoiseTemperature();
-						monostatic_comp["nodirect"] = recv->checkFlag(radar::Receiver::RecvFlag::FLAG_NODIRECT);
-						monostatic_comp["nopropagationloss"] =
-							recv->checkFlag(radar::Receiver::RecvFlag::FLAG_NOPROPLOSS);
-
-						if (!t->getSchedule().empty())
-						{
-							monostatic_comp["schedule"] = t->getSchedule();
-						}
-
-						if (t->getMode() == radar::OperationMode::PULSED_MODE)
-						{
-							monostatic_comp["pulsed_mode"] = {{"prf", t->getPrf()},
-															  {"window_skip", recv->getWindowSkip()},
-															  {"window_length", recv->getWindowLength()}};
-						}
-						else
-						{
-							if (t->getMode() == radar::OperationMode::FMCW_MODE)
-							{
-								monostatic_comp["fmcw_mode"] = receiver_fmcw_mode_to_json(*recv);
-							}
-							else
-							{
-								monostatic_comp["cw_mode"] = nlohmann::json::object();
-							}
-						}
-					}
-					plat_json["components"].push_back(nlohmann::json{{"monostatic", monostatic_comp}});
-				}
-				else
-				{
-					plat_json["components"].push_back(nlohmann::json{{"transmitter", *t}});
-				}
-			}
-		}
-
-		// Add Standalone Receivers
-		for (const auto& r : world.getReceivers())
-		{
-			if (r->getPlatform() == p)
-			{
-				// This must be a standalone receiver, as monostatic cases were handled above.
-				if (r->getAttached() == nullptr)
-				{
-					plat_json["components"].push_back(nlohmann::json{{"receiver", *r}});
-				}
-			}
-		}
-
-		// Add Targets
-		for (const auto& target : world.getTargets())
-		{
-			if (target->getPlatform() == p)
-			{
-				plat_json["components"].push_back(nlohmann::json{{"target", *target}});
-			}
-		}
+		appendTransmitterComponents(components, p, world);
+		appendReceiverComponents(components, p, world);
+		appendTargetComponents(components, p, world);
 
 		return plat_json;
 	}

--- a/packages/libfers/src/serial/json_serializer.cpp
+++ b/packages/libfers/src/serial/json_serializer.cpp
@@ -371,7 +371,7 @@ namespace
 
 namespace math
 {
-	void to_json(nlohmann::json& j, const Vec3& v)
+	void to_json(nlohmann::json& j, const Vec3& v) // NOLINT(*-use-internal-linkage)
 	{
 		j = {{"x", v.x}, {"y", v.y}, {"z", v.z}};
 	} // NOLINT(*-use-internal-linkage)
@@ -805,7 +805,7 @@ namespace antenna
 
 namespace radar
 {
-	void to_json(nlohmann::json& j, const SchedulePeriod& p)
+	void to_json(nlohmann::json& j, const SchedulePeriod& p) // NOLINT(*-use-internal-linkage)
 	{
 		j = {{"start", p.start}, {"end", p.end}};
 	} // NOLINT(*-use-internal-linkage)

--- a/packages/libfers/src/serial/json_serializer.cpp
+++ b/packages/libfers/src/serial/json_serializer.cpp
@@ -173,8 +173,13 @@ namespace
 			}
 			if (!allowed)
 			{
-				throw std::runtime_error(owner + " " + std::string(object_name) + " contains unsupported key '" + key +
-										 "'.");
+				std::string message = owner;
+				message += ' ';
+				message += object_name;
+				message += " contains unsupported key '";
+				message += key;
+				message += "'.";
+				throw std::runtime_error(message);
 			}
 		}
 	}

--- a/packages/libfers/src/serial/kml_generator.cpp
+++ b/packages/libfers/src/serial/kml_generator.cpp
@@ -16,6 +16,7 @@
 #include <GeographicLib/UTMUPS.hpp>
 #include <expected>
 #include <fstream>
+#include <limits>
 #include <memory>
 
 #include "core/logging.h"
@@ -49,7 +50,8 @@ namespace serial
 					const bool northp = ctx.parameters.utm_north_hemisphere;
 					ctx.converter = [zone, northp](const math::Vec3& pos, double& lat, double& lon, double& alt)
 					{
-						double gamma, k;
+						double gamma = std::numeric_limits<double>::quiet_NaN();
+						double k = std::numeric_limits<double>::quiet_NaN();
 						GeographicLib::UTMUPS::Reverse(zone, northp, pos.x, pos.y, lat, lon, gamma, k);
 						alt = pos.z;
 					};

--- a/packages/libfers/src/serial/kml_generator_utils.cpp
+++ b/packages/libfers/src/serial/kml_generator_utils.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstddef>
 #include <iomanip>
+#include <limits>
 #include <map>
 #include <ranges>
 #include <sstream>
@@ -34,6 +35,11 @@ namespace serial::kml_generator_utils
 	constexpr int ISOTROPIC_PATTERN_POINTS = 100;
 	constexpr double ISOTROPIC_PATTERN_RADIUS_KM = 20.0;
 	constexpr double DIRECTIONAL_ANTENNA_ARROW_LENGTH_M = 20000.0;
+
+	namespace
+	{
+		[[nodiscard]] double unassignedCoordinate() noexcept { return std::numeric_limits<double>::quiet_NaN(); }
+	}
 
 	double sincAntennaGain(const double theta, const double alpha, const double beta, const double gamma)
 	{
@@ -151,7 +157,8 @@ namespace serial::kml_generator_utils
 		for (int i = 0; i < ISOTROPIC_PATTERN_POINTS; i++)
 		{
 			const double bearing = i * 360.0 / ISOTROPIC_PATTERN_POINTS;
-			double new_lat, new_lon;
+			double new_lat = unassignedCoordinate();
+			double new_lon = unassignedCoordinate();
 			calculateDestinationCoordinate(lat, lon, bearing, radius_km * 1000.0, new_lat, new_lon);
 			circle_coordinates.emplace_back(new_lat, new_lon);
 		}
@@ -266,7 +273,9 @@ namespace serial::kml_generator_utils
 	void generateIsotropicAntennaKml(std::ostream& out, const math::Vec3& position, const KmlContext& ctx,
 									 const std::string& indent)
 	{
-		double lat, lon, alt_abs;
+		double lat = unassignedCoordinate();
+		double lon = unassignedCoordinate();
+		double alt_abs = unassignedCoordinate();
 		ctx.converter(position, lat, lon, alt_abs);
 
 		const auto circle_coordinates = generateCircleCoordinates(lat, lon, ISOTROPIC_PATTERN_RADIUS_KM);
@@ -293,7 +302,9 @@ namespace serial::kml_generator_utils
 									   const std::optional<double>& angle3DbDropDeg, const std::string& indent)
 	{
 		const auto& first_wp_pos = platform->getMotionPath()->getCoords().front().pos;
-		double start_lat, start_lon, start_alt;
+		double start_lat = unassignedCoordinate();
+		double start_lon = unassignedCoordinate();
+		double start_alt = unassignedCoordinate();
 		ctx.converter(first_wp_pos, start_lat, start_lon, start_alt);
 		const std::string start_coords_str = formatCoordinates(start_lon, start_lat, start_alt);
 
@@ -315,7 +326,8 @@ namespace serial::kml_generator_utils
 		const double delta_altitude = DIRECTIONAL_ANTENNA_ARROW_LENGTH_M * std::sin(initial_rotation.elevation);
 		const double end_alt = start_alt + delta_altitude;
 
-		double dest_lat, dest_lon;
+		double dest_lat = unassignedCoordinate();
+		double dest_lon = unassignedCoordinate();
 		calculateDestinationCoordinate(start_lat, start_lon, start_azimuth_deg_kml, horizontal_distance, dest_lat,
 									   dest_lon);
 		const std::string end_coords_str = formatCoordinates(dest_lon, dest_lat, end_alt);
@@ -337,14 +349,16 @@ namespace serial::kml_generator_utils
 
 		if (angle3DbDropDeg.has_value() && *angle3DbDropDeg > EPSILON)
 		{
-			double side1_lat, side1_lon;
+			double side1_lat = unassignedCoordinate();
+			double side1_lon = unassignedCoordinate();
 			calculateDestinationCoordinate(start_lat, start_lon, start_azimuth_deg_kml - *angle3DbDropDeg,
 										   horizontal_distance, side1_lat, side1_lon);
 			const std::string side1_coords_str = formatCoordinates(side1_lon, side1_lat, end_alt);
 			writeAntennaBeamLine(out, indent, "Antenna 3dB Beamwidth", "#lineStyleBlue", start_coords_str,
 								 side1_coords_str);
 
-			double side2_lat, side2_lon;
+			double side2_lat = unassignedCoordinate();
+			double side2_lon = unassignedCoordinate();
 			calculateDestinationCoordinate(start_lat, start_lon, start_azimuth_deg_kml + *angle3DbDropDeg,
 										   horizontal_distance, side2_lat, side2_lon);
 			const std::string side2_coords_str = formatCoordinates(side2_lon, side2_lat, end_alt);
@@ -443,9 +457,10 @@ namespace serial::kml_generator_utils
 		const math::Path* path = platform->getMotionPath();
 		const auto& waypoints = path->getCoords();
 
-		double first_alt_abs;
+		double first_alt_abs = unassignedCoordinate();
 		{
-			double lat, lon;
+			double lat = unassignedCoordinate();
+			double lon = unassignedCoordinate();
 			ctx.converter(waypoints.front().pos, lat, lon, first_alt_abs);
 		}
 
@@ -465,7 +480,9 @@ namespace serial::kml_generator_utils
 		if (const double time_diff = end_time - start_time; time_diff <= 0.0)
 		{
 			const math::Vec3 p_pos = path->getPosition(start_time);
-			double p_lon, p_lat, p_alt_abs;
+			double p_lon = unassignedCoordinate();
+			double p_lat = unassignedCoordinate();
+			double p_alt_abs = unassignedCoordinate();
 			ctx.converter(p_pos, p_lat, p_lon, p_alt_abs);
 			out << indent << "    <when>" << start_time << "</when>\n";
 			out << indent << "    <gx:coord>" << p_lon << " " << p_lat << " " << p_alt_abs << "</gx:coord>\n";
@@ -477,7 +494,9 @@ namespace serial::kml_generator_utils
 			{
 				const double current_time = start_time + i * time_step;
 				const math::Vec3 p_pos = path->getPosition(current_time);
-				double p_lon, p_lat, p_alt_abs;
+				double p_lon = unassignedCoordinate();
+				double p_lat = unassignedCoordinate();
+				double p_alt_abs = unassignedCoordinate();
 				ctx.converter(p_pos, p_lat, p_lon, p_alt_abs);
 				out << indent << "    <when>" << current_time << "</when>\n";
 				out << indent << "    <gx:coord>" << p_lon << " " << p_lat << " " << p_alt_abs << "</gx:coord>\n";
@@ -500,11 +519,15 @@ namespace serial::kml_generator_utils
 		const auto& [start_wp_pos, start_wp_t] = path->getCoords().front();
 		const auto& [end_wp_pos, end_wp_t] = path->getCoords().back();
 
-		double start_lat, start_lon, start_alt_abs;
+		double start_lat = unassignedCoordinate();
+		double start_lon = unassignedCoordinate();
+		double start_alt_abs = unassignedCoordinate();
 		ctx.converter(start_wp_pos, start_lat, start_lon, start_alt_abs);
 		const std::string start_coordinates = formatCoordinates(start_lon, start_lat, start_alt_abs);
 
-		double end_lat, end_lon, end_alt_abs;
+		double end_lat = unassignedCoordinate();
+		double end_lon = unassignedCoordinate();
+		double end_alt_abs = unassignedCoordinate();
 		ctx.converter(end_wp_pos, end_lat, end_lon, end_alt_abs);
 		const std::string end_coordinates = formatCoordinates(end_lon, end_lat, end_alt_abs);
 
@@ -516,7 +539,9 @@ namespace serial::kml_generator_utils
 									const double refAlt, const KmlContext& ctx, const std::string& indent)
 	{
 		const auto& [first_wp_pos, first_wp_t] = platform->getMotionPath()->getCoords().front();
-		double lat, lon, alt_abs;
+		double lat = unassignedCoordinate();
+		double lon = unassignedCoordinate();
+		double alt_abs = unassignedCoordinate();
 		ctx.converter(first_wp_pos, lat, lon, alt_abs);
 		const std::string coordinates = formatCoordinates(lon, lat, alt_abs);
 

--- a/packages/libfers/src/serial/kml_generator_utils.cpp
+++ b/packages/libfers/src/serial/kml_generator_utils.cpp
@@ -378,6 +378,72 @@ namespace serial::kml_generator_utils
 		out << indent << "</Placemark>\n";
 	}
 
+	std::optional<double> antennaCarrierWavelength(const radar::Radar* radar, const KmlContext& ctx)
+	{
+		if (const auto* tx = dynamic_cast<const radar::Transmitter*>(radar))
+		{
+			if (tx->getSignal() != nullptr)
+			{
+				return ctx.parameters.c / tx->getSignal()->getCarrier();
+			}
+			return std::nullopt;
+		}
+		if (const auto* rx = dynamic_cast<const radar::Receiver*>(radar))
+		{
+			if (const auto* attached_tx = dynamic_cast<const radar::Transmitter*>(rx->getAttached()))
+			{
+				if (attached_tx->getSignal() != nullptr)
+				{
+					return ctx.parameters.c / attached_tx->getSignal()->getCarrier();
+				}
+			}
+		}
+		return std::nullopt;
+	}
+
+	std::optional<double> antenna3DbDropAngle(const antenna::Antenna* ant, const std::optional<double> wavelength)
+	{
+		if (const auto* sinc_ant = dynamic_cast<const antenna::Sinc*>(ant))
+		{
+			return find3DbDropAngle(sinc_ant->getAlpha(), sinc_ant->getBeta(), sinc_ant->getGamma());
+		}
+		if (const auto* gaussian_ant = dynamic_cast<const antenna::Gaussian*>(ant))
+		{
+			return findGaussian3DbDropAngle(gaussian_ant);
+		}
+		if (const auto* parabolic_ant = dynamic_cast<const antenna::Parabolic*>(ant))
+		{
+			if (wavelength)
+			{
+				return findParabolic3DbDropAngle(parabolic_ant, *wavelength);
+			}
+			return std::nullopt;
+		}
+		if (const auto* squarehorn_ant = dynamic_cast<const antenna::SquareHorn*>(ant))
+		{
+			if (wavelength)
+			{
+				return findSquareHorn3DbDropAngle(squarehorn_ant, *wavelength);
+			}
+			return std::nullopt;
+		}
+		return std::nullopt;
+	}
+
+	void logSymbolicAntennaKml(const antenna::Antenna* ant)
+	{
+		if ((dynamic_cast<const antenna::XmlAntenna*>(ant) == nullptr) &&
+			(dynamic_cast<const antenna::H5Antenna*>(ant) == nullptr))
+		{
+			return;
+		}
+		LOG(logging::Level::INFO,
+			"KML visualization for antenna '{}' ('{}') is symbolic. "
+			"Only the boresight direction is shown, as a 3dB beamwidth is not calculated from file-based "
+			"patterns.",
+			ant->getName(), dynamic_cast<const antenna::XmlAntenna*>(ant) ? "xml" : "file");
+	}
+
 	void generateAntennaKml(std::ostream& out, const radar::Platform* platform, const radar::Radar* radar,
 							const KmlContext& ctx, const std::string& indent)
 	{
@@ -394,59 +460,9 @@ namespace serial::kml_generator_utils
 		}
 		else
 		{
-			std::optional<double> angle_3db_drop_deg;
-
-			std::optional<double> wavelength;
-			if (const auto* tx = dynamic_cast<const radar::Transmitter*>(radar))
-			{
-				if (tx->getSignal() != nullptr)
-				{
-					wavelength = ctx.parameters.c / tx->getSignal()->getCarrier();
-				}
-			}
-			else if (const auto* rx = dynamic_cast<const radar::Receiver*>(radar))
-			{
-				if (const auto* attached_tx = dynamic_cast<const radar::Transmitter*>(rx->getAttached()))
-				{
-					if (attached_tx->getSignal() != nullptr)
-					{
-						wavelength = ctx.parameters.c / attached_tx->getSignal()->getCarrier();
-					}
-				}
-			}
-
-			if (const auto* sinc_ant = dynamic_cast<const antenna::Sinc*>(ant))
-			{
-				angle_3db_drop_deg = find3DbDropAngle(sinc_ant->getAlpha(), sinc_ant->getBeta(), sinc_ant->getGamma());
-			}
-			else if (const auto* gaussian_ant = dynamic_cast<const antenna::Gaussian*>(ant))
-			{
-				angle_3db_drop_deg = findGaussian3DbDropAngle(gaussian_ant);
-			}
-			else if (const auto* parabolic_ant = dynamic_cast<const antenna::Parabolic*>(ant))
-			{
-				if (wavelength)
-				{
-					angle_3db_drop_deg = findParabolic3DbDropAngle(parabolic_ant, *wavelength);
-				}
-			}
-			else if (const auto* squarehorn_ant = dynamic_cast<const antenna::SquareHorn*>(ant))
-			{
-				if (wavelength)
-				{
-					angle_3db_drop_deg = findSquareHorn3DbDropAngle(squarehorn_ant, *wavelength);
-				}
-			}
-			else if ((dynamic_cast<const antenna::XmlAntenna*>(ant) != nullptr) ||
-					 (dynamic_cast<const antenna::H5Antenna*>(ant) != nullptr))
-			{
-				LOG(logging::Level::INFO,
-					"KML visualization for antenna '{}' ('{}') is symbolic. "
-					"Only the boresight direction is shown, as a 3dB beamwidth is not calculated from file-based "
-					"patterns.",
-					ant->getName(), dynamic_cast<const antenna::XmlAntenna*>(ant) ? "xml" : "file");
-			}
-
+			const auto wavelength = antennaCarrierWavelength(radar, ctx);
+			const auto angle_3db_drop_deg = antenna3DbDropAngle(ant, wavelength);
+			logSymbolicAntennaKml(ant);
 			generateDirectionalAntennaKml(out, platform, ctx, angle_3db_drop_deg, indent);
 		}
 	}

--- a/packages/libfers/src/serial/libxml_wrapper.cpp
+++ b/packages/libfers/src/serial/libxml_wrapper.cpp
@@ -11,8 +11,10 @@
 
 #include "libxml_wrapper.h"
 
+#include <array>
 #include <cctype>
 #include <cstdarg>
+#include <cstdio>
 #include <format>
 #include <limits>
 #include <string>
@@ -35,13 +37,16 @@ namespace
 			return;
 		}
 
-		char buf[1024];
+		std::array<char, 1024> buf{};
 		va_list args;
+		// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay): va_list is an array typedef on this ABI.
 		va_start(args, msg);
-		vsnprintf(buf, sizeof(buf), msg, args);
+		// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay): va_list is required by vsnprintf.
+		std::vsnprintf(buf.data(), buf.size(), msg, args);
+		// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay): va_list is an array typedef on this ABI.
 		va_end(args);
 
-		err_str->append(buf);
+		err_str->append(buf.data());
 	}
 
 	[[nodiscard]] int checkedXmlInputSize(const std::size_t size)

--- a/packages/libfers/src/serial/libxml_wrapper.cpp
+++ b/packages/libfers/src/serial/libxml_wrapper.cpp
@@ -152,8 +152,9 @@ bool XmlDocument::validateWithDtd(const std::span<const unsigned char> dtdData) 
 
 	if (!is_valid)
 	{
-		std::string fancyError = formatError("XML DTD Validation Failed", dtdErrors,
-											 "Check your scenario XML tags and attributes against 'fers-xml.dtd'.");
+		const std::string fancyError =
+			formatError("XML DTD Validation Failed", dtdErrors,
+						"Check your scenario XML tags and attributes against 'fers-xml.dtd'.");
 		LOG(logging::Level::ERROR, "{}", fancyError);
 		throw XmlException("XML failed DTD validation.");
 	}
@@ -180,7 +181,7 @@ bool XmlDocument::validateWithXsd(const std::span<const unsigned char> xsdData) 
 																	  xmlSchemaFree);
 	if (!schema)
 	{
-		std::string fancyError =
+		const std::string fancyError =
 			formatError("XSD Schema Parse Failed", xsdParseErrors, "The internal XSD schema is invalid.");
 		LOG(logging::Level::FATAL, "{}", fancyError);
 		throw XmlException("Failed to parse schema from memory.");
@@ -200,8 +201,9 @@ bool XmlDocument::validateWithXsd(const std::span<const unsigned char> xsdData) 
 
 	if (const bool is_valid = xmlSchemaValidateDoc(schema_valid_ctxt.get(), _doc.get()) == 0; !is_valid)
 	{
-		std::string fancyError = formatError("XML XSD Validation Failed", xsdErrors,
-											 "Check your scenario XML tags and attributes against 'fers-xml.xsd'.");
+		const std::string fancyError =
+			formatError("XML XSD Validation Failed", xsdErrors,
+						"Check your scenario XML tags and attributes against 'fers-xml.xsd'.");
 		LOG(logging::Level::ERROR, "{}", fancyError);
 		throw XmlException("XML failed XSD validation.");
 	}
@@ -249,7 +251,7 @@ bool XmlDocument::loadFile(const std::string_view filename)
 	_doc.reset(xmlReadFile(filename.data(), nullptr, XML_PARSE_NOERROR | XML_PARSE_NOWARNING));
 	if (!_doc)
 	{
-		std::string fancyError =
+		const std::string fancyError =
 			formatError("XML Parsing Failed", getXmlLastErrorFormatted(), "Ensure the XML file is well-formed.");
 		LOG(logging::Level::ERROR, "{}", fancyError);
 		return false;
@@ -264,7 +266,7 @@ bool XmlDocument::loadString(const std::string& content)
 							 XML_PARSE_NOERROR | XML_PARSE_NOWARNING));
 	if (!_doc)
 	{
-		std::string fancyError =
+		const std::string fancyError =
 			formatError("XML Parsing Failed", getXmlLastErrorFormatted(), "Ensure the XML string is well-formed.");
 		LOG(logging::Level::ERROR, "{}", fancyError);
 		return false;

--- a/packages/libfers/src/serial/libxml_wrapper.cpp
+++ b/packages/libfers/src/serial/libxml_wrapper.cpp
@@ -14,6 +14,7 @@
 #include <cctype>
 #include <cstdarg>
 #include <format>
+#include <limits>
 #include <string>
 
 #include "libxml/encoding.h"
@@ -41,6 +42,26 @@ namespace
 		va_end(args);
 
 		err_str->append(buf);
+	}
+
+	[[nodiscard]] int checkedXmlInputSize(const std::size_t size)
+	{
+		if (size > static_cast<std::size_t>(std::numeric_limits<int>::max()))
+		{
+			throw XmlException("XML input exceeds libxml2 length limit.");
+		}
+		return static_cast<int>(size);
+	}
+
+	[[nodiscard]] std::string bytesToString(const std::span<const unsigned char> bytes)
+	{
+		std::string result;
+		result.reserve(bytes.size());
+		for (const unsigned char byte : bytes)
+		{
+			result.push_back(static_cast<char>(byte));
+		}
+		return result;
 	}
 
 	/// Formats a raw XML error message with a title and remediation hint.
@@ -96,10 +117,11 @@ namespace
 
 bool XmlDocument::validateWithDtd(const std::span<const unsigned char> dtdData) const
 {
+	const std::string dtd_string = bytesToString(dtdData);
 	xmlDtdPtr dtd =
 		xmlIOParseDTD(nullptr,
-					  xmlParserInputBufferCreateMem(reinterpret_cast<const char*>(dtdData.data()),
-													static_cast<int>(dtdData.size()), XML_CHAR_ENCODING_UTF8),
+					  xmlParserInputBufferCreateMem(dtd_string.data(), checkedXmlInputSize(dtd_string.size()),
+													XML_CHAR_ENCODING_UTF8),
 					  XML_CHAR_ENCODING_UTF8);
 	if (dtd == nullptr)
 	{
@@ -136,9 +158,9 @@ bool XmlDocument::validateWithDtd(const std::span<const unsigned char> dtdData) 
 
 bool XmlDocument::validateWithXsd(const std::span<const unsigned char> xsdData) const
 {
+	const std::string xsd_string = bytesToString(xsdData);
 	const std::unique_ptr<xmlSchemaParserCtxt, decltype(&xmlSchemaFreeParserCtxt)> schema_parser_ctxt(
-		xmlSchemaNewMemParserCtxt(reinterpret_cast<const char*>(xsdData.data()), static_cast<int>(xsdData.size())),
-		xmlSchemaFreeParserCtxt);
+		xmlSchemaNewMemParserCtxt(xsd_string.data(), checkedXmlInputSize(xsd_string.size())), xmlSchemaFreeParserCtxt);
 	if (!schema_parser_ctxt)
 	{
 		throw XmlException("Failed to create schema parser context.");
@@ -260,7 +282,7 @@ std::string XmlDocument::dumpToString() const
 		LOG(logging::Level::ERROR, "Failed to dump XML document to memory buffer.");
 		return "";
 	}
-	const std::string result(reinterpret_cast<const char*>(buffer), static_cast<size_t>(size));
+	const std::string result = xml_detail::toString(buffer, size);
 	xmlFree(buffer);
 	return result;
 }

--- a/packages/libfers/src/serial/libxml_wrapper.cpp
+++ b/packages/libfers/src/serial/libxml_wrapper.cpp
@@ -203,7 +203,7 @@ void removeIncludeElements(const XmlDocument& doc)
 
 	while (true)
 	{
-		if (XmlElement include_element = root.childElement("include", 0); include_element.isValid())
+		if (const XmlElement include_element = root.childElement("include", 0); include_element.isValid())
 		{
 			xmlUnlinkNode(include_element.getNode());
 			xmlFreeNode(include_element.getNode());

--- a/packages/libfers/src/serial/libxml_wrapper.h
+++ b/packages/libfers/src/serial/libxml_wrapper.h
@@ -17,12 +17,14 @@
 
 #include <iostream>
 #include <libxml/parser.h>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "core/logging.h"
 #include "libxml/globals.h"
@@ -42,6 +44,102 @@ public:
 	 */
 	explicit XmlException(const std::string_view message) : std::runtime_error(std::string(message)) {}
 };
+
+namespace xml_detail
+{
+	class XmlCharBuffer
+	{
+		std::vector<xmlChar> _value;
+
+	public:
+		explicit XmlCharBuffer(const std::string_view value)
+		{
+			_value.reserve(value.size() + 1);
+			for (const char character : value)
+			{
+				_value.push_back(static_cast<xmlChar>(static_cast<unsigned char>(character)));
+			}
+			_value.push_back(0);
+		}
+
+		[[nodiscard]] const xmlChar* c_str() const noexcept { return _value.data(); }
+
+		[[nodiscard]] int contentLength() const
+		{
+			const auto length = _value.empty() ? static_cast<std::size_t>(0) : _value.size() - 1;
+			if (length > static_cast<std::size_t>(std::numeric_limits<int>::max()))
+			{
+				throw XmlException("XML string exceeds libxml2 length limit.");
+			}
+			return static_cast<int>(length);
+		}
+	};
+
+	[[nodiscard]] inline std::string toString(const xmlChar* value)
+	{
+		if (value == nullptr)
+		{
+			return "";
+		}
+
+		std::string result;
+		for (const xmlChar* cursor = value; *cursor != 0; ++cursor)
+		{
+			result.push_back(static_cast<char>(*cursor));
+		}
+		return result;
+	}
+
+	[[nodiscard]] inline std::string toString(const xmlChar* value, const int length)
+	{
+		if (value == nullptr || length <= 0)
+		{
+			return "";
+		}
+
+		std::string result;
+		result.reserve(static_cast<std::size_t>(length));
+		for (int index = 0; index < length; ++index)
+		{
+			result.push_back(static_cast<char>(value[index]));
+		}
+		return result;
+	}
+
+	[[nodiscard]] inline bool equals(const xmlChar* xml_value, const std::string_view value)
+	{
+		if (xml_value == nullptr)
+		{
+			return false;
+		}
+
+		for (std::size_t index = 0; index < value.size(); ++index)
+		{
+			if (xml_value[index] == 0 || static_cast<char>(xml_value[index]) != value[index])
+			{
+				return false;
+			}
+		}
+		return xml_value[value.size()] == 0;
+	}
+
+	[[nodiscard]] inline xmlNodePtr createNode(const std::string_view name)
+	{
+		const XmlCharBuffer xml_name(name);
+		xmlNodePtr node = xmlNewNode(nullptr, xml_name.c_str());
+		if (node == nullptr)
+		{
+			throw XmlException("Failed to create XML node: " + std::string(name));
+		}
+		return node;
+	}
+
+	[[nodiscard]] inline xmlDocPtr createDocument()
+	{
+		const XmlCharBuffer version("1.0");
+		return xmlNewDoc(version.c_str());
+	}
+}
 
 /**
  * @class XmlElement
@@ -78,7 +176,18 @@ public:
 	 *
 	 * @return The name of the XML element.
 	 */
-	[[nodiscard]] std::string_view name() const noexcept { return reinterpret_cast<const char*>(_node->name); }
+	[[nodiscard]] std::string name() const { return _node == nullptr ? "" : xml_detail::toString(_node->name); }
+
+	/**
+	 * @brief Create a new XML element by name.
+	 *
+	 * @param name The name of the XML element.
+	 * @return The newly created XML element.
+	 */
+	[[nodiscard]] static XmlElement create(const std::string_view name)
+	{
+		return XmlElement(xml_detail::createNode(name));
+	}
 
 	/**
 	 * @brief Get the text content of the XML element.
@@ -92,7 +201,7 @@ public:
 			return "";
 		}
 		xmlChar* text = xmlNodeGetContent(_node);
-		std::string result = reinterpret_cast<const char*>(text);
+		std::string result = xml_detail::toString(text);
 		xmlFree(text);
 		return result;
 	}
@@ -104,7 +213,8 @@ public:
 	 */
 	void setText(const std::string_view text) const
 	{
-		xmlNodeSetContent(_node, reinterpret_cast<const xmlChar*>(text.data()));
+		const xml_detail::XmlCharBuffer xml_text(text);
+		xmlNodeSetContentLen(_node, xml_text.c_str(), xml_text.contentLength());
 	}
 
 	/**
@@ -118,9 +228,10 @@ public:
 	static std::string getSafeAttribute(const XmlElement& element, const std::string_view name)
 	{
 		std::string value;
-		if (xmlChar* attr = xmlGetProp(element.getNode(), reinterpret_cast<const xmlChar*>(name.data())))
+		const xml_detail::XmlCharBuffer xml_name(name);
+		if (xmlChar* attr = xmlGetProp(element.getNode(), xml_name.c_str()))
 		{
-			value = reinterpret_cast<const char*>(attr);
+			value = xml_detail::toString(attr);
 			xmlFree(attr);
 		}
 		else
@@ -143,9 +254,10 @@ public:
 		{
 			return std::nullopt;
 		}
-		if (xmlChar* attr = xmlGetProp(element.getNode(), reinterpret_cast<const xmlChar*>(name.data())))
+		const xml_detail::XmlCharBuffer xml_name(name);
+		if (xmlChar* attr = xmlGetProp(element.getNode(), xml_name.c_str()))
 		{
-			std::string value = reinterpret_cast<const char*>(attr);
+			std::string value = xml_detail::toString(attr);
 			xmlFree(attr);
 			return value;
 		}
@@ -160,8 +272,9 @@ public:
 	 */
 	void setAttribute(const std::string_view name, const std::string_view value) const
 	{
-		xmlSetProp(_node, reinterpret_cast<const xmlChar*>(name.data()),
-				   reinterpret_cast<const xmlChar*>(value.data()));
+		const xml_detail::XmlCharBuffer xml_name(name);
+		const xml_detail::XmlCharBuffer xml_value(value);
+		xmlSetProp(_node, xml_name.c_str(), xml_value.c_str());
 	}
 
 	/**
@@ -170,10 +283,10 @@ public:
 	 * @param name The name of the new child element.
 	 * @return The newly created XmlElement.
 	 */
-	[[nodiscard]] XmlElement addChild(const std::string_view name) const noexcept
+	[[nodiscard]] XmlElement addChild(const std::string_view name) const
 	{
-		const xmlNode* child = xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>(name.data()));
-		xmlAddChild(_node, const_cast<xmlNode*>(child));
+		xmlNodePtr child = xml_detail::createNode(name);
+		xmlAddChild(_node, child);
 		return XmlElement(child);
 	}
 
@@ -193,7 +306,7 @@ public:
 		unsigned count = 0;
 		for (auto* child = _node->children; child != nullptr; child = child->next)
 		{
-			if (child->type == XML_ELEMENT_NODE && (name.empty() || name == reinterpret_cast<const char*>(child->name)))
+			if (child->type == XML_ELEMENT_NODE && (name.empty() || xml_detail::equals(child->name, name)))
 			{
 				if (count == index)
 				{
@@ -234,7 +347,7 @@ public:
 	 *
 	 * @throws std::runtime_error if the document creation fails.
 	 */
-	XmlDocument() : _doc(xmlNewDoc(reinterpret_cast<const xmlChar*>("1.0")), &xmlFreeDoc)
+	XmlDocument() : _doc(xml_detail::createDocument(), &xmlFreeDoc)
 	{
 		if (!_doc)
 		{

--- a/packages/libfers/src/serial/libxml_wrapper.h
+++ b/packages/libfers/src/serial/libxml_wrapper.h
@@ -159,7 +159,7 @@ public:
 	 *
 	 * @param node The xmlNode pointer representing the XML element.
 	 */
-	explicit XmlElement(const xmlNode* node) : _node(const_cast<xmlNode*>(node)) {}
+	explicit XmlElement(xmlNodePtr node) : _node(node) {}
 
 	XmlElement(const XmlElement&) = default;
 
@@ -431,7 +431,7 @@ public:
 		{
 			throw std::runtime_error("Document not loaded");
 		}
-		const xmlNode* root = xmlDocGetRootElement(_doc.get());
+		xmlNodePtr root = xmlDocGetRootElement(_doc.get());
 		if (root == nullptr)
 		{
 			throw std::runtime_error("Root element not found");

--- a/packages/libfers/src/serial/rotation_warning_utils.cpp
+++ b/packages/libfers/src/serial/rotation_warning_utils.cpp
@@ -122,6 +122,123 @@ namespace serial::rotation_warning_utils
 			return best;
 		}
 
+		void score_magnitude(InferenceResult& result, const RealType abs_value) noexcept
+		{
+			const RealType pi = std::numbers::pi_v<RealType>;
+			const RealType two_pi = 2.0 * pi;
+			if (abs_value > 360.0)
+			{
+				result.degree_score += 8;
+			}
+			else if (abs_value > 180.0)
+			{
+				result.degree_score += 7;
+			}
+			else if (abs_value > two_pi)
+			{
+				result.degree_score += abs_value < 10.0 ? 3 : 6;
+			}
+			else if (abs_value > pi)
+			{
+				result.degree_score += 2;
+			}
+		}
+
+		void score_common_angle_matches(InferenceResult& result, const RealType abs_value) noexcept
+		{
+			const bool degree_famous = matches_common_angle(abs_value, common_degree_angles);
+			const bool radian_famous = matches_common_angle(abs_value, common_radian_angles);
+			if (degree_famous && !radian_famous)
+			{
+				result.degree_score += 3;
+			}
+			else if (radian_famous && !degree_famous)
+			{
+				result.radian_score += 3;
+			}
+		}
+
+		void score_integer_roundness(InferenceResult& result, const RealType abs_value) noexcept
+		{
+			const RealType two_pi = 2.0 * std::numbers::pi_v<RealType>;
+			if (is_near_integer(abs_value))
+			{
+				const RealType rounded = std::round(abs_value);
+				if ((std::fmod(rounded, 45.0) == 0.0) || (std::fmod(rounded, 30.0) == 0.0) ||
+					(std::fmod(rounded, 15.0) == 0.0) || (std::fmod(rounded, 10.0) == 0.0) ||
+					(std::fmod(rounded, 5.0) == 0.0))
+				{
+					result.degree_score += 2;
+				}
+				else
+				{
+					result.degree_score += 1;
+				}
+			}
+			else if ((abs_value <= two_pi + 1.0) && !is_near_tenth(abs_value))
+			{
+				result.radian_score += 1;
+			}
+		}
+
+		void score_pi_ratio(InferenceResult& result, const RealType abs_value) noexcept
+		{
+			if (matches_simple_pi_ratio(abs_value))
+			{
+				result.radian_score += 3;
+			}
+		}
+
+		void score_trig_cleanliness(InferenceResult& result, const RealType value, const RealType abs_value,
+									const ValueKind kind) noexcept
+		{
+			const RealType pi = std::numbers::pi_v<RealType>;
+			const RealType two_pi = 2.0 * pi;
+			if ((kind != ValueKind::Angle) || (abs_value > two_pi + 0.5) ||
+				(std::abs(result.degree_score - result.radian_score) > 1))
+			{
+				return;
+			}
+
+			const RealType degree_distance = best_clean_trig_distance(value * pi / 180.0);
+			const RealType radian_distance = best_clean_trig_distance(value);
+			if (degree_distance + 1e-4 < radian_distance)
+			{
+				++result.degree_score;
+			}
+			else if (radian_distance + 1e-4 < degree_distance)
+			{
+				++result.radian_score;
+			}
+		}
+
+		void assign_inference_confidence(InferenceResult& result) noexcept
+		{
+			if (result.degree_score == result.radian_score)
+			{
+				result.confidence = Confidence::None;
+				return;
+			}
+
+			result.inferred_unit = result.degree_score > result.radian_score ? params::RotationAngleUnit::Degrees
+																			 : params::RotationAngleUnit::Radians;
+			const int lead = std::abs(result.degree_score - result.radian_score);
+			const int max_score = std::max(result.degree_score, result.radian_score);
+
+			if ((lead >= 5) || ((max_score >= 7) && (lead >= 3)))
+			{
+				result.confidence = Confidence::High;
+			}
+			else if ((lead >= 3) || ((max_score >= 5) && (lead >= 2)))
+			{
+				result.confidence = Confidence::Medium;
+			}
+			else if ((lead >= 2) || (max_score >= 4))
+			{
+				result.confidence = Confidence::Low;
+			}
+		}
+
 		/// Returns the external token for a rotation angle unit.
 		[[nodiscard]] std::string unit_token(const params::RotationAngleUnit unit)
 		{
@@ -149,8 +266,6 @@ namespace serial::rotation_warning_utils
 	InferenceResult infer_unit_from_value(const RealType value, const ValueKind kind) noexcept
 	{
 		const RealType abs_value = std::abs(value);
-		const RealType pi = std::numbers::pi_v<RealType>;
-		const RealType two_pi = 2.0 * pi;
 
 		InferenceResult result;
 		if (abs_value <= kEpsilon)
@@ -158,96 +273,12 @@ namespace serial::rotation_warning_utils
 			return result;
 		}
 
-		if (abs_value > 360.0)
-		{
-			result.degree_score += 8;
-		}
-		else if (abs_value > 180.0)
-		{
-			result.degree_score += 7;
-		}
-		else if (abs_value > two_pi)
-		{
-			result.degree_score += abs_value < 10.0 ? 3 : 6;
-		}
-		else if (abs_value > pi)
-		{
-			result.degree_score += 2;
-		}
-
-		const bool degree_famous = matches_common_angle(abs_value, common_degree_angles);
-		const bool radian_famous = matches_common_angle(abs_value, common_radian_angles);
-		if (degree_famous && !radian_famous)
-		{
-			result.degree_score += 3;
-		}
-		else if (radian_famous && !degree_famous)
-		{
-			result.radian_score += 3;
-		}
-
-		if (is_near_integer(abs_value))
-		{
-			const RealType rounded = std::round(abs_value);
-			if ((std::fmod(rounded, 45.0) == 0.0) || (std::fmod(rounded, 30.0) == 0.0) ||
-				(std::fmod(rounded, 15.0) == 0.0) || (std::fmod(rounded, 10.0) == 0.0) ||
-				(std::fmod(rounded, 5.0) == 0.0))
-			{
-				result.degree_score += 2;
-			}
-			else
-			{
-				result.degree_score += 1;
-			}
-		}
-		else if ((abs_value <= two_pi + 1.0) && !is_near_tenth(abs_value))
-		{
-			result.radian_score += 1;
-		}
-
-		if (matches_simple_pi_ratio(abs_value))
-		{
-			result.radian_score += 3;
-		}
-
-		if ((kind == ValueKind::Angle) && (abs_value <= two_pi + 0.5) &&
-			(std::abs(result.degree_score - result.radian_score) <= 1))
-		{
-			const RealType degree_distance = best_clean_trig_distance(value * pi / 180.0);
-			const RealType radian_distance = best_clean_trig_distance(value);
-			if (degree_distance + 1e-4 < radian_distance)
-			{
-				++result.degree_score;
-			}
-			else if (radian_distance + 1e-4 < degree_distance)
-			{
-				++result.radian_score;
-			}
-		}
-
-		if (result.degree_score == result.radian_score)
-		{
-			result.confidence = Confidence::None;
-			return result;
-		}
-
-		result.inferred_unit = result.degree_score > result.radian_score ? params::RotationAngleUnit::Degrees
-																		 : params::RotationAngleUnit::Radians;
-		const int lead = std::abs(result.degree_score - result.radian_score);
-		const int max_score = std::max(result.degree_score, result.radian_score);
-
-		if ((lead >= 5) || ((max_score >= 7) && (lead >= 3)))
-		{
-			result.confidence = Confidence::High;
-		}
-		else if ((lead >= 3) || ((max_score >= 5) && (lead >= 2)))
-		{
-			result.confidence = Confidence::Medium;
-		}
-		else if ((lead >= 2) || (max_score >= 4))
-		{
-			result.confidence = Confidence::Low;
-		}
+		score_magnitude(result, abs_value);
+		score_common_angle_matches(result, abs_value);
+		score_integer_roundness(result, abs_value);
+		score_pi_ratio(result, abs_value);
+		score_trig_cleanliness(result, value, abs_value, kind);
+		assign_inference_confidence(result);
 
 		return result;
 	}

--- a/packages/libfers/src/serial/rotation_warning_utils.h
+++ b/packages/libfers/src/serial/rotation_warning_utils.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -16,14 +17,14 @@
 namespace serial::rotation_warning_utils
 {
 	/// Kind of rotation value being inspected for unit mistakes.
-	enum class ValueKind
+	enum class ValueKind : std::uint8_t
 	{
 		Angle, ///< Absolute rotation angle.
 		Rate ///< Rotation rate.
 	};
 
 	/// Confidence level for an inferred rotation unit.
-	enum class Confidence
+	enum class Confidence : std::uint8_t
 	{
 		None, ///< No useful inference could be made.
 		Low, ///< Weak evidence for the inferred unit.
@@ -32,7 +33,7 @@ namespace serial::rotation_warning_utils
 	};
 
 	/// Minimum confidence threshold for emitting rotation-unit warnings.
-	enum class WarningSensitivity
+	enum class WarningSensitivity : std::uint8_t
 	{
 		HighConfidence, ///< Warn only on high-confidence mismatches.
 		MediumOrHigh, ///< Warn on medium or high-confidence mismatches.

--- a/packages/libfers/src/serial/vita49/paced_sender.cpp
+++ b/packages/libfers/src/serial/vita49/paced_sender.cpp
@@ -53,7 +53,7 @@ namespace serial::vita49
 
 	void PacedSender::start(const RealType simulation_epoch_time)
 	{
-		std::lock_guard const lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		if (_started)
 		{
 			return;
@@ -103,7 +103,7 @@ namespace serial::vita49
 	void PacedSender::stop()
 	{
 		{
-			std::lock_guard const lock(_mutex);
+			std::scoped_lock const lock(_mutex);
 			if (!_started && !_thread.joinable())
 			{
 				_sender->close();
@@ -119,7 +119,7 @@ namespace serial::vita49
 		}
 
 		{
-			std::lock_guard const lock(_mutex);
+			std::scoped_lock const lock(_mutex);
 			_started = false;
 			_stopping = false;
 			_send_in_progress = false;
@@ -130,49 +130,49 @@ namespace serial::vita49
 
 	std::uint64_t PacedSender::latePacketCount(const std::uint32_t stream_id) const
 	{
-		std::lock_guard const lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		const auto found = _late_packets.find(stream_id);
 		return found == _late_packets.end() ? 0 : found->second;
 	}
 
 	std::uint64_t PacedSender::sentPacketCount(const std::uint32_t stream_id) const
 	{
-		std::lock_guard const lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		const auto found = _sent_packets.find(stream_id);
 		return found == _sent_packets.end() ? 0 : found->second;
 	}
 
 	std::uint64_t PacedSender::sendFailureCount(const std::uint32_t stream_id) const
 	{
-		std::lock_guard const lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		const auto found = _send_failures.find(stream_id);
 		return found == _send_failures.end() ? 0 : found->second;
 	}
 
 	std::uint64_t PacedSender::droppedDataPacketCount(const std::uint32_t stream_id) const
 	{
-		std::lock_guard const lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		const auto found = _dropped_data_packets.find(stream_id);
 		return found == _dropped_data_packets.end() ? 0 : found->second;
 	}
 
 	std::uint64_t PacedSender::droppedContextPacketCount(const std::uint32_t stream_id) const
 	{
-		std::lock_guard const lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		const auto found = _dropped_context_packets.find(stream_id);
 		return found == _dropped_context_packets.end() ? 0 : found->second;
 	}
 
 	std::uint64_t PacedSender::droppedSampleCount(const std::uint32_t stream_id) const
 	{
-		std::lock_guard const lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		const auto found = _dropped_samples.find(stream_id);
 		return found == _dropped_samples.end() ? 0 : found->second;
 	}
 
 	std::vector<DroppedDatagram> PacedSender::consumeDroppedDatagrams()
 	{
-		std::lock_guard const lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		auto result = std::move(_pending_dropped_datagrams);
 		_pending_dropped_datagrams.clear();
 		return result;
@@ -247,13 +247,13 @@ namespace serial::vita49
 		}
 		catch (...)
 		{
-			std::lock_guard const lock(_mutex);
+			std::scoped_lock const lock(_mutex);
 			++_send_failures[packet.stream_id];
 			recordDroppedUnlocked(packet);
 			_pending_dropped_datagrams.push_back(makeDroppedDatagram(packet));
 			return;
 		}
-		std::lock_guard const lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		++_sent_packets[packet.stream_id];
 		if (now > due + std::chrono::milliseconds(1))
 		{

--- a/packages/libfers/src/serial/vita49/paced_sender.cpp
+++ b/packages/libfers/src/serial/vita49/paced_sender.cpp
@@ -53,7 +53,7 @@ namespace serial::vita49
 
 	void PacedSender::start(const RealType simulation_epoch_time)
 	{
-		std::lock_guard lock(_mutex);
+		std::lock_guard const lock(_mutex);
 		if (_started)
 		{
 			return;
@@ -103,7 +103,7 @@ namespace serial::vita49
 	void PacedSender::stop()
 	{
 		{
-			std::lock_guard lock(_mutex);
+			std::lock_guard const lock(_mutex);
 			if (!_started && !_thread.joinable())
 			{
 				_sender->close();
@@ -119,7 +119,7 @@ namespace serial::vita49
 		}
 
 		{
-			std::lock_guard lock(_mutex);
+			std::lock_guard const lock(_mutex);
 			_started = false;
 			_stopping = false;
 			_send_in_progress = false;
@@ -130,49 +130,49 @@ namespace serial::vita49
 
 	std::uint64_t PacedSender::latePacketCount(const std::uint32_t stream_id) const
 	{
-		std::lock_guard lock(_mutex);
+		std::lock_guard const lock(_mutex);
 		const auto found = _late_packets.find(stream_id);
 		return found == _late_packets.end() ? 0 : found->second;
 	}
 
 	std::uint64_t PacedSender::sentPacketCount(const std::uint32_t stream_id) const
 	{
-		std::lock_guard lock(_mutex);
+		std::lock_guard const lock(_mutex);
 		const auto found = _sent_packets.find(stream_id);
 		return found == _sent_packets.end() ? 0 : found->second;
 	}
 
 	std::uint64_t PacedSender::sendFailureCount(const std::uint32_t stream_id) const
 	{
-		std::lock_guard lock(_mutex);
+		std::lock_guard const lock(_mutex);
 		const auto found = _send_failures.find(stream_id);
 		return found == _send_failures.end() ? 0 : found->second;
 	}
 
 	std::uint64_t PacedSender::droppedDataPacketCount(const std::uint32_t stream_id) const
 	{
-		std::lock_guard lock(_mutex);
+		std::lock_guard const lock(_mutex);
 		const auto found = _dropped_data_packets.find(stream_id);
 		return found == _dropped_data_packets.end() ? 0 : found->second;
 	}
 
 	std::uint64_t PacedSender::droppedContextPacketCount(const std::uint32_t stream_id) const
 	{
-		std::lock_guard lock(_mutex);
+		std::lock_guard const lock(_mutex);
 		const auto found = _dropped_context_packets.find(stream_id);
 		return found == _dropped_context_packets.end() ? 0 : found->second;
 	}
 
 	std::uint64_t PacedSender::droppedSampleCount(const std::uint32_t stream_id) const
 	{
-		std::lock_guard lock(_mutex);
+		std::lock_guard const lock(_mutex);
 		const auto found = _dropped_samples.find(stream_id);
 		return found == _dropped_samples.end() ? 0 : found->second;
 	}
 
 	std::vector<DroppedDatagram> PacedSender::consumeDroppedDatagrams()
 	{
-		std::lock_guard lock(_mutex);
+		std::lock_guard const lock(_mutex);
 		auto result = std::move(_pending_dropped_datagrams);
 		_pending_dropped_datagrams.clear();
 		return result;
@@ -247,13 +247,13 @@ namespace serial::vita49
 		}
 		catch (...)
 		{
-			std::lock_guard lock(_mutex);
+			std::lock_guard const lock(_mutex);
 			++_send_failures[packet.stream_id];
 			recordDroppedUnlocked(packet);
 			_pending_dropped_datagrams.push_back(makeDroppedDatagram(packet));
 			return;
 		}
-		std::lock_guard lock(_mutex);
+		std::lock_guard const lock(_mutex);
 		++_sent_packets[packet.stream_id];
 		if (now > due + std::chrono::milliseconds(1))
 		{

--- a/packages/libfers/src/serial/vita49/udp_sender.cpp
+++ b/packages/libfers/src/serial/vita49/udp_sender.cpp
@@ -6,6 +6,7 @@
 
 #include "serial/vita49/udp_sender.h"
 
+#include <bit>
 #include <cstring>
 #include <memory>
 #include <stdexcept>
@@ -31,8 +32,12 @@ namespace serial::vita49
 		void tuneSendBuffer(const int socket_fd) noexcept
 		{
 			const int send_buffer_bytes = kRequestedUdpSendBufferBytes;
-			(void)::setsockopt(socket_fd, SOL_SOCKET, SO_SNDBUF, reinterpret_cast<const char*>(&send_buffer_bytes),
-							   sizeof(send_buffer_bytes));
+#ifdef _WIN32
+			const auto* option_value = std::bit_cast<const char*>(&send_buffer_bytes);
+#else
+			const void* option_value = &send_buffer_bytes;
+#endif
+			(void)::setsockopt(socket_fd, SOL_SOCKET, SO_SNDBUF, option_value, sizeof(send_buffer_bytes));
 		}
 	}
 
@@ -123,8 +128,14 @@ namespace serial::vita49
 			return;
 		}
 
-		const auto sent = ::sendto(_socket, reinterpret_cast<const char*>(bytes.data()), bytes.size(), 0,
-								   static_cast<const sockaddr*>(_address), static_cast<socklen_t>(_address_size));
+#ifdef _WIN32
+		const auto* payload = std::bit_cast<const char*>(bytes.data());
+		const auto sent = ::sendto(_socket, payload, static_cast<int>(bytes.size()), 0,
+								   static_cast<const sockaddr*>(_address), static_cast<int>(_address_size));
+#else
+		const auto sent = ::sendto(_socket, bytes.data(), bytes.size(), 0, static_cast<const sockaddr*>(_address),
+								   static_cast<socklen_t>(_address_size));
+#endif
 		if (sent < 0 || static_cast<std::size_t>(sent) != bytes.size())
 		{
 			throw std::runtime_error("VITA UDP send failed");

--- a/packages/libfers/src/serial/vita49/udp_sender.cpp
+++ b/packages/libfers/src/serial/vita49/udp_sender.cpp
@@ -98,8 +98,12 @@ namespace serial::vita49
 
 		for (auto* candidate = result; candidate != nullptr; candidate = candidate->ai_next)
 		{
+#ifdef _WIN32
 			const int fd =
 				static_cast<int>(::socket(candidate->ai_family, candidate->ai_socktype, candidate->ai_protocol));
+#else
+			const int fd = ::socket(candidate->ai_family, candidate->ai_socktype, candidate->ai_protocol);
+#endif
 			if (fd < 0)
 			{
 				continue;

--- a/packages/libfers/src/serial/vita49/udp_sender.cpp
+++ b/packages/libfers/src/serial/vita49/udp_sender.cpp
@@ -89,7 +89,7 @@ namespace serial::vita49
 		{
 			throw std::runtime_error("VITA UDP destination resolution failed: " + host + ":" + port_string);
 		}
-		std::unique_ptr<addrinfo, decltype(&freeaddrinfo)> result_guard(result, freeaddrinfo);
+		std::unique_ptr<addrinfo, decltype(&freeaddrinfo)> const result_guard(result, freeaddrinfo);
 
 		for (auto* candidate = result; candidate != nullptr; candidate = candidate->ai_next)
 		{

--- a/packages/libfers/src/serial/vita49/udp_sender.cpp
+++ b/packages/libfers/src/serial/vita49/udp_sender.cpp
@@ -27,8 +27,6 @@ namespace serial::vita49
 	{
 		constexpr int kRequestedUdpSendBufferBytes = 4 * 1024 * 1024;
 
-		void freeAddress(void* address) noexcept { delete[] static_cast<std::byte*>(address); }
-
 		void tuneSendBuffer(const int socket_fd) noexcept
 		{
 			const int send_buffer_bytes = kRequestedUdpSendBufferBytes;
@@ -44,10 +42,9 @@ namespace serial::vita49
 	UdpSender::~UdpSender() { close(); }
 
 	UdpSender::UdpSender(UdpSender&& other) noexcept :
-		_socket(other._socket), _address(other._address), _address_size(other._address_size)
+		_socket(other._socket), _address(std::move(other._address)), _address_size(other._address_size)
 	{
 		other._socket = -1;
-		other._address = nullptr;
 		other._address_size = 0;
 	}
 
@@ -57,10 +54,9 @@ namespace serial::vita49
 		{
 			close();
 			_socket = other._socket;
-			_address = other._address;
+			_address = std::move(other._address);
 			_address_size = other._address_size;
 			other._socket = -1;
-			other._address = nullptr;
 			other._address_size = 0;
 		}
 		return *this;
@@ -112,9 +108,9 @@ namespace serial::vita49
 			tuneSendBuffer(fd);
 			_socket = fd;
 			_address_size = candidate->ai_addrlen;
-			auto* storage = new std::byte[_address_size];
-			std::memcpy(storage, candidate->ai_addr, _address_size);
-			_address = storage;
+			auto storage = std::make_unique<std::byte[]>(_address_size);
+			std::memcpy(storage.get(), candidate->ai_addr, _address_size);
+			_address = std::move(storage);
 			return;
 		}
 
@@ -135,9 +131,11 @@ namespace serial::vita49
 #ifdef _WIN32
 		const auto* payload = std::bit_cast<const char*>(bytes.data());
 		const auto sent = ::sendto(_socket, payload, static_cast<int>(bytes.size()), 0,
-								   static_cast<const sockaddr*>(_address), static_cast<int>(_address_size));
+								   static_cast<const sockaddr*>(static_cast<const void*>(_address.get())),
+								   static_cast<int>(_address_size));
 #else
-		const auto sent = ::sendto(_socket, bytes.data(), bytes.size(), 0, static_cast<const sockaddr*>(_address),
+		const auto sent = ::sendto(_socket, bytes.data(), bytes.size(), 0,
+								   static_cast<const sockaddr*>(static_cast<const void*>(_address.get())),
 								   static_cast<socklen_t>(_address_size));
 #endif
 		if (sent < 0 || static_cast<std::size_t>(sent) != bytes.size())
@@ -158,11 +156,7 @@ namespace serial::vita49
 #endif
 			_socket = -1;
 		}
-		if (_address != nullptr)
-		{
-			freeAddress(_address);
-			_address = nullptr;
-			_address_size = 0;
-		}
+		_address.reset();
+		_address_size = 0;
 	}
 }

--- a/packages/libfers/src/serial/vita49/udp_sender.h
+++ b/packages/libfers/src/serial/vita49/udp_sender.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <span>
 #include <string>
 
@@ -38,7 +40,7 @@ namespace serial::vita49
 
 	private:
 		int _socket = -1;
-		void* _address = nullptr;
+		std::unique_ptr<std::byte[]> _address;
 		std::size_t _address_size = 0;
 	};
 }

--- a/packages/libfers/src/serial/vita49/vita49_output_sink.cpp
+++ b/packages/libfers/src/serial/vita49/vita49_output_sink.cpp
@@ -71,7 +71,7 @@ namespace serial::vita49
 
 	void Vita49OutputSink::initializeRun(const core::OutputConfig& config, std::string simulation_name)
 	{
-		std::scoped_lock lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		if (config.mode != core::OutputMode::Vita49Udp)
 		{
 			throw std::invalid_argument("Vita49OutputSink requires VITA output mode");
@@ -105,7 +105,7 @@ namespace serial::vita49
 
 	std::uint32_t Vita49OutputSink::registerStream(const core::ReceiverStreamDescriptor& stream)
 	{
-		std::scoped_lock lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		const auto stream_id = _registry.registerStream(stream);
 		if (!_streams.contains(stream_id))
 		{
@@ -125,7 +125,7 @@ namespace serial::vita49
 
 	void Vita49OutputSink::openStream(const std::uint32_t stream_id, const RealType first_sample_time)
 	{
-		std::scoped_lock lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		emitContext(stream_id, first_sample_time, true, false);
 		stateFor(stream_id).opened = true;
 		emitTelemetry({}, true);
@@ -133,7 +133,7 @@ namespace serial::vita49
 
 	void Vita49OutputSink::submitBlock(const core::ReceiverSampleBlock& block)
 	{
-		std::scoped_lock lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		if (!_initialized || !_packetizer)
 		{
 			throw std::logic_error("VITA output sink has not been initialized");
@@ -183,7 +183,7 @@ namespace serial::vita49
 
 	void Vita49OutputSink::emitContextHeartbeat(const RealType simulation_time)
 	{
-		std::scoped_lock lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		emitTelemetry(consumeSenderDropsLocked(), false);
 		for (auto& [stream_id, state] : _streams)
 		{
@@ -196,7 +196,7 @@ namespace serial::vita49
 
 	void Vita49OutputSink::closeStream(const std::uint32_t stream_id)
 	{
-		std::scoped_lock lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		emitTelemetry(consumeSenderDropsLocked(), false);
 		auto& state = stateFor(stream_id);
 		if (!state.closed)
@@ -209,7 +209,7 @@ namespace serial::vita49
 
 	core::OutputStats Vita49OutputSink::finalize()
 	{
-		std::scoped_lock lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		if (_finalized)
 		{
 			auto stats = snapshotStatsLocked();
@@ -258,7 +258,7 @@ namespace serial::vita49
 
 	core::OutputStats Vita49OutputSink::snapshotStats() const
 	{
-		std::scoped_lock lock(_mutex);
+		std::scoped_lock const lock(_mutex);
 		return snapshotStatsLocked();
 	}
 

--- a/packages/libfers/src/serial/vita49/vita49_output_sink.h
+++ b/packages/libfers/src/serial/vita49/vita49_output_sink.h
@@ -28,6 +28,10 @@ namespace serial::vita49
 		explicit Vita49OutputSink(std::unique_ptr<DatagramSender> sender = nullptr,
 								  core::ReceiverOutputTelemetryCallback telemetry_callback = nullptr);
 		~Vita49OutputSink() override;
+		Vita49OutputSink(const Vita49OutputSink&) = delete;
+		Vita49OutputSink& operator=(const Vita49OutputSink&) = delete;
+		Vita49OutputSink(Vita49OutputSink&&) = delete;
+		Vita49OutputSink& operator=(Vita49OutputSink&&) = delete;
 
 		void initializeRun(const core::OutputConfig& config, std::string simulation_name) override;
 		std::uint32_t registerStream(const core::ReceiverStreamDescriptor& stream) override;

--- a/packages/libfers/src/serial/vita49/vita49_packetizer.cpp
+++ b/packages/libfers/src/serial/vita49/vita49_packetizer.cpp
@@ -65,8 +65,16 @@ namespace serial::vita49
 			const auto timestamp = timestampFromEpoch(_epoch_unix_nanoseconds, packet_first_sample_time);
 
 			auto serialized = Vita49Serializer::serializeSignalDataFixedFullscale(
-				stream_id, kFersVrtIqClassId, timestamp, packet_counts.next(), block.valid_data, block.calibrated_time,
-				block.reference_lock, loss_flag_for_next_packet, block.samples.subspan(offset, count), _adc_fullscale);
+				FixedFullscaleSignalDataPacket{.stream_id = stream_id,
+											   .class_id = kFersVrtIqClassId,
+											   .timestamp = timestamp,
+											   .packet_count = packet_counts.next(),
+											   .valid_data = block.valid_data,
+											   .calibrated_time = block.calibrated_time,
+											   .reference_lock = block.reference_lock,
+											   .sample_loss = loss_flag_for_next_packet,
+											   .samples = block.samples.subspan(offset, count),
+											   .fullscale = _adc_fullscale});
 			const bool packet_over_range = serialized.clipped_sample_count > 0;
 			result.over_range_count += serialized.clipped_sample_count;
 

--- a/packages/libfers/src/serial/vita49/vita49_serializer.cpp
+++ b/packages/libfers/src/serial/vita49/vita49_serializer.cpp
@@ -303,40 +303,39 @@ namespace serial::vita49
 		return writer.takeBytes();
 	}
 
-	SignalDataSerializationResult Vita49Serializer::serializeSignalDataFixedFullscale(
-		const std::uint32_t stream_id, const std::uint64_t class_id, const Timestamp timestamp,
-		const std::uint8_t packet_count, const bool valid_data, const bool calibrated_time, const bool reference_lock,
-		const bool sample_loss, const std::span<const ComplexType> samples, const RealType fullscale)
+	SignalDataSerializationResult
+	Vita49Serializer::serializeSignalDataFixedFullscale(const FixedFullscaleSignalDataPacket& packet)
 	{
-		if (!std::isfinite(fullscale) || fullscale <= 0.0)
+		if (!std::isfinite(packet.fullscale) || packet.fullscale <= 0.0)
 		{
 			throw std::invalid_argument("VITA signal full-scale must be positive and finite");
 		}
 
-		const std::size_t byte_count = kSignalDataFixedBytes + samples.size() * sizeof(std::int16_t) * 2u;
+		const std::size_t byte_count = kSignalDataFixedBytes + packet.samples.size() * sizeof(std::int16_t) * 2u;
 		const auto packet_size_words = checkedWordCount(byte_count);
 
 		ByteWriter writer(byte_count);
 		writer.writeU32(makeHeader(PacketType::SignalDataWithStreamId, true, true, IntegerTimestampMode::Utc,
-								   FractionalTimestampMode::RealTimePicoseconds, packet_count, packet_size_words));
-		writer.writeU32(stream_id);
-		writer.writeU64(class_id);
-		writer.writeU32(timestamp.integer_seconds);
-		writer.writeU64(timestamp.fractional_picoseconds);
+								   FractionalTimestampMode::RealTimePicoseconds, packet.packet_count,
+								   packet_size_words));
+		writer.writeU32(packet.stream_id);
+		writer.writeU64(packet.class_id);
+		writer.writeU32(packet.timestamp.integer_seconds);
+		writer.writeU64(packet.timestamp.fractional_picoseconds);
 
 		std::uint64_t clipped_sample_count = 0;
-		for (const auto& sample : samples)
+		for (const auto& sample : packet.samples)
 		{
 			bool clipped = false;
-			writer.writeI16(scaleComponentToInt16(sample.real(), fullscale, clipped));
-			writer.writeI16(scaleComponentToInt16(sample.imag(), fullscale, clipped));
+			writer.writeI16(scaleComponentToInt16(sample.real(), packet.fullscale, clipped));
+			writer.writeI16(scaleComponentToInt16(sample.imag(), packet.fullscale, clipped));
 			if (clipped)
 			{
 				++clipped_sample_count;
 			}
 		}
-		writer.writeU32(
-			makeTrailer(valid_data, calibrated_time, reference_lock, clipped_sample_count > 0, sample_loss));
+		writer.writeU32(makeTrailer(packet.valid_data, packet.calibrated_time, packet.reference_lock,
+									clipped_sample_count > 0, packet.sample_loss));
 
 		if (writer.bytes().size() != byte_count)
 		{

--- a/packages/libfers/src/serial/vita49/vita49_serializer.h
+++ b/packages/libfers/src/serial/vita49/vita49_serializer.h
@@ -36,15 +36,26 @@ namespace serial::vita49
 		std::vector<std::uint8_t> _bytes;
 	};
 
+	struct FixedFullscaleSignalDataPacket
+	{
+		std::uint32_t stream_id;
+		std::uint64_t class_id;
+		Timestamp timestamp;
+		std::uint8_t packet_count;
+		bool valid_data;
+		bool calibrated_time;
+		bool reference_lock;
+		bool sample_loss;
+		std::span<const ComplexType> samples;
+		RealType fullscale;
+	};
+
 	class Vita49Serializer
 	{
 	public:
 		[[nodiscard]] static std::vector<std::uint8_t> serializeSignalData(const SignalDataPacket& packet);
 		[[nodiscard]] static SignalDataSerializationResult
-		serializeSignalDataFixedFullscale(std::uint32_t stream_id, std::uint64_t class_id, Timestamp timestamp,
-										  std::uint8_t packet_count, bool valid_data, bool calibrated_time,
-										  bool reference_lock, bool sample_loss, std::span<const ComplexType> samples,
-										  RealType fullscale);
+		serializeSignalDataFixedFullscale(const FixedFullscaleSignalDataPacket& packet);
 		[[nodiscard]] static std::vector<std::uint8_t> serializeContext(const ContextPacket& packet);
 	};
 }

--- a/packages/libfers/src/serial/vita49/vita49_types.cpp
+++ b/packages/libfers/src/serial/vita49/vita49_types.cpp
@@ -14,7 +14,7 @@ namespace serial::vita49
 {
 	std::uint8_t PacketCountSequencer::next() noexcept
 	{
-		const std::uint8_t value = static_cast<std::uint8_t>(_next & 0x0Fu);
+		const auto value = static_cast<std::uint8_t>(_next & 0x0Fu);
 		_next = static_cast<std::uint8_t>((_next + 1u) & 0x0Fu);
 		return value;
 	}
@@ -58,7 +58,7 @@ namespace serial::vita49
 		const auto epoch_seconds = static_cast<std::uint64_t>(epoch_unix_nanoseconds / 1'000'000'000ull);
 		const auto epoch_nanoseconds = static_cast<std::uint64_t>(epoch_unix_nanoseconds % 1'000'000'000ull);
 
-		const long double offset_seconds = static_cast<long double>(sample_time_seconds);
+		const auto offset_seconds = static_cast<long double>(sample_time_seconds);
 		const long double offset_floor = std::floor(offset_seconds);
 		const auto whole_offset_seconds = static_cast<std::int64_t>(offset_floor);
 		long double fractional_seconds =
@@ -84,7 +84,7 @@ namespace serial::vita49
 
 		auto fractional_picoseconds =
 			static_cast<std::uint64_t>(std::llround(fractional_seconds * 1'000'000'000'000.0L));
-		std::uint32_t integer_seconds = static_cast<std::uint32_t>(signed_seconds);
+		auto integer_seconds = static_cast<std::uint32_t>(signed_seconds);
 		if (fractional_picoseconds >= 1'000'000'000'000ull)
 		{
 			fractional_picoseconds -= 1'000'000'000'000ull;

--- a/packages/libfers/src/serial/vita49/vita49_types.h
+++ b/packages/libfers/src/serial/vita49/vita49_types.h
@@ -83,7 +83,7 @@ namespace serial::vita49
 		Cif0ReferenceFrequency | Cif0IfOffset | Cif0Bandwidth | Cif0ReferenceLevel | Cif0DeviceIdentifier |
 		Cif0AsciiMetadata;
 
-	enum ContextFlags : std::uint32_t
+	enum ContextFlags : std::uint32_t // NOLINT(performance-enum-size)
 	{
 		ContextFlagDechirped = 1u << 0u,
 		ContextFlagIfResampled = 1u << 1u,

--- a/packages/libfers/src/serial/xml_parser_utils.cpp
+++ b/packages/libfers/src/serial/xml_parser_utils.cpp
@@ -111,57 +111,28 @@ namespace serial::xml_parser_utils
 			return value;
 		}
 
-		/// Parses receiver-side dechirp settings from an FMCW mode block.
-		void parse_receiver_dechirp_config(const XmlElement& parent, radar::Receiver& receiver,
-										   const std::string& owner)
+		bool has_if_chain_fields(const radar::Receiver::FmcwIfChainRequest& if_chain) noexcept
 		{
-			if (receiver.getMode() != radar::OperationMode::FMCW_MODE)
-			{
-				receiver.setDechirpMode(radar::Receiver::DechirpMode::None);
-				return;
-			}
+			return if_chain.sample_rate_hz.has_value() || if_chain.filter_bandwidth_hz.has_value() ||
+				if_chain.filter_transition_width_hz.has_value();
+		}
 
-			const XmlElement fmcw_mode = parent.childElement("fmcw_mode", 0);
-			if (!fmcw_mode.isValid())
+		void reject_disabled_dechirp_fields(const XmlElement& ref_element,
+											const radar::Receiver::FmcwIfChainRequest& if_chain,
+											const std::string& owner)
+		{
+			if (ref_element.isValid())
 			{
-				receiver.setDechirpMode(radar::Receiver::DechirpMode::None);
-				return;
+				throw XmlException(owner + " declares <dechirp_reference> while dechirp_mode is 'none'.");
 			}
-
-			radar::Receiver::DechirpMode mode = radar::Receiver::DechirpMode::None;
-			if (const auto mode_attr = XmlElement::getOptionalAttribute(fmcw_mode, "dechirp_mode"))
+			if (has_if_chain_fields(if_chain))
 			{
-				try
-				{
-					mode = radar::parseDechirpModeToken(*mode_attr);
-				}
-				catch (const std::exception& e)
-				{
-					throw XmlException(owner + " has invalid dechirp_mode. " + e.what());
-				}
+				throw XmlException(owner + " declares IF-chain fields while dechirp_mode is 'none'.");
 			}
+		}
 
-			const XmlElement ref_element = fmcw_mode.childElement("dechirp_reference", 0);
-			radar::Receiver::FmcwIfChainRequest if_chain{
-				.sample_rate_hz = parse_optional_fmcw_if_child(fmcw_mode, "if_sample_rate", owner),
-				.filter_bandwidth_hz = parse_optional_fmcw_if_child(fmcw_mode, "if_filter_bandwidth", owner),
-				.filter_transition_width_hz =
-					parse_optional_fmcw_if_child(fmcw_mode, "if_filter_transition_width", owner)};
-			if (mode == radar::Receiver::DechirpMode::None)
-			{
-				if (ref_element.isValid())
-				{
-					throw XmlException(owner + " declares <dechirp_reference> while dechirp_mode is 'none'.");
-				}
-				if (if_chain.sample_rate_hz.has_value() || if_chain.filter_bandwidth_hz.has_value() ||
-					if_chain.filter_transition_width_hz.has_value())
-				{
-					throw XmlException(owner + " declares IF-chain fields while dechirp_mode is 'none'.");
-				}
-				receiver.setDechirpMode(mode);
-				return;
-			}
-
+		void validate_if_chain_request(const radar::Receiver::FmcwIfChainRequest& if_chain, const std::string& owner)
+		{
 			if ((if_chain.filter_bandwidth_hz.has_value() || if_chain.filter_transition_width_hz.has_value()) &&
 				!if_chain.sample_rate_hz.has_value())
 			{
@@ -175,14 +146,16 @@ namespace serial::xml_parser_utils
 					throw XmlException(owner + " <if_sample_rate> must not exceed the simulation sample rate.");
 				}
 			}
-			if (if_chain.sample_rate_hz.has_value() && if_chain.filter_bandwidth_hz.has_value())
+			if (if_chain.sample_rate_hz.has_value() && if_chain.filter_bandwidth_hz.has_value() &&
+				*if_chain.filter_bandwidth_hz >= *if_chain.sample_rate_hz / 2.0)
 			{
-				if (*if_chain.filter_bandwidth_hz >= *if_chain.sample_rate_hz / 2.0)
-				{
-					throw XmlException(owner + " <if_filter_bandwidth> must be less than half <if_sample_rate>.");
-				}
+				throw XmlException(owner + " <if_filter_bandwidth> must be less than half <if_sample_rate>.");
 			}
+		}
 
+		radar::Receiver::DechirpReference
+		parse_dechirp_reference(const XmlElement& fmcw_mode, const XmlElement& ref_element, const std::string& owner)
+		{
 			if (!ref_element.isValid())
 			{
 				throw XmlException(owner + " enables dechirping but does not declare <dechirp_reference>.");
@@ -232,6 +205,55 @@ namespace serial::xml_parser_utils
 			case radar::Receiver::DechirpReferenceSource::None:
 				throw XmlException(owner + " dechirp_reference source must be attached, transmitter, or custom.");
 			}
+
+			return reference;
+		}
+
+		/// Parses receiver-side dechirp settings from an FMCW mode block.
+		void parse_receiver_dechirp_config(const XmlElement& parent, radar::Receiver& receiver,
+										   const std::string& owner)
+		{
+			if (receiver.getMode() != radar::OperationMode::FMCW_MODE)
+			{
+				receiver.setDechirpMode(radar::Receiver::DechirpMode::None);
+				return;
+			}
+
+			const XmlElement fmcw_mode = parent.childElement("fmcw_mode", 0);
+			if (!fmcw_mode.isValid())
+			{
+				receiver.setDechirpMode(radar::Receiver::DechirpMode::None);
+				return;
+			}
+
+			radar::Receiver::DechirpMode mode = radar::Receiver::DechirpMode::None;
+			if (const auto mode_attr = XmlElement::getOptionalAttribute(fmcw_mode, "dechirp_mode"))
+			{
+				try
+				{
+					mode = radar::parseDechirpModeToken(*mode_attr);
+				}
+				catch (const std::exception& e)
+				{
+					throw XmlException(owner + " has invalid dechirp_mode. " + e.what());
+				}
+			}
+
+			const XmlElement ref_element = fmcw_mode.childElement("dechirp_reference", 0);
+			radar::Receiver::FmcwIfChainRequest if_chain{
+				.sample_rate_hz = parse_optional_fmcw_if_child(fmcw_mode, "if_sample_rate", owner),
+				.filter_bandwidth_hz = parse_optional_fmcw_if_child(fmcw_mode, "if_filter_bandwidth", owner),
+				.filter_transition_width_hz =
+					parse_optional_fmcw_if_child(fmcw_mode, "if_filter_transition_width", owner)};
+			if (mode == radar::Receiver::DechirpMode::None)
+			{
+				reject_disabled_dechirp_fields(ref_element, if_chain, owner);
+				receiver.setDechirpMode(mode);
+				return;
+			}
+
+			validate_if_chain_request(if_chain, owner);
+			auto reference = parse_dechirp_reference(fmcw_mode, ref_element, owner);
 
 			receiver.setDechirpMode(mode);
 			receiver.setDechirpReference(std::move(reference));

--- a/packages/libfers/src/serial/xml_parser_utils.cpp
+++ b/packages/libfers/src/serial/xml_parser_utils.cpp
@@ -373,7 +373,7 @@ namespace serial::xml_parser_utils
 				}
 			}
 		}
-		return radar::processRawSchedule(std::move(raw_periods), parentName, isPulsed, pri);
+		return radar::processRawSchedule(raw_periods, parentName, isPulsed, pri);
 	}
 
 	void parseParameters(const XmlElement& parameters, params::Parameters& params_out)

--- a/packages/libfers/src/serial/xml_parser_utils.cpp
+++ b/packages/libfers/src/serial/xml_parser_utils.cpp
@@ -235,7 +235,7 @@ namespace serial::xml_parser_utils
 
 			receiver.setDechirpMode(mode);
 			receiver.setDechirpReference(std::move(reference));
-			receiver.setFmcwIfChainRequest(std::move(if_chain));
+			receiver.setFmcwIfChainRequest(if_chain);
 		}
 
 		/// Throws an XML validation exception with the provided message.

--- a/packages/libfers/src/serial/xml_parser_utils.cpp
+++ b/packages/libfers/src/serial/xml_parser_utils.cpp
@@ -376,101 +376,95 @@ namespace serial::xml_parser_utils
 		return radar::processRawSchedule(raw_periods, parentName, isPulsed, pri);
 	}
 
-	void parseParameters(const XmlElement& parameters, params::Parameters& params_out)
+	unsigned parseUnsignedParameter(const std::string_view param_name, const RealType raw_value)
 	{
-		params_out.start = get_child_real_type(parameters, "starttime");
-		params_out.end = get_child_real_type(parameters, "endtime");
-		LOG(logging::Level::INFO, "Simulation time set from {:.5f} to {:.5f} seconds", params_out.start,
-			params_out.end);
-
-		params_out.rate = get_child_real_type(parameters, "rate");
-		if (params_out.rate <= 0)
+		if (!std::isfinite(raw_value))
 		{
-			throw std::runtime_error("Sampling rate must be > 0");
+			throw XmlException(std::format("Parameter '{}' must be finite.", param_name));
 		}
-		LOG(logging::Level::DEBUG, "Sample rate set to: {:.5f}", params_out.rate);
-
-		const auto parse_unsigned_parameter = [&](const std::string_view param_name, const RealType raw_value)
+		if (raw_value < 0.0)
 		{
-			if (!std::isfinite(raw_value))
-			{
-				throw XmlException(std::format("Parameter '{}' must be finite.", param_name));
-			}
-			if (raw_value < 0.0)
-			{
-				throw XmlException(std::format("Parameter '{}' must be non-negative.", param_name));
-			}
+			throw XmlException(std::format("Parameter '{}' must be non-negative.", param_name));
+		}
 
-			const RealType floored_value = std::floor(raw_value);
-			if (floored_value > static_cast<RealType>(std::numeric_limits<unsigned>::max()))
-			{
-				throw XmlException(std::format("Parameter '{}' exceeds the supported unsigned range.", param_name));
-			}
-
-			return static_cast<unsigned>(floored_value);
-		};
-
-		auto set_optional_real_parameter = [&](const std::string& param_name, const RealType default_value, auto setter)
+		const RealType floored_value = std::floor(raw_value);
+		if (floored_value > static_cast<RealType>(std::numeric_limits<unsigned>::max()))
 		{
-			if (!parameters.childElement(param_name, 0).isValid())
-			{
-				LOG(logging::Level::DEBUG, "Parameter '{}' not specified. Using default value {}.", param_name,
-					default_value);
-				return;
-			}
+			throw XmlException(std::format("Parameter '{}' exceeds the supported unsigned range.", param_name));
+		}
 
-			setter(get_child_real_type(parameters, param_name));
-		};
+		return static_cast<unsigned>(floored_value);
+	}
 
-		auto set_optional_unsigned_parameter =
-			[&](const std::string& param_name, const unsigned default_value, auto setter)
+	template <typename Setter>
+	void setOptionalRealParameter(const XmlElement& parameters, const std::string& param_name,
+								  const RealType default_value, Setter setter)
+	{
+		if (!parameters.childElement(param_name, 0).isValid())
 		{
-			if (!parameters.childElement(param_name, 0).isValid())
-			{
-				LOG(logging::Level::DEBUG, "Parameter '{}' not specified. Using default value {}.", param_name,
-					default_value);
-				return;
-			}
+			LOG(logging::Level::DEBUG, "Parameter '{}' not specified. Using default value {}.", param_name,
+				default_value);
+			return;
+		}
 
-			setter(parse_unsigned_parameter(param_name, get_child_real_type(parameters, param_name)));
-		};
+		setter(get_child_real_type(parameters, param_name));
+	}
 
-		set_optional_real_parameter("c", params::Parameters::DEFAULT_C,
-									[&](const RealType value)
-									{
-										params_out.c = value;
-										LOG(logging::Level::INFO, "Propagation speed (c) set to: {:.5f}", value);
-									});
+	template <typename Setter>
+	void setOptionalUnsignedParameter(const XmlElement& parameters, const std::string& param_name,
+									  const unsigned default_value, Setter setter)
+	{
+		if (!parameters.childElement(param_name, 0).isValid())
+		{
+			LOG(logging::Level::DEBUG, "Parameter '{}' not specified. Using default value {}.", param_name,
+				default_value);
+			return;
+		}
 
-		set_optional_real_parameter("simSamplingRate", 1000.0,
-									[&](const RealType value)
-									{
-										params_out.sim_sampling_rate = value;
-										LOG(logging::Level::DEBUG, "Simulation sampling rate set to: {:.5f} Hz", value);
-									});
+		setter(parseUnsignedParameter(param_name, get_child_real_type(parameters, param_name)));
+	}
+
+	void parseOptionalNumericParameters(const XmlElement& parameters, params::Parameters& params_out)
+	{
+		setOptionalRealParameter(parameters, "c", params::Parameters::DEFAULT_C,
+								 [&](const RealType value)
+								 {
+									 params_out.c = value;
+									 LOG(logging::Level::INFO, "Propagation speed (c) set to: {:.5f}", value);
+								 });
+
+		setOptionalRealParameter(parameters, "simSamplingRate", 1000.0,
+								 [&](const RealType value)
+								 {
+									 params_out.sim_sampling_rate = value;
+									 LOG(logging::Level::DEBUG, "Simulation sampling rate set to: {:.5f} Hz", value);
+								 });
 
 		if (parameters.childElement("randomseed", 0).isValid())
 		{
-			const auto seed = parse_unsigned_parameter("randomseed", get_child_real_type(parameters, "randomseed"));
+			const auto seed = parseUnsignedParameter("randomseed", get_child_real_type(parameters, "randomseed"));
 			params_out.random_seed = seed;
 			LOG(logging::Level::DEBUG, "Random seed set to: {}", seed);
 		}
 
-		set_optional_unsigned_parameter("adc_bits", 0,
-										[&](const unsigned value)
-										{
-											params_out.adc_bits = value;
-											LOG(logging::Level::DEBUG, "ADC quantization bits set to: {}", value);
-										});
+		setOptionalUnsignedParameter(parameters, "adc_bits", 0,
+									 [&](const unsigned value)
+									 {
+										 params_out.adc_bits = value;
+										 LOG(logging::Level::DEBUG, "ADC quantization bits set to: {}", value);
+									 });
 
-		set_optional_unsigned_parameter("oversample", 1,
-										[&](const unsigned value)
-										{
-											params::validateOversampleRatio(value);
-											params_out.oversample_ratio = value;
-											LOG(logging::Level::DEBUG, "Oversampling enabled with ratio: {}", value);
-										});
+		setOptionalUnsignedParameter(parameters, "oversample", 1,
+									 [&](const unsigned value)
+									 {
+										 params::validateOversampleRatio(value);
+										 params_out.oversample_ratio = value;
+										 LOG(logging::Level::DEBUG, "Oversampling enabled with ratio: {}", value);
+									 });
+	}
 
+	void parseRotationAngleUnit(const XmlElement& parameters, params::Parameters& params_out)
+	{
 		try
 		{
 			const auto unit_token = parameters.childElement("rotationangleunit", 0).getText();
@@ -489,7 +483,10 @@ namespace serial::xml_parser_utils
 		catch (const XmlException&)
 		{
 		}
+	}
 
+	bool parseOriginParameter(const XmlElement& parameters, params::Parameters& params_out)
+	{
 		bool origin_set = false;
 		if (const XmlElement origin_element = parameters.childElement("origin", 0); origin_element.isValid())
 		{
@@ -516,39 +513,48 @@ namespace serial::xml_parser_utils
 					e.what());
 			}
 		}
+		return origin_set;
+	}
 
+	void parseUtmCoordinateSystem(const XmlElement& cs_element, params::Parameters& params_out)
+	{
+		params_out.coordinate_frame = params::CoordinateFrame::UTM;
+		params_out.utm_zone = std::stoi(XmlElement::getSafeAttribute(cs_element, "zone"));
+		const std::string hem_str = XmlElement::getSafeAttribute(cs_element, "hemisphere");
+
+		if (params_out.utm_zone < GeographicLib::UTMUPS::MINUTMZONE ||
+			params_out.utm_zone > GeographicLib::UTMUPS::MAXUTMZONE)
+		{
+			throw XmlException("KML UTM zone " + std::to_string(params_out.utm_zone) +
+							   " is invalid; must be in [1, 60].");
+		}
+		if (hem_str == "N" || hem_str == "n")
+		{
+			params_out.utm_north_hemisphere = true;
+		}
+		else if (hem_str == "S" || hem_str == "s")
+		{
+			params_out.utm_north_hemisphere = false;
+		}
+		else
+		{
+			throw XmlException("KML UTM hemisphere '" + hem_str + "' is invalid; must be 'N' or 'S'.");
+		}
+		LOG(logging::Level::INFO, "KML coordinate system set to UTM, zone {}{}", params_out.utm_zone,
+			params_out.utm_north_hemisphere ? 'N' : 'S');
+	}
+
+	void parseCoordinateSystemParameter(const XmlElement& parameters, params::Parameters& params_out,
+										const bool origin_set)
+	{
 		if (const XmlElement cs_element = parameters.childElement("coordinatesystem", 0); cs_element.isValid())
 		{
 			try
 			{
 				const std::string frame_str = XmlElement::getSafeAttribute(cs_element, "frame");
-
 				if (frame_str == "UTM")
 				{
-					params_out.coordinate_frame = params::CoordinateFrame::UTM;
-					params_out.utm_zone = std::stoi(XmlElement::getSafeAttribute(cs_element, "zone"));
-					const std::string hem_str = XmlElement::getSafeAttribute(cs_element, "hemisphere");
-
-					if (params_out.utm_zone < GeographicLib::UTMUPS::MINUTMZONE ||
-						params_out.utm_zone > GeographicLib::UTMUPS::MAXUTMZONE)
-					{
-						throw XmlException("KML UTM zone " + std::to_string(params_out.utm_zone) +
-										   " is invalid; must be in [1, 60].");
-					}
-					if (hem_str == "N" || hem_str == "n")
-					{
-						params_out.utm_north_hemisphere = true;
-					}
-					else if (hem_str == "S" || hem_str == "s")
-					{
-						params_out.utm_north_hemisphere = false;
-					}
-					else
-					{
-						throw XmlException("KML UTM hemisphere '" + hem_str + "' is invalid; must be 'N' or 'S'.");
-					}
-					LOG(logging::Level::INFO, "KML coordinate system set to UTM, zone {}{}", params_out.utm_zone,
-						params_out.utm_north_hemisphere ? 'N' : 'S');
+					parseUtmCoordinateSystem(cs_element, params_out);
 				}
 				else if (frame_str == "ECEF")
 				{
@@ -579,6 +585,26 @@ namespace serial::xml_parser_utils
 				params_out.utm_north_hemisphere = true;
 			}
 		}
+	}
+
+	void parseParameters(const XmlElement& parameters, params::Parameters& params_out)
+	{
+		params_out.start = get_child_real_type(parameters, "starttime");
+		params_out.end = get_child_real_type(parameters, "endtime");
+		LOG(logging::Level::INFO, "Simulation time set from {:.5f} to {:.5f} seconds", params_out.start,
+			params_out.end);
+
+		params_out.rate = get_child_real_type(parameters, "rate");
+		if (params_out.rate <= 0)
+		{
+			throw std::runtime_error("Sampling rate must be > 0");
+		}
+		LOG(logging::Level::DEBUG, "Sample rate set to: {:.5f}", params_out.rate);
+
+		parseOptionalNumericParameters(parameters, params_out);
+		parseRotationAngleUnit(parameters, params_out);
+		const bool origin_set = parseOriginParameter(parameters, params_out);
+		parseCoordinateSystemParameter(parameters, params_out, origin_set);
 	}
 
 	void parseWaveform(const XmlElement& waveform, ParserContext& ctx)

--- a/packages/libfers/src/serial/xml_parser_utils.cpp
+++ b/packages/libfers/src/serial/xml_parser_utils.cpp
@@ -356,7 +356,7 @@ namespace serial::xml_parser_utils
 			unsigned p_idx = 0;
 			while (true)
 			{
-				XmlElement period_element = schedule_element.childElement("period", p_idx++);
+				XmlElement const period_element = schedule_element.childElement("period", p_idx++);
 				if (!period_element.isValid())
 				{
 					break;
@@ -696,7 +696,7 @@ namespace serial::xml_parser_utils
 		unsigned noise_index = 0;
 		while (true)
 		{
-			XmlElement noise_element = timing.childElement("noise_entry", noise_index++);
+			XmlElement const noise_element = timing.childElement("noise_entry", noise_index++);
 			if (!noise_element.isValid())
 			{
 				break;
@@ -841,7 +841,7 @@ namespace serial::xml_parser_utils
 		unsigned waypoint_index = 0;
 		while (true)
 		{
-			XmlElement waypoint = motionPath.childElement("positionwaypoint", waypoint_index);
+			XmlElement const waypoint = motionPath.childElement("positionwaypoint", waypoint_index);
 			if (!waypoint.isValid())
 			{
 				break;
@@ -900,7 +900,7 @@ namespace serial::xml_parser_utils
 		unsigned waypoint_index = 0;
 		while (true)
 		{
-			XmlElement waypoint = rotation.childElement("rotationwaypoint", waypoint_index);
+			XmlElement const waypoint = rotation.childElement("rotationwaypoint", waypoint_index);
 			if (!waypoint.isValid())
 			{
 				break;
@@ -1012,7 +1012,7 @@ namespace serial::xml_parser_utils
 			resolve_reference_id(transmitter, "timing", "transmitter '" + name + "'", *refs.timings);
 		transmitter_obj->setTiming(resolve_timing_instance(timing_id, ctx, "transmitter '" + name + "'"));
 
-		RealType pri = is_pulsed ? (1.0 / transmitter_obj->getPrf()) : 0.0;
+		RealType const pri = is_pulsed ? (1.0 / transmitter_obj->getPrf()) : 0.0;
 		auto schedule = parseSchedule(transmitter, name, is_pulsed, pri);
 		if (wave->isFmcwFamily())
 		{
@@ -1114,7 +1114,7 @@ namespace serial::xml_parser_utils
 				receiver_obj->getName().c_str());
 		}
 
-		RealType pri = is_pulsed ? (1.0 / receiver_obj->getWindowPrf()) : 0.0;
+		RealType const pri = is_pulsed ? (1.0 / receiver_obj->getWindowPrf()) : 0.0;
 		auto schedule = parseSchedule(receiver, name, is_pulsed, pri);
 		if (!schedule.empty())
 		{
@@ -1247,7 +1247,7 @@ namespace serial::xml_parser_utils
 					   const std::function<void(const XmlElement&, std::string_view)>& register_name,
 					   const ReferenceLookup& refs)
 	{
-		std::string name = XmlElement::getSafeAttribute(platform, "name");
+		std::string const name = XmlElement::getSafeAttribute(platform, "name");
 		const SimId id = assign_id_from_attribute("platform '" + name + "'", ObjectType::Platform);
 		auto plat = std::make_unique<radar::Platform>(name, id);
 
@@ -1285,18 +1285,18 @@ namespace serial::xml_parser_utils
 		unsigned index = 0;
 		while (true)
 		{
-			XmlElement include_element = doc.getRootElement().childElement("include", index++);
+			XmlElement const include_element = doc.getRootElement().childElement("include", index++);
 			if (!include_element.isValid())
 				break;
 
-			std::string include_filename = include_element.getText();
+			std::string const include_filename = include_element.getText();
 			if (include_filename.empty())
 			{
 				LOG(logging::Level::ERROR, "<include> element is missing the filename!");
 				continue;
 			}
 
-			fs::path include_path = currentDir / include_filename;
+			fs::path const include_path = currentDir / include_filename;
 			includePaths.push_back(include_path);
 
 			XmlDocument included_doc;
@@ -1394,7 +1394,7 @@ namespace serial::xml_parser_utils
 			unsigned index = 0;
 			while (true)
 			{
-				XmlElement element = parent.childElement(elementName, index++);
+				XmlElement const element = parent.childElement(elementName, index++);
 				if (!element.isValid())
 					break;
 				parseFunction(element, parser_ctx);

--- a/packages/libfers/src/serial/xml_parser_utils.cpp
+++ b/packages/libfers/src/serial/xml_parser_utils.cpp
@@ -743,7 +743,7 @@ namespace serial::xml_parser_utils
 
 	void parseAntenna(const XmlElement& antenna, ParserContext& ctx)
 	{
-		std::string name = XmlElement::getSafeAttribute(antenna, "name");
+		const std::string name = XmlElement::getSafeAttribute(antenna, "name");
 		const SimId id = assign_id_from_attribute("antenna '" + name + "'", ObjectType::Antenna);
 		const std::string pattern = XmlElement::getSafeAttribute(antenna, "pattern");
 

--- a/packages/libfers/src/serial/xml_parser_utils.cpp
+++ b/packages/libfers/src/serial/xml_parser_utils.cpp
@@ -970,9 +970,9 @@ namespace serial::xml_parser_utils
 	}
 
 	/// Parses a transmitter after its operation mode has already been determined.
-	radar::Transmitter* parseTransmitterWithMode(const XmlElement& transmitter, radar::Platform* platform,
-												 ParserContext& ctx, const ReferenceLookup& refs,
-												 const radar::OperationMode mode)
+	static radar::Transmitter* parseTransmitterWithMode(const XmlElement& transmitter, radar::Platform* platform,
+														ParserContext& ctx, const ReferenceLookup& refs,
+														const radar::OperationMode mode)
 	{
 		const std::string name = XmlElement::getSafeAttribute(transmitter, "name");
 		const SimId id = assign_id_from_attribute("transmitter '" + name + "'", ObjectType::Transmitter);
@@ -1041,8 +1041,9 @@ namespace serial::xml_parser_utils
 	}
 
 	/// Parses a receiver after its operation mode has already been determined.
-	radar::Receiver* parseReceiverWithMode(const XmlElement& receiver, radar::Platform* platform, ParserContext& ctx,
-										   const ReferenceLookup& refs, const radar::OperationMode mode)
+	static radar::Receiver* parseReceiverWithMode(const XmlElement& receiver, radar::Platform* platform,
+												  ParserContext& ctx, const ReferenceLookup& refs,
+												  const radar::OperationMode mode)
 	{
 		const std::string name = XmlElement::getSafeAttribute(receiver, "name");
 		const SimId id = assign_id_from_attribute("receiver '" + name + "'", ObjectType::Receiver);

--- a/packages/libfers/src/serial/xml_serializer.cpp
+++ b/packages/libfers/src/serial/xml_serializer.cpp
@@ -25,9 +25,9 @@ namespace serial
 {
 	std::string world_to_xml_string(const core::World& world)
 	{
-		XmlDocument doc;
+		XmlDocument const doc;
 		xmlNodePtr sim_node = xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("simulation"));
-		XmlElement root(sim_node);
+		XmlElement const root(sim_node);
 		doc.setRootElement(root);
 
 		const auto& p = params::params;
@@ -46,22 +46,22 @@ namespace serial
 
 		for (const auto& waveform : world.getWaveforms() | std::views::values)
 		{
-			XmlElement waveform_elem = root.addChild("waveform");
+			XmlElement const waveform_elem = root.addChild("waveform");
 			xml_serializer_utils::serializeWaveform(*waveform, waveform_elem);
 		}
 		for (const auto& timing : world.getTimings() | std::views::values)
 		{
-			XmlElement timing_elem = root.addChild("timing");
+			XmlElement const timing_elem = root.addChild("timing");
 			xml_serializer_utils::serializeTiming(*timing, timing_elem);
 		}
 		for (const auto& antenna : world.getAntennas() | std::views::values)
 		{
-			XmlElement antenna_elem = root.addChild("antenna");
+			XmlElement const antenna_elem = root.addChild("antenna");
 			xml_serializer_utils::serializeAntenna(*antenna, antenna_elem);
 		}
 		for (const auto& platform : world.getPlatforms())
 		{
-			XmlElement plat_elem = root.addChild("platform");
+			XmlElement const plat_elem = root.addChild("platform");
 			xml_serializer_utils::serializePlatform(*platform, world, plat_elem);
 		}
 

--- a/packages/libfers/src/serial/xml_serializer.cpp
+++ b/packages/libfers/src/serial/xml_serializer.cpp
@@ -26,8 +26,7 @@ namespace serial
 	std::string world_to_xml_string(const core::World& world)
 	{
 		XmlDocument const doc;
-		xmlNodePtr sim_node = xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("simulation"));
-		XmlElement const root(sim_node);
+		XmlElement const root = XmlElement::create("simulation");
 		doc.setRootElement(root);
 
 		const auto& p = params::params;

--- a/packages/libfers/src/serial/xml_serializer_utils.cpp
+++ b/packages/libfers/src/serial/xml_serializer_utils.cpp
@@ -43,7 +43,7 @@ namespace serial::xml_serializer_utils
 		const XmlElement sched_elem = parent.addChild("schedule");
 		for (const auto& period : schedule)
 		{
-			XmlElement p_elem = sched_elem.addChild("period");
+			XmlElement const p_elem = sched_elem.addChild("period");
 			p_elem.setAttribute("start", std::to_string(period.start));
 			p_elem.setAttribute("end", std::to_string(period.end));
 		}
@@ -180,7 +180,7 @@ namespace serial::xml_serializer_utils
 		timing.copyAlphas(alphas, weights);
 		for (size_t i = 0; i < alphas.size(); ++i)
 		{
-			XmlElement entry = parent.addChild("noise_entry");
+			XmlElement const entry = parent.addChild("noise_entry");
 			addChildWithNumber(entry, "alpha", alphas[i]);
 			addChildWithNumber(entry, "weight", weights[i]);
 		}
@@ -251,7 +251,7 @@ namespace serial::xml_serializer_utils
 
 		for (const auto& [pos, t] : path.getCoords())
 		{
-			XmlElement wp_elem = parent.addChild("positionwaypoint");
+			XmlElement const wp_elem = parent.addChild("positionwaypoint");
 			addChildWithNumber(wp_elem, "x", pos.x);
 			addChildWithNumber(wp_elem, "y", pos.y);
 			addChildWithNumber(wp_elem, "altitude", pos.z);
@@ -302,7 +302,7 @@ namespace serial::xml_serializer_utils
 			const auto unit = params::rotationAngleUnit();
 			for (const auto& wp : rotPath.getCoords())
 			{
-				XmlElement wp_elem = rot_elem.addChild("rotationwaypoint");
+				XmlElement const wp_elem = rot_elem.addChild("rotationwaypoint");
 				RealType azimuth = rotation_angle_utils::internal_azimuth_to_external(wp.azimuth, unit);
 				if (unit == params::RotationAngleUnit::Degrees)
 				{
@@ -466,7 +466,7 @@ namespace serial::xml_serializer_utils
 		{
 			if (const auto* chi = dynamic_cast<const radar::RcsChiSquare*>(model))
 			{
-				XmlElement model_elem = target_elem.addChild("model");
+				XmlElement const model_elem = target_elem.addChild("model");
 				model_elem.setAttribute("type", "chisquare");
 				addChildWithNumber(model_elem, "k", chi->getK());
 			}

--- a/packages/libfers/src/serial/xml_serializer_utils.cpp
+++ b/packages/libfers/src/serial/xml_serializer_utils.cpp
@@ -341,7 +341,7 @@ namespace serial::xml_serializer_utils
 		serializeSchedule(tx.getSchedule(), tx_elem);
 	}
 
-	void serializeReceiverFmcwMode(const radar::Receiver& rx, const XmlElement& mode_elem)
+	static void serializeReceiverFmcwMode(const radar::Receiver& rx, const XmlElement& mode_elem)
 	{
 		if (!rx.isDechirpEnabled())
 		{

--- a/packages/libfers/src/signal/dsp_filters.cpp
+++ b/packages/libfers/src/signal/dsp_filters.cpp
@@ -16,6 +16,7 @@
 #include <array>
 #include <cmath>
 #include <complex>
+#include <cstddef>
 #include <numeric>
 #include <ranges>
 #include <set>
@@ -152,18 +153,20 @@ namespace fers_signal
 		const auto design = blackmanFir(1 / static_cast<RealType>(ratio), ratio, filter_length);
 		const auto filt_length = static_cast<unsigned>(design.coeffs.size());
 
-		std::vector tmp(static_cast<size_t>(size * ratio + filt_length), ComplexType{0.0, 0.0});
+		const auto oversampled_size = static_cast<std::size_t>(size) * static_cast<std::size_t>(ratio);
+		std::vector tmp(oversampled_size + static_cast<std::size_t>(filt_length), ComplexType{0.0, 0.0});
 
 		for (unsigned i = 0; i < size; ++i)
 		{
-			tmp[static_cast<size_t>(i * ratio)] = in[i];
+			tmp[static_cast<std::size_t>(i) * static_cast<std::size_t>(ratio)] = in[i];
 		}
 
 		const FirFilter filt(design.coeffs);
 		filt.filter(tmp);
 
-		const auto delay = filt_length / 2;
-		std::ranges::copy_n(tmp.begin() + delay, size * ratio, out.begin());
+		const auto delay = static_cast<std::size_t>(filt_length / 2);
+		const std::span<const ComplexType> filtered_output(tmp.data() + delay, oversampled_size);
+		std::ranges::copy(filtered_output, out.begin());
 	}
 
 	/**
@@ -189,7 +192,7 @@ namespace fers_signal
 		validateOversamplingConfig(ratio);
 		const unsigned filter_length = params::renderFilterLength();
 		const auto design = blackmanFir(1 / static_cast<RealType>(ratio), ratio, filter_length);
-		const auto filt_length = static_cast<unsigned>(design.coeffs.size());
+		const auto filt_length = design.coeffs.size();
 
 		std::vector tmp(in.size() + filt_length, ComplexType{0, 0});
 
@@ -200,9 +203,11 @@ namespace fers_signal
 
 		const auto downsampled_size = in.size() / ratio;
 		std::vector<ComplexType> out(downsampled_size);
-		for (unsigned i = 0; i < downsampled_size; ++i)
+		const auto filter_delay = filt_length / 2;
+		for (std::size_t i = 0; i < downsampled_size; ++i)
 		{
-			out[i] = tmp[static_cast<size_t>(i * ratio + filt_length / 2)] / static_cast<RealType>(ratio);
+			const auto source_index = i * static_cast<std::size_t>(ratio) + filter_delay;
+			out[i] = tmp[source_index] / static_cast<RealType>(ratio);
 		}
 
 		return out;

--- a/packages/libfers/src/signal/dsp_filters.cpp
+++ b/packages/libfers/src/signal/dsp_filters.cpp
@@ -150,7 +150,7 @@ namespace fers_signal
 		validateOversamplingConfig(ratio);
 		const unsigned filter_length = params::renderFilterLength();
 		const auto design = blackmanFir(1 / static_cast<RealType>(ratio), ratio, filter_length);
-		const unsigned filt_length = static_cast<unsigned>(design.coeffs.size());
+		const auto filt_length = static_cast<unsigned>(design.coeffs.size());
 
 		std::vector tmp(static_cast<size_t>(size * ratio + filt_length), ComplexType{0.0, 0.0});
 
@@ -189,7 +189,7 @@ namespace fers_signal
 		validateOversamplingConfig(ratio);
 		const unsigned filter_length = params::renderFilterLength();
 		const auto design = blackmanFir(1 / static_cast<RealType>(ratio), ratio, filter_length);
-		const unsigned filt_length = static_cast<unsigned>(design.coeffs.size());
+		const auto filt_length = static_cast<unsigned>(design.coeffs.size());
 
 		std::vector tmp(in.size() + filt_length, ComplexType{0, 0});
 

--- a/packages/libfers/src/signal/dsp_filters.cpp
+++ b/packages/libfers/src/signal/dsp_filters.cpp
@@ -208,9 +208,8 @@ namespace fers_signal
 		return out;
 	}
 
-	DownsamplingSink::DownsamplingSink()
+	DownsamplingSink::DownsamplingSink() : _ratio(params::oversampleRatio())
 	{
-		_ratio = params::oversampleRatio();
 		validateOversamplingConfig(_ratio);
 		if (_ratio <= 1)
 		{

--- a/packages/libfers/src/signal/if_resampler.cpp
+++ b/packages/libfers/src/signal/if_resampler.cpp
@@ -188,7 +188,8 @@ namespace
 		stage.group_delay_seconds = static_cast<RealType>(taps - 1) / (2.0 * design_rate_hz);
 		if (kind == fers_signal::FmcwIfResamplerStageKind::HalfBandDecimateBy2)
 		{
-			stage.estimated_macs_per_stage_output = static_cast<RealType>((taps + 3) / 4);
+			const auto half_band_branch_macs = (taps + 3) / 4;
+			stage.estimated_macs_per_stage_output = static_cast<RealType>(half_band_branch_macs);
 		}
 		else
 		{
@@ -542,7 +543,7 @@ namespace fers_signal
 			const RealType limiting_nyquist = 0.5 * std::min(_plan.input_sample_rate_hz, _plan.output_sample_rate_hz);
 			const RealType cutoff_hz = std::min(_plan.cutoff_hz, limiting_nyquist * 0.999);
 			const RealType cutoff = cutoff_hz / _plan.input_sample_rate_hz;
-			const auto half = static_cast<RealType>((taps - 1) / 2);
+			const RealType half = static_cast<RealType>(taps - 1) / 2.0;
 
 			for (std::size_t phase = 0; phase < phase_count; ++phase)
 			{

--- a/packages/libfers/src/signal/if_resampler.h
+++ b/packages/libfers/src/signal/if_resampler.h
@@ -22,7 +22,7 @@
 
 namespace fers_signal
 {
-	enum class FmcwIfResamplerStageKind
+	enum class FmcwIfResamplerStageKind : std::uint8_t
 	{
 		HalfBandDecimateBy2,
 		RationalPolyphase

--- a/packages/libfers/src/signal/radar_signal.cpp
+++ b/packages/libfers/src/signal/radar_signal.cpp
@@ -55,7 +55,7 @@ namespace fers_signal
 									 const RealType chirp_period, const RealType start_frequency_offset,
 									 std::optional<std::size_t> chirp_count, const FmcwChirpDirection direction) :
 		_chirp_bandwidth(chirp_bandwidth), _chirp_duration(chirp_duration), _chirp_period(chirp_period),
-		_start_frequency_offset(start_frequency_offset), _chirp_count(std::move(chirp_count)),
+		_start_frequency_offset(start_frequency_offset), _chirp_count(chirp_count),
 		_chirp_rate(chirp_bandwidth / chirp_duration), _direction(direction)
 	{
 	}
@@ -113,7 +113,7 @@ namespace fers_signal
 										   const RealType start_frequency_offset,
 										   std::optional<std::size_t> triangle_count) :
 		_chirp_bandwidth(chirp_bandwidth), _chirp_duration(chirp_duration),
-		_start_frequency_offset(start_frequency_offset), _triangle_count(std::move(triangle_count)),
+		_start_frequency_offset(start_frequency_offset), _triangle_count(triangle_count),
 		_chirp_rate(chirp_bandwidth / chirp_duration), _triangle_period(2.0 * chirp_duration),
 		_delta_phi_up(2.0 * PI * start_frequency_offset * chirp_duration +
 					  PI * _chirp_rate * chirp_duration * chirp_duration)

--- a/packages/libfers/src/signal/radar_signal.cpp
+++ b/packages/libfers/src/signal/radar_signal.cpp
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <complex>
 #include <iterator>
+#include <limits>
 #include <stdexcept>
 #include <utility>
 
@@ -238,9 +239,14 @@ namespace fers_signal
 	{
 		clear();
 		const unsigned ratio = params::oversampleRatio();
-		_data.resize(samples * ratio);
-		_size = samples * ratio;
-		_rate = sampleRate * ratio;
+		const auto oversampled_samples = static_cast<std::size_t>(samples) * static_cast<std::size_t>(ratio);
+		if (oversampled_samples > std::numeric_limits<unsigned>::max())
+		{
+			throw std::overflow_error("Oversampled signal sample count exceeds unsigned range");
+		}
+		_data.resize(oversampled_samples);
+		_size = static_cast<unsigned>(oversampled_samples);
+		_rate = sampleRate * static_cast<RealType>(ratio);
 
 		if (ratio == 1)
 		{

--- a/packages/libfers/src/signal/radar_signal.h
+++ b/packages/libfers/src/signal/radar_signal.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <span>
@@ -32,7 +33,7 @@ namespace interp
 namespace fers_signal
 {
 	/// Sweep direction for a linear FMCW chirp.
-	enum class FmcwChirpDirection
+	enum class FmcwChirpDirection : std::uint8_t
 	{
 		Up, ///< Instantaneous baseband frequency increases over the chirp.
 		Down ///< Instantaneous baseband frequency decreases over the chirp.

--- a/packages/libfers/src/simulation/channel_model.cpp
+++ b/packages/libfers/src/simulation/channel_model.cpp
@@ -320,6 +320,130 @@ namespace
 		return source;
 	}
 
+	bool computeLinearFmcwPhaseWithoutTracker(const core::ActiveStreamingSource& source, const RealType t_ret,
+											  const RealType tau, RealType& phase_out)
+	{
+		const RealType time_since_segment_start = t_ret - source.segment_start;
+		const auto chirp_index = static_cast<std::size_t>(std::floor(time_since_segment_start / source.chirp_period));
+		if (source.chirp_count.has_value() && chirp_index >= *source.chirp_count)
+		{
+			return false;
+		}
+		const RealType chirp_time = time_since_segment_start - static_cast<RealType>(chirp_index) * source.chirp_period;
+		if (chirp_time < 0.0 || chirp_time >= source.chirp_duration)
+		{
+			return false;
+		}
+		phase_out = -2.0 * PI * source.carrier_freq * tau + source.two_pi_f0 * chirp_time +
+			source.s_pi_alpha * chirp_time * chirp_time;
+		return true;
+	}
+
+	bool computeLinearFmcwPhaseWithTracker(const core::ActiveStreamingSource& source, const RealType t_ret,
+										   const RealType tau, core::FmcwChirpBoundaryTracker& chirp_tracker,
+										   RealType& phase_out)
+	{
+		if (!chirp_tracker.initialized)
+		{
+			initializeFmcwTracker(source, t_ret, chirp_tracker);
+		}
+
+		while (t_ret >= chirp_tracker.t_n + source.chirp_period)
+		{
+			chirp_tracker.t_n += source.chirp_period;
+			++chirp_tracker.n_current;
+		}
+
+		if (source.chirp_count.has_value() && chirp_tracker.n_current >= *source.chirp_count)
+		{
+			return false;
+		}
+
+		const RealType u_ret = t_ret - chirp_tracker.t_n;
+		if (u_ret < 0.0 || u_ret >= source.chirp_duration)
+		{
+			return false;
+		}
+
+		phase_out =
+			-2.0 * PI * source.carrier_freq * tau + source.two_pi_f0 * u_ret + source.s_pi_alpha * u_ret * u_ret;
+		return true;
+	}
+
+	bool computeTriangleFmcwPhaseWithoutTracker(const core::ActiveStreamingSource& source, const RealType t_ret,
+												const RealType tau, RealType& phase_out)
+	{
+		const RealType delta = t_ret - source.segment_start;
+		const auto triangle_index = static_cast<std::size_t>(std::floor(delta / source.triangle_period));
+		if (source.triangle_count.has_value() && triangle_index >= *source.triangle_count)
+		{
+			return false;
+		}
+		const RealType local_triangle_time = delta - static_cast<RealType>(triangle_index) * source.triangle_period;
+		const bool down_leg = local_triangle_time >= source.chirp_duration;
+		const RealType u_ret = down_leg ? local_triangle_time - source.chirp_duration : local_triangle_time;
+		if (u_ret < 0.0 || u_ret >= source.chirp_duration)
+		{
+			return false;
+		}
+		const RealType phi_base = std::fmod(static_cast<RealType>(triangle_index) * source.mod_phi_tri, 2.0 * PI) +
+			(down_leg ? source.mod_phi_up : 0.0);
+		const RealType modular_phi_base = phi_base >= 2.0 * PI ? phi_base - 2.0 * PI : phi_base;
+		const RealType linear_coeff = down_leg ? source.two_pi_f0_plus_B : source.two_pi_f0;
+		const RealType quad_coeff = down_leg ? source.neg_pi_alpha : source.pi_alpha;
+		phase_out = -2.0 * PI * source.carrier_freq * tau + modular_phi_base + linear_coeff * u_ret +
+			quad_coeff * u_ret * u_ret;
+		return true;
+	}
+
+	void advanceTriangleTracker(const core::ActiveStreamingSource& source, const RealType t_ret,
+								core::FmcwChirpBoundaryTracker& chirp_tracker)
+	{
+		while (t_ret >= chirp_tracker.triangle_t_leg + source.chirp_duration)
+		{
+			chirp_tracker.triangle_t_leg += source.chirp_duration;
+			chirp_tracker.triangle_leg = 1U - chirp_tracker.triangle_leg;
+			if (chirp_tracker.triangle_leg == 0U)
+			{
+				++chirp_tracker.triangle_index;
+			}
+			chirp_tracker.triangle_phi_base += source.mod_phi_up;
+			if (chirp_tracker.triangle_phi_base >= 2.0 * PI)
+			{
+				chirp_tracker.triangle_phi_base -= 2.0 * PI;
+			}
+		}
+	}
+
+	bool computeTriangleFmcwPhaseWithTracker(const core::ActiveStreamingSource& source, const RealType t_ret,
+											 const RealType tau, core::FmcwChirpBoundaryTracker& chirp_tracker,
+											 RealType& phase_out)
+	{
+		if (!chirp_tracker.triangle_initialized)
+		{
+			initializeFmcwTriangleTracker(source, t_ret, chirp_tracker);
+		}
+
+		advanceTriangleTracker(source, t_ret, chirp_tracker);
+		if (source.triangle_count.has_value() && chirp_tracker.triangle_index >= *source.triangle_count)
+		{
+			return false;
+		}
+
+		const RealType u_ret = t_ret - chirp_tracker.triangle_t_leg;
+		if (u_ret < 0.0 || u_ret >= source.chirp_duration)
+		{
+			return false;
+		}
+
+		const bool down_leg = chirp_tracker.triangle_leg == 1U;
+		const RealType linear_coeff = down_leg ? source.two_pi_f0_plus_B : source.two_pi_f0;
+		const RealType quad_coeff = down_leg ? source.neg_pi_alpha : source.pi_alpha;
+		phase_out = -2.0 * PI * source.carrier_freq * tau + chirp_tracker.triangle_phi_base + linear_coeff * u_ret +
+			quad_coeff * u_ret * u_ret;
+		return true;
+	}
+
 	/// Computes streaming phase for CW or FMCW sources at a receiver time.
 	bool computeStreamingPhase(const core::ActiveStreamingSource& source, const RealType rx_time, const RealType tau,
 							   core::FmcwChirpBoundaryTracker* const chirp_tracker, RealType& phase_out)
@@ -339,121 +463,18 @@ namespace
 		{
 			if (chirp_tracker == nullptr)
 			{
-				const RealType time_since_segment_start = t_ret - source.segment_start;
-				const auto chirp_index =
-					static_cast<std::size_t>(std::floor(time_since_segment_start / source.chirp_period));
-				if (source.chirp_count.has_value() && chirp_index >= *source.chirp_count)
-				{
-					return false;
-				}
-				const RealType chirp_time =
-					time_since_segment_start - static_cast<RealType>(chirp_index) * source.chirp_period;
-				if (chirp_time < 0.0 || chirp_time >= source.chirp_duration)
-				{
-					return false;
-				}
-				phase_out = -2.0 * PI * source.carrier_freq * tau + source.two_pi_f0 * chirp_time +
-					source.s_pi_alpha * chirp_time * chirp_time;
-				return true;
+				return computeLinearFmcwPhaseWithoutTracker(source, t_ret, tau, phase_out);
 			}
-
-			if (!chirp_tracker->initialized)
-			{
-				initializeFmcwTracker(source, t_ret, *chirp_tracker);
-			}
-
-			while (t_ret >= chirp_tracker->t_n + source.chirp_period)
-			{
-				chirp_tracker->t_n += source.chirp_period;
-				++chirp_tracker->n_current;
-			}
-
-			if (source.chirp_count.has_value() && chirp_tracker->n_current >= *source.chirp_count)
-			{
-				return false;
-			}
-
-			const RealType u_ret = t_ret - chirp_tracker->t_n;
-			// This lower-bound guard is required for causality: cold-path initialization pins the
-			// tracker to the segment start when the retarded time precedes the first chirp, and the
-			// advance loop can only move forward. Without the u_ret < 0 check, we'd evaluate the chirp
-			// polynomial at negative local time and extrapolate a non-causal signal before turn-on.
-			if (u_ret < 0.0 || u_ret >= source.chirp_duration)
-			{
-				return false;
-			}
-
-			phase_out =
-				-2.0 * PI * source.carrier_freq * tau + source.two_pi_f0 * u_ret + source.s_pi_alpha * u_ret * u_ret;
-			return true;
+			return computeLinearFmcwPhaseWithTracker(source, t_ret, tau, *chirp_tracker, phase_out);
 		}
 
 		if (source.kind == core::StreamingWaveformKind::FmcwTriangle)
 		{
 			if (chirp_tracker == nullptr)
 			{
-				const RealType delta = t_ret - source.segment_start;
-				const auto triangle_index = static_cast<std::size_t>(std::floor(delta / source.triangle_period));
-				if (source.triangle_count.has_value() && triangle_index >= *source.triangle_count)
-				{
-					return false;
-				}
-				const RealType local_triangle_time =
-					delta - static_cast<RealType>(triangle_index) * source.triangle_period;
-				const bool down_leg = local_triangle_time >= source.chirp_duration;
-				const RealType u_ret = down_leg ? local_triangle_time - source.chirp_duration : local_triangle_time;
-				if (u_ret < 0.0 || u_ret >= source.chirp_duration)
-				{
-					return false;
-				}
-				const RealType phi_base =
-					std::fmod(static_cast<RealType>(triangle_index) * source.mod_phi_tri, 2.0 * PI) +
-					(down_leg ? source.mod_phi_up : 0.0);
-				const RealType modular_phi_base = phi_base >= 2.0 * PI ? phi_base - 2.0 * PI : phi_base;
-				const RealType linear_coeff = down_leg ? source.two_pi_f0_plus_B : source.two_pi_f0;
-				const RealType quad_coeff = down_leg ? source.neg_pi_alpha : source.pi_alpha;
-				phase_out = -2.0 * PI * source.carrier_freq * tau + modular_phi_base + linear_coeff * u_ret +
-					quad_coeff * u_ret * u_ret;
-				return true;
+				return computeTriangleFmcwPhaseWithoutTracker(source, t_ret, tau, phase_out);
 			}
-
-			if (!chirp_tracker->triangle_initialized)
-			{
-				initializeFmcwTriangleTracker(source, t_ret, *chirp_tracker);
-			}
-
-			while (t_ret >= chirp_tracker->triangle_t_leg + source.chirp_duration)
-			{
-				chirp_tracker->triangle_t_leg += source.chirp_duration;
-				chirp_tracker->triangle_leg = 1U - chirp_tracker->triangle_leg;
-				if (chirp_tracker->triangle_leg == 0U)
-				{
-					++chirp_tracker->triangle_index;
-				}
-				chirp_tracker->triangle_phi_base += source.mod_phi_up;
-				if (chirp_tracker->triangle_phi_base >= 2.0 * PI)
-				{
-					chirp_tracker->triangle_phi_base -= 2.0 * PI;
-				}
-			}
-
-			if (source.triangle_count.has_value() && chirp_tracker->triangle_index >= *source.triangle_count)
-			{
-				return false;
-			}
-
-			const RealType u_ret = t_ret - chirp_tracker->triangle_t_leg;
-			if (u_ret < 0.0 || u_ret >= source.chirp_duration)
-			{
-				return false;
-			}
-
-			const bool down_leg = chirp_tracker->triangle_leg == 1U;
-			const RealType linear_coeff = down_leg ? source.two_pi_f0_plus_B : source.two_pi_f0;
-			const RealType quad_coeff = down_leg ? source.neg_pi_alpha : source.pi_alpha;
-			phase_out = -2.0 * PI * source.carrier_freq * tau + chirp_tracker->triangle_phi_base +
-				linear_coeff * u_ret + quad_coeff * u_ret * u_ret;
-			return true;
+			return computeTriangleFmcwPhaseWithTracker(source, t_ret, tau, *chirp_tracker, phase_out);
 		}
 
 		phase_out = -2.0 * PI * source.carrier_freq * tau;
@@ -912,205 +933,214 @@ namespace simulation
 		return response;
 	}
 
+	namespace
+	{
+		struct PreviewTransmitterContext
+		{
+			const Transmitter& transmitter;
+			Vec3 position;
+			RealType radiated_power;
+			RealType lambda;
+		};
+
+		struct PreviewReceiverContext
+		{
+			const Receiver& receiver;
+			Vec3 position;
+			bool no_loss;
+		};
+
+		PreviewTransmitterContext makePreviewTransmitterContext(const Transmitter& transmitter, const RealType time)
+		{
+			const auto* waveform = transmitter.getSignal();
+			return PreviewTransmitterContext{.transmitter = transmitter,
+											 .position = transmitter.getPosition(time),
+											 .radiated_power = previewRadiatedPower(waveform),
+											 .lambda =
+												 (waveform != nullptr) ? (params::c() / waveform->getCarrier()) : 0.3};
+		}
+
+		PreviewReceiverContext makePreviewReceiverContext(const Receiver& receiver, const RealType time)
+		{
+			return PreviewReceiverContext{.receiver = receiver,
+										  .position = receiver.getPosition(time),
+										  .no_loss = receiver.checkFlag(Receiver::RecvFlag::FLAG_NOPROPLOSS)};
+		}
+
+		void addIlluminatorLinks(std::vector<PreviewLink>& links, const PreviewTransmitterContext& tx_ctx,
+								 const core::World& world, const RealType time)
+		{
+			for (const auto& target : world.getTargets())
+			{
+				const auto target_position = target->getPosition(time);
+				const Vec3 vec_tx_tgt = target_position - tx_ctx.position;
+				const RealType range = vec_tx_tgt.length();
+				if (range <= EPSILON)
+				{
+					continue;
+				}
+
+				const Vec3 u_tx_tgt = vec_tx_tgt / range;
+				const RealType gain = computeAntennaGain(&tx_ctx.transmitter, u_tx_tgt, time, tx_ctx.lambda);
+				const RealType power_density = (tx_ctx.radiated_power * gain) / (4.0 * PI * range * range);
+				links.push_back({.type = LinkType::BistaticTxTgt,
+								 .quality = LinkQuality::Strong,
+								 .label = formatPreviewDbwPerSquareMeterLabel(power_density),
+								 .display_value = wattsToDb(power_density),
+								 .source_id = tx_ctx.transmitter.getId(),
+								 .dest_id = target->getId(),
+								 .origin_id = tx_ctx.transmitter.getId()});
+			}
+		}
+
+		void addMonostaticLinks(std::vector<PreviewLink>& links, const PreviewTransmitterContext& tx_ctx,
+								const PreviewReceiverContext& rx_ctx, const core::World& world, const RealType time)
+		{
+			for (const auto& target : world.getTargets())
+			{
+				const auto target_position = target->getPosition(time);
+				const Vec3 vec_tx_tgt = target_position - tx_ctx.position;
+				const RealType range = vec_tx_tgt.length();
+				if (range <= EPSILON)
+				{
+					continue;
+				}
+
+				const Vec3 u_tx_tgt = vec_tx_tgt / range;
+				const RealType gt = computeAntennaGain(&tx_ctx.transmitter, u_tx_tgt, time, tx_ctx.lambda);
+				const RealType gr = computeAntennaGain(&rx_ctx.receiver, u_tx_tgt, time, tx_ctx.lambda);
+				SVec3 in_angle(u_tx_tgt);
+				SVec3 out_angle(-u_tx_tgt);
+				const RealType rcs = target->getRcs(in_angle, out_angle, time);
+				const RealType power_ratio =
+					computeReflectedPathPower(gt, gr, rcs, tx_ctx.lambda, range, range, rx_ctx.no_loss);
+				const RealType pr_watts = tx_ctx.radiated_power * power_ratio;
+				const RealType pr_unit_watts = tx_ctx.radiated_power *
+					computeReflectedPathPower(gt, gr, 1.0, tx_ctx.lambda, range, range, rx_ctx.no_loss);
+
+				links.push_back({.type = LinkType::Monostatic,
+								 .quality = isSignalStrong(pr_unit_watts, rx_ctx.receiver.getNoiseTemperature())
+									 ? LinkQuality::Strong
+									 : LinkQuality::Weak,
+								 .label = formatPreviewDbmLabel(pr_unit_watts),
+								 .display_value = wattsToDbm(pr_unit_watts),
+								 .source_id = tx_ctx.transmitter.getId(),
+								 .dest_id = target->getId(),
+								 .origin_id = tx_ctx.transmitter.getId(),
+								 .rcs = rcs,
+								 .actual_power_dbm = wattsToDbm(pr_watts)});
+			}
+		}
+
+		void addDirectLink(std::vector<PreviewLink>& links, const PreviewTransmitterContext& tx_ctx,
+						   const PreviewReceiverContext& rx_ctx, const RealType time)
+		{
+			if (rx_ctx.receiver.checkFlag(Receiver::RecvFlag::FLAG_NODIRECT))
+			{
+				return;
+			}
+
+			const Vec3 vec_direct = rx_ctx.position - tx_ctx.position;
+			const RealType range = vec_direct.length();
+			if (range <= EPSILON)
+			{
+				return;
+			}
+
+			const Vec3 u_tx_rx = vec_direct / range;
+			const RealType gt = computeAntennaGain(&tx_ctx.transmitter, u_tx_rx, time, tx_ctx.lambda);
+			const RealType gr = computeAntennaGain(&rx_ctx.receiver, -u_tx_rx, time, tx_ctx.lambda);
+			const RealType power_ratio = computeDirectPathPower(gt, gr, tx_ctx.lambda, range, rx_ctx.no_loss);
+			const RealType pr_watts = tx_ctx.radiated_power * power_ratio;
+
+			links.push_back({.type = LinkType::DirectTxRx,
+							 .quality = LinkQuality::Strong,
+							 .label = formatPreviewDbmLabel(pr_watts, "Direct: "),
+							 .display_value = wattsToDbm(pr_watts),
+							 .source_id = tx_ctx.transmitter.getId(),
+							 .dest_id = rx_ctx.receiver.getId(),
+							 .origin_id = tx_ctx.transmitter.getId()});
+		}
+
+		void addBistaticTargetReceiverLinks(std::vector<PreviewLink>& links, const PreviewTransmitterContext& tx_ctx,
+											const PreviewReceiverContext& rx_ctx, const core::World& world,
+											const RealType time)
+		{
+			for (const auto& target : world.getTargets())
+			{
+				const auto target_position = target->getPosition(time);
+				const Vec3 vec_tx_tgt = target_position - tx_ctx.position;
+				const Vec3 vec_tgt_rx = rx_ctx.position - target_position;
+				const RealType r1 = vec_tx_tgt.length();
+				const RealType r2 = vec_tgt_rx.length();
+				if (r1 <= EPSILON || r2 <= EPSILON)
+				{
+					continue;
+				}
+
+				const Vec3 u_tx_tgt = vec_tx_tgt / r1;
+				const Vec3 u_tgt_rx = vec_tgt_rx / r2;
+				const RealType gt = computeAntennaGain(&tx_ctx.transmitter, u_tx_tgt, time, tx_ctx.lambda);
+				const RealType gr = computeAntennaGain(&rx_ctx.receiver, -u_tgt_rx, time, tx_ctx.lambda);
+				SVec3 in_angle(u_tx_tgt);
+				SVec3 out_angle(-u_tgt_rx);
+				const RealType rcs = target->getRcs(in_angle, out_angle, time);
+				const RealType power_ratio =
+					computeReflectedPathPower(gt, gr, rcs, tx_ctx.lambda, r1, r2, rx_ctx.no_loss);
+				const RealType pr_watts = tx_ctx.radiated_power * power_ratio;
+				const RealType pr_unit_watts = tx_ctx.radiated_power *
+					computeReflectedPathPower(gt, gr, 1.0, tx_ctx.lambda, r1, r2, rx_ctx.no_loss);
+
+				links.push_back({.type = LinkType::BistaticTgtRx,
+								 .quality = isSignalStrong(pr_unit_watts, rx_ctx.receiver.getNoiseTemperature())
+									 ? LinkQuality::Strong
+									 : LinkQuality::Weak,
+								 .label = formatPreviewDbmLabel(pr_unit_watts),
+								 .display_value = wattsToDbm(pr_unit_watts),
+								 .source_id = target->getId(),
+								 .dest_id = rx_ctx.receiver.getId(),
+								 .origin_id = tx_ctx.transmitter.getId(),
+								 .rcs = rcs,
+								 .actual_power_dbm = wattsToDbm(pr_watts)});
+			}
+		}
+
+		void addReceiverLinks(std::vector<PreviewLink>& links, const PreviewTransmitterContext& tx_ctx,
+							  const PreviewReceiverContext& rx_ctx, const core::World& world, const RealType time)
+		{
+			if (tx_ctx.transmitter.getAttached() == &rx_ctx.receiver)
+			{
+				addMonostaticLinks(links, tx_ctx, rx_ctx, world, time);
+				return;
+			}
+
+			addDirectLink(links, tx_ctx, rx_ctx, time);
+			addBistaticTargetReceiverLinks(links, tx_ctx, rx_ctx, world, time);
+		}
+	}
+
 	std::vector<PreviewLink> calculatePreviewLinks(const core::World& world, const RealType time)
 	{
 		std::vector<PreviewLink> links;
 
-		// Default wavelength (1GHz) if no waveform is attached, to allow geometric visualization
-		const RealType lambda_default = 0.3;
-
 		for (const auto& tx : world.getTransmitters())
 		{
-			// 1. Check Transmitter Schedule
 			if (!isComponentActive(tx->getSchedule(), time))
 			{
 				continue;
 			}
 
-			const auto p_tx = tx->getPosition(time);
-			const auto* waveform = tx->getSignal();
-			const RealType pt = previewRadiatedPower(waveform);
-			const RealType lambda = (waveform != nullptr) ? (params::c() / waveform->getCarrier()) : lambda_default;
-
-			// --- PRE-CALCULATE ILLUMINATOR PATHS (Tx -> Tgt) ---
-			// These depend only on the Transmitter and Targets. We calculate them once per Tx
-			// to avoid duplication when multiple receivers are present.
-			// We do NOT filter out Monostatic transmitters here. Even in a monostatic setup,
-			// the "Illuminator" link provides distinct info (Power Density at Target) compared
-			// to the "Monostatic" link (Received Power at Rx). By being outside the Rx loop,
-			// it is guaranteed to be unique per Target.
-			for (const auto& tgt : world.getTargets())
-			{
-				const auto p_tgt = tgt->getPosition(time);
-				const Vec3 vec_tx_tgt = p_tgt - p_tx;
-				const RealType r1 = vec_tx_tgt.length();
-
-				if (r1 <= EPSILON)
-					continue;
-
-				const Vec3 u_tx_tgt = vec_tx_tgt / r1;
-				// Tx Gain: Tx -> Tgt
-				const RealType gt = computeAntennaGain(tx.get(), u_tx_tgt, time, lambda);
-
-				// Power Density at Target: S = (Pt * Gt) / (4 * pi * R1^2)
-				const RealType p_density = (pt * gt) / (4.0 * PI * r1 * r1);
-
-				links.push_back({.type = LinkType::BistaticTxTgt,
-								 .quality = LinkQuality::Strong,
-								 .label = formatPreviewDbwPerSquareMeterLabel(p_density),
-								 .display_value = wattsToDb(p_density),
-								 .source_id = tx->getId(),
-								 .dest_id = tgt->getId(),
-								 .origin_id = tx->getId()});
-			}
+			const auto tx_ctx = makePreviewTransmitterContext(*tx, time);
+			addIlluminatorLinks(links, tx_ctx, world, time);
 
 			for (const auto& rx : world.getReceivers())
 			{
-				// 2. Check Receiver Schedule
 				if (!isComponentActive(rx->getSchedule(), time))
 				{
 					continue;
 				}
-
-				const auto p_rx = rx->getPosition(time);
-				const bool is_monostatic = (tx->getAttached() == rx.get());
-				const bool no_loss = rx->checkFlag(Receiver::RecvFlag::FLAG_NOPROPLOSS);
-
-				if (is_monostatic)
-				{
-					// --- Monostatic Case ---
-					// Calculates the round-trip Received Power (dBm)
-					for (const auto& tgt : world.getTargets())
-					{
-						const auto p_tgt = tgt->getPosition(time);
-
-						// Use computeLink helper logic, but catch exception manually by checking dist
-						// to avoid try/catch overhead in render loop
-						const Vec3 vec_tx_tgt = p_tgt - p_tx;
-						const RealType dist = vec_tx_tgt.length();
-
-						if (dist <= EPSILON)
-							continue;
-
-						const Vec3 u_tx_tgt = vec_tx_tgt / dist; // Unit vec Tx -> Tgt
-
-						// Reusing internal helpers
-						// Tx Gain: Direction Tx -> Tgt
-						const RealType gt = computeAntennaGain(tx.get(), u_tx_tgt, time, lambda);
-						// Rx Gain: Direction Rx -> Tgt (which is -u_tx_tgt because Rx is at Tx)
-						const RealType gr = computeAntennaGain(rx.get(), u_tx_tgt, time, lambda);
-
-						// RCS: In = Tx->Tgt, Out = Tgt->Rx (which is -(Tx->Tgt))
-						SVec3 in_angle(u_tx_tgt);
-						SVec3 out_angle(-u_tx_tgt);
-						const RealType rcs = tgt->getRcs(in_angle, out_angle, time);
-
-						// Reusing Reflected Path Helper
-						// r_tx = dist, r_rx = dist
-						const RealType power_ratio =
-							computeReflectedPathPower(gt, gr, rcs, lambda, dist, dist, no_loss);
-
-						const RealType pr_watts = pt * power_ratio;
-
-						// Label shows power with unit RCS (sigma=1) so it varies only with geometry,
-						// not with the fluctuation model. Actual RCS is carried separately for the tooltip.
-						const RealType pr_unit_watts =
-							pt * computeReflectedPathPower(gt, gr, 1.0, lambda, dist, dist, no_loss);
-
-						links.push_back({.type = LinkType::Monostatic,
-										 .quality = isSignalStrong(pr_unit_watts, rx->getNoiseTemperature())
-											 ? LinkQuality::Strong
-											 : LinkQuality::Weak,
-										 .label = formatPreviewDbmLabel(pr_unit_watts),
-										 .display_value = wattsToDbm(pr_unit_watts),
-										 .source_id = tx->getId(),
-										 .dest_id = tgt->getId(),
-										 .origin_id = tx->getId(),
-										 .rcs = rcs,
-										 .actual_power_dbm = wattsToDbm(pr_watts)});
-					}
-				}
-				else
-				{
-					// --- Bistatic Case ---
-
-					// 1. Direct Path (Interference)
-					if (!rx->checkFlag(Receiver::RecvFlag::FLAG_NODIRECT))
-					{
-						const Vec3 vec_direct = p_rx - p_tx;
-						const RealType dist = vec_direct.length();
-
-						if (dist > EPSILON)
-						{
-							const Vec3 u_tx_rx = vec_direct / dist;
-
-							// Tx Gain: Tx -> Rx
-							const RealType gt = computeAntennaGain(tx.get(), u_tx_rx, time, lambda);
-							// Rx Gain: Rx -> Tx (which is -u_tx_rx)
-							const RealType gr = computeAntennaGain(rx.get(), -u_tx_rx, time, lambda);
-
-							const RealType power_ratio = computeDirectPathPower(gt, gr, lambda, dist, no_loss);
-							const RealType pr_watts = pt * power_ratio;
-
-							links.push_back({.type = LinkType::DirectTxRx,
-											 .quality = LinkQuality::Strong,
-											 .label = formatPreviewDbmLabel(pr_watts, "Direct: "),
-											 .display_value = wattsToDbm(pr_watts),
-											 .source_id = tx->getId(),
-											 .dest_id = rx->getId(),
-											 .origin_id = tx->getId()});
-						}
-					}
-
-					// 2. Reflected Path (Scattered Leg: Tgt -> Rx)
-					for (const auto& tgt : world.getTargets())
-					{
-						const auto p_tgt = tgt->getPosition(time);
-						const Vec3 vec_tx_tgt = p_tgt - p_tx;
-						const Vec3 vec_tgt_rx = p_rx - p_tgt; // Vector Tgt -> Rx
-
-						const RealType r1 = vec_tx_tgt.length();
-						const RealType r2 = vec_tgt_rx.length();
-
-						if (r1 <= EPSILON || r2 <= EPSILON)
-							continue;
-
-						const Vec3 u_tx_tgt = vec_tx_tgt / r1;
-						const Vec3 u_tgt_rx = vec_tgt_rx / r2;
-
-						// Tx Gain: Tx -> Tgt
-						const RealType gt = computeAntennaGain(tx.get(), u_tx_tgt, time, lambda);
-						// Rx Gain: Rx -> Tgt (Vector is Tgt->Rx, so look vector is -u_tgt_rx)
-						const RealType gr = computeAntennaGain(rx.get(), -u_tgt_rx, time, lambda);
-
-						// RCS
-						SVec3 in_angle(u_tx_tgt);
-						SVec3 out_angle(-u_tgt_rx); // Out angle is usually defined from Target OUTWARDS
-						const RealType rcs = tgt->getRcs(in_angle, out_angle, time);
-
-						const RealType power_ratio = computeReflectedPathPower(gt, gr, rcs, lambda, r1, r2, no_loss);
-						const RealType pr_watts = pt * power_ratio;
-
-						// Label shows power with unit RCS (sigma=1) so it varies only with geometry.
-						const RealType pr_unit_watts =
-							pt * computeReflectedPathPower(gt, gr, 1.0, lambda, r1, r2, no_loss);
-
-						// Note: Illuminator leg (Tx->Tgt) was handled in the outer loop.
-
-						// Leg 2: Scattered
-						links.push_back({.type = LinkType::BistaticTgtRx,
-										 .quality = isSignalStrong(pr_unit_watts, rx->getNoiseTemperature())
-											 ? LinkQuality::Strong
-											 : LinkQuality::Weak,
-										 .label = formatPreviewDbmLabel(pr_unit_watts),
-										 .display_value = wattsToDbm(pr_unit_watts),
-										 .source_id = tgt->getId(),
-										 .dest_id = rx->getId(),
-										 .origin_id = tx->getId(),
-										 .rcs = rcs,
-										 .actual_power_dbm = wattsToDbm(pr_watts)});
-					}
-				}
+				const auto rx_ctx = makePreviewReceiverContext(*rx, time);
+				addReceiverLinks(links, tx_ctx, rx_ctx, world, time);
 			}
 		}
 		return links;

--- a/packages/libfers/src/simulation/channel_model.cpp
+++ b/packages/libfers/src/simulation/channel_model.cpp
@@ -896,10 +896,10 @@ namespace simulation
 					solveReDirect(trans, recv, current_time, signal, results);
 				}
 
-				interp::InterpPoint point{.power = results.power,
-										  .time = current_time.count() + results.delay,
-										  .delay = results.delay,
-										  .phase = results.phase};
+				interp::InterpPoint const point{.power = results.power,
+												.time = current_time.count() + results.delay,
+												.delay = results.delay,
+												.phase = results.phase};
 				response->addInterpPoint(point);
 			}
 		}

--- a/packages/libfers/src/simulation/channel_model.h
+++ b/packages/libfers/src/simulation/channel_model.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
 #include <exception>
 #include <memory>
 #include <span>
@@ -91,7 +92,7 @@ namespace simulation
 	};
 
 	/// Selects how timing phase noise is applied to streaming channel contributions.
-	enum class StreamingTimingPhaseMode
+	enum class StreamingTimingPhaseMode : std::uint8_t
 	{
 		ReceiverRelative, ///< Existing raw streaming convention: transmitter phase minus receiver LO phase.
 		TransmitterOnly, ///< Incoming RF/baseband signal before receiver LO subtraction.
@@ -259,7 +260,7 @@ namespace simulation
 	 * @enum LinkType
 	 * @brief Categorizes the visual link for rendering.
 	 */
-	enum class LinkType
+	enum class LinkType : std::uint8_t
 	{
 		Monostatic, ///< Combined Tx/Rx path
 		BistaticTxTgt, ///< Illuminator path
@@ -271,7 +272,7 @@ namespace simulation
 	 * @enum LinkQuality
 	 * @brief Describes the radiometric quality of the link.
 	 */
-	enum class LinkQuality
+	enum class LinkQuality : std::uint8_t
 	{
 		Strong, ///< SNR > 0 dB
 		Weak ///< SNR < 0 dB (Geometric line of sight, but below noise floor)

--- a/packages/libfers/tests/antenna/test_antenna_factory.cpp
+++ b/packages/libfers/tests/antenna/test_antenna_factory.cpp
@@ -28,13 +28,13 @@ TEST_CASE("Isotropic antenna gain equals efficiency factor", "[antenna]")
 
 TEST_CASE("Antenna ids default to antenna type", "[antenna]")
 {
-	antenna::Isotropic antenna("iso-default");
+	antenna::Isotropic const antenna("iso-default");
 	REQUIRE(SimIdGenerator::getType(antenna.getId()) == ObjectType::Antenna);
 }
 
 TEST_CASE("Antenna base noise temperature defaults to zero", "[antenna]")
 {
-	antenna::Isotropic antenna("iso");
+	antenna::Isotropic const antenna("iso");
 	REQUIRE_THAT(antenna.getNoiseTemperature(unitDirection(0.3, -0.2)), WithinAbs(0.0, 0.0));
 }
 
@@ -63,7 +63,7 @@ TEST_CASE("Gaussian antenna gain follows expected Gaussian surface", "[antenna]"
 {
 	const RealType azscale = 0.5;
 	const RealType elscale = 1.5;
-	antenna::Gaussian antenna("gauss", azscale, elscale);
+	antenna::Gaussian const antenna("gauss", azscale, elscale);
 
 	const auto ref = unitDirection(0.0, 0.0);
 	const auto angle = unitDirection(0.2, 0.1);
@@ -89,7 +89,7 @@ TEST_CASE("Sinc antenna gain is symmetric about boresight", "[antenna]")
 
 TEST_CASE("Gaussian antenna gain is symmetric about boresight", "[antenna]")
 {
-	antenna::Gaussian antenna("gauss", 0.75, 1.25);
+	antenna::Gaussian const antenna("gauss", 0.75, 1.25);
 
 	const auto ref = unitDirection(0.0, 0.0);
 	const auto positive = unitDirection(0.2, -0.15);

--- a/packages/libfers/tests/antenna/test_antenna_factory_io.cpp
+++ b/packages/libfers/tests/antenna/test_antenna_factory_io.cpp
@@ -169,8 +169,8 @@ TEST_CASE("XmlAntenna interpolates normalized axis gains", "[antenna][io]")
 	const auto elevation_value = antenna.getElevationSamples()->getValueAt(0.25);
 	REQUIRE(azimuth_value.has_value());
 	REQUIRE(elevation_value.has_value());
-	REQUIRE_THAT(*azimuth_value, WithinAbs(0.75, 1e-12));
-	REQUIRE_THAT(*elevation_value, WithinAbs(0.75, 1e-12));
+	REQUIRE_THAT(azimuth_value.value_or(0.0), WithinAbs(0.75, 1e-12));
+	REQUIRE_THAT(elevation_value.value_or(0.0), WithinAbs(0.75, 1e-12));
 
 	const RealType expected = 0.75 * 0.75 * 8.0 * 0.5;
 	REQUIRE_THAT(antenna.getGain(unitDirection(-0.5, 0.25), unitDirection(0.0, 0.0), 1.0), WithinAbs(expected, 1e-12));

--- a/packages/libfers/tests/antenna/test_antenna_factory_io.cpp
+++ b/packages/libfers/tests/antenna/test_antenna_factory_io.cpp
@@ -212,7 +212,7 @@ TEST_CASE("XmlAntenna supports explicit no-symmetry asymmetric lookup", "[antenn
 	removeIfExists(path);
 	writeXmlAntennaFile(path, xmlAsymmetricPatternFixture(true));
 
-	antenna::XmlAntenna antenna("xml", path.string(), 15);
+	antenna::XmlAntenna const antenna("xml", path.string(), 15);
 
 	const RealType negative_gain = antenna.getGain(unitDirection(-PI / 2.0, 0.0), unitDirection(0.0, 0.0), 1.0);
 	const RealType positive_gain = antenna.getGain(unitDirection(PI / 2.0, 0.0), unitDirection(0.0, 0.0), 1.0);
@@ -228,7 +228,7 @@ TEST_CASE("XmlAntenna auto-detects direct signed-angle lookup from negative samp
 	removeIfExists(path);
 	writeXmlAntennaFile(path, xmlAsymmetricPatternFixture(false));
 
-	antenna::XmlAntenna antenna("xml", path.string(), 16);
+	antenna::XmlAntenna const antenna("xml", path.string(), 16);
 
 	const RealType negative_gain = antenna.getGain(unitDirection(-PI / 2.0, 0.0), unitDirection(0.0, 0.0), 1.0);
 	const RealType positive_gain = antenna.getGain(unitDirection(PI / 2.0, 0.0), unitDirection(0.0, 0.0), 1.0);
@@ -367,7 +367,7 @@ TEST_CASE("H5Antenna preserves explicit antenna id", "[antenna][io]")
 	writeHdf5PatternFile(path, {{2.0, 4.0}, {6.0, 8.0}});
 
 	constexpr SimId explicitId = (static_cast<SimId>(0xABCD) << 32) | 0x1234;
-	antenna::H5Antenna antenna("h5", path.string(), explicitId);
+	antenna::H5Antenna const antenna("h5", path.string(), explicitId);
 
 	REQUIRE(antenna.getId() == explicitId);
 

--- a/packages/libfers/tests/api/test_api_contract.cpp
+++ b/packages/libfers/tests/api/test_api_contract.cpp
@@ -13,16 +13,16 @@ TEST_CASE("API destroying a null context is a safe no-op", "[api][core]")
 
 	fers_context_destroy(nullptr);
 
-	api_test::ApiString error = api_test::lastError();
+	api_test::ApiString const error = api_test::lastError();
 	REQUIRE(error.get() == nullptr);
 }
 
 TEST_CASE("API context creation returns a valid handle", "[api][core]")
 {
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
-	api_test::ApiString error = api_test::lastError();
+	api_test::ApiString const error = api_test::lastError();
 	REQUIRE(error.get() == nullptr);
 }
 
@@ -38,7 +38,7 @@ TEST_CASE("API last error is null when no failure has occurred", "[api][core]")
 {
 	api_test::clearLastError();
 
-	api_test::ApiString error = api_test::lastError();
+	api_test::ApiString const error = api_test::lastError();
 	REQUIRE(error.get() == nullptr);
 }
 
@@ -52,13 +52,13 @@ TEST_CASE("API free helpers accept null pointers", "[api][core]")
 	fers_free_antenna_pattern_data(nullptr);
 	fers_free_preview_links(nullptr);
 
-	api_test::ApiString error = api_test::lastError();
+	api_test::ApiString const error = api_test::lastError();
 	REQUIRE(error.get() == nullptr);
 }
 
 TEST_CASE("API set thread count clears stale error state on success", "[api][core]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
 
 	REQUIRE(fers_set_thread_count(0) != 0);
@@ -72,7 +72,7 @@ TEST_CASE("API set thread count clears stale error state on success", "[api][cor
 
 TEST_CASE("API successful calls clear stale thread-local errors beyond thread-count changes", "[api][core]")
 {
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	REQUIRE(fers_get_scenario_as_json(nullptr) == nullptr);

--- a/packages/libfers/tests/api/test_api_paths.cpp
+++ b/packages/libfers/tests/api/test_api_paths.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
@@ -71,11 +72,12 @@ TEST_CASE("API motion path interpolation falls back to repeated positions for no
 		  "[api][paths]")
 {
 	api_test::clearLastError();
-	const fers_motion_waypoint_t waypoints[] = {
-		{1.0, 2.0, 3.0, 4.0},
-		{1.0, 2.0, 3.0, 4.0},
+	const std::array<fers_motion_waypoint_t, 2> waypoints = {
+		fers_motion_waypoint_t{1.0, 2.0, 3.0, 4.0},
+		fers_motion_waypoint_t{1.0, 2.0, 3.0, 4.0},
 	};
-	api_test::MotionPath const path(fers_get_interpolated_motion_path(waypoints, 2, FERS_INTERP_LINEAR, 3));
+	api_test::MotionPath const path(
+		fers_get_interpolated_motion_path(waypoints.data(), waypoints.size(), FERS_INTERP_LINEAR, 3));
 
 	REQUIRE(path.get() != nullptr);
 	REQUIRE(path.get()->count == 3u);
@@ -95,11 +97,12 @@ TEST_CASE("API motion path interpolation falls back to repeated positions for no
 TEST_CASE("API motion path interpolation returns expected linear positions and velocities", "[api][paths]")
 {
 	api_test::clearLastError();
-	const fers_motion_waypoint_t waypoints[] = {
-		{0.0, 0.0, 0.0, 0.0},
-		{10.0, 10.0, 20.0, 30.0},
+	const std::array<fers_motion_waypoint_t, 2> waypoints = {
+		fers_motion_waypoint_t{0.0, 0.0, 0.0, 0.0},
+		fers_motion_waypoint_t{10.0, 10.0, 20.0, 30.0},
 	};
-	api_test::MotionPath const path(fers_get_interpolated_motion_path(waypoints, 2, FERS_INTERP_LINEAR, 3));
+	api_test::MotionPath const path(
+		fers_get_interpolated_motion_path(waypoints.data(), waypoints.size(), FERS_INTERP_LINEAR, 3));
 
 	REQUIRE(path.get() != nullptr);
 	REQUIRE(path.get()->count == 3u);
@@ -129,12 +132,13 @@ TEST_CASE("API motion path interpolation returns expected linear positions and v
 TEST_CASE("API motion path interpolation maps cubic enum to cubic behavior", "[api][paths]")
 {
 	api_test::clearLastError();
-	const fers_motion_waypoint_t waypoints[] = {
-		{0.0, 0.0, 0.0, 0.0},
-		{1.0, 1.0, 0.0, 0.0},
-		{2.0, 2.0, 0.0, 0.0},
+	const std::array<fers_motion_waypoint_t, 3> waypoints = {
+		fers_motion_waypoint_t{0.0, 0.0, 0.0, 0.0},
+		fers_motion_waypoint_t{1.0, 1.0, 0.0, 0.0},
+		fers_motion_waypoint_t{2.0, 2.0, 0.0, 0.0},
 	};
-	api_test::MotionPath const path(fers_get_interpolated_motion_path(waypoints, 3, FERS_INTERP_CUBIC, 3));
+	api_test::MotionPath const path(
+		fers_get_interpolated_motion_path(waypoints.data(), waypoints.size(), FERS_INTERP_CUBIC, 3));
 
 	REQUIRE(path.get() != nullptr);
 	REQUIRE(path.get()->count == 3u);
@@ -204,12 +208,12 @@ TEST_CASE("API rotation path interpolation returns constant compass angles for s
 TEST_CASE("API rotation path interpolation preserves compass-angle semantics", "[api][paths]")
 {
 	api_test::clearLastError();
-	const fers_rotation_waypoint_t waypoints[] = {
-		{0.0, 0.0, -10.0},
-		{10.0, 180.0, 20.0},
+	const std::array<fers_rotation_waypoint_t, 2> waypoints = {
+		fers_rotation_waypoint_t{0.0, 0.0, -10.0},
+		fers_rotation_waypoint_t{10.0, 180.0, 20.0},
 	};
-	api_test::RotationPath const path(
-		fers_get_interpolated_rotation_path(waypoints, 2, FERS_INTERP_LINEAR, FERS_ANGLE_UNIT_DEG, 3));
+	api_test::RotationPath const path(fers_get_interpolated_rotation_path(waypoints.data(), waypoints.size(),
+																		  FERS_INTERP_LINEAR, FERS_ANGLE_UNIT_DEG, 3));
 
 	REQUIRE(path.get() != nullptr);
 	REQUIRE(path.get()->count == 3u);
@@ -225,13 +229,13 @@ TEST_CASE("API rotation path interpolation preserves compass-angle semantics", "
 TEST_CASE("API rotation path interpolation maps cubic enum to cubic behavior", "[api][paths]")
 {
 	api_test::clearLastError();
-	const fers_rotation_waypoint_t waypoints[] = {
-		{0.0, 90.0, 0.0},
-		{1.0, 32.7042204869, 57.2957795131},
-		{2.0, -24.5915590262, 114.5915590262},
+	const std::array<fers_rotation_waypoint_t, 3> waypoints = {
+		fers_rotation_waypoint_t{0.0, 90.0, 0.0},
+		fers_rotation_waypoint_t{1.0, 32.7042204869, 57.2957795131},
+		fers_rotation_waypoint_t{2.0, -24.5915590262, 114.5915590262},
 	};
-	api_test::RotationPath const path(
-		fers_get_interpolated_rotation_path(waypoints, 3, FERS_INTERP_CUBIC, FERS_ANGLE_UNIT_DEG, 3));
+	api_test::RotationPath const path(fers_get_interpolated_rotation_path(waypoints.data(), waypoints.size(),
+																		  FERS_INTERP_CUBIC, FERS_ANGLE_UNIT_DEG, 3));
 
 	REQUIRE(path.get() != nullptr);
 	REQUIRE(path.get()->count == 3u);
@@ -242,12 +246,12 @@ TEST_CASE("API rotation path interpolation maps cubic enum to cubic behavior", "
 TEST_CASE("API rotation path interpolation preserves unnormalized winding angles", "[api][paths]")
 {
 	api_test::clearLastError();
-	const fers_rotation_waypoint_t waypoints[] = {
-		{0.0, -30.0, 0.0},
-		{10.0, 390.0, 0.0},
+	const std::array<fers_rotation_waypoint_t, 2> waypoints = {
+		fers_rotation_waypoint_t{0.0, -30.0, 0.0},
+		fers_rotation_waypoint_t{10.0, 390.0, 0.0},
 	};
-	api_test::RotationPath const path(
-		fers_get_interpolated_rotation_path(waypoints, 2, FERS_INTERP_LINEAR, FERS_ANGLE_UNIT_DEG, 3));
+	api_test::RotationPath const path(fers_get_interpolated_rotation_path(waypoints.data(), waypoints.size(),
+																		  FERS_INTERP_LINEAR, FERS_ANGLE_UNIT_DEG, 3));
 
 	REQUIRE(path.get() != nullptr);
 	REQUIRE(path.get()->count == 3u);
@@ -260,12 +264,12 @@ TEST_CASE("API rotation path interpolation preserves unnormalized winding angles
 TEST_CASE("API rotation path interpolation supports radians", "[api][paths]")
 {
 	api_test::clearLastError();
-	const fers_rotation_waypoint_t waypoints[] = {
-		{0.0, 0.0, 0.0},
-		{1.0, PI / 2.0, PI / 4.0},
+	const std::array<fers_rotation_waypoint_t, 2> waypoints = {
+		fers_rotation_waypoint_t{0.0, 0.0, 0.0},
+		fers_rotation_waypoint_t{1.0, PI / 2.0, PI / 4.0},
 	};
-	api_test::RotationPath const path(
-		fers_get_interpolated_rotation_path(waypoints, 2, FERS_INTERP_LINEAR, FERS_ANGLE_UNIT_RAD, 3));
+	api_test::RotationPath const path(fers_get_interpolated_rotation_path(waypoints.data(), waypoints.size(),
+																		  FERS_INTERP_LINEAR, FERS_ANGLE_UNIT_RAD, 3));
 
 	REQUIRE(path.get() != nullptr);
 	REQUIRE(path.get()->count == 3u);

--- a/packages/libfers/tests/api/test_api_paths.cpp
+++ b/packages/libfers/tests/api/test_api_paths.cpp
@@ -9,6 +9,24 @@
 using Catch::Matchers::ContainsSubstring;
 using Catch::Matchers::WithinAbs;
 
+namespace
+{
+	void requireMotionPosition(const fers_interpolated_point_t& point, const double x, const double y, const double z)
+	{
+		REQUIRE_THAT(point.x, WithinAbs(x, 1e-12));
+		REQUIRE_THAT(point.y, WithinAbs(y, 1e-12));
+		REQUIRE_THAT(point.z, WithinAbs(z, 1e-12));
+	}
+
+	void requireMotionVelocity(const fers_interpolated_point_t& point, const double vx, const double vy,
+							   const double vz)
+	{
+		REQUIRE_THAT(point.vx, WithinAbs(vx, 1e-12));
+		REQUIRE_THAT(point.vy, WithinAbs(vy, 1e-12));
+		REQUIRE_THAT(point.vz, WithinAbs(vz, 1e-12));
+	}
+}
+
 TEST_CASE("API motion path interpolation validates arguments", "[api][paths]")
 {
 	api_test::clearLastError();
@@ -111,21 +129,13 @@ TEST_CASE("API motion path interpolation returns expected linear positions and v
 	const auto& middle = path.get()->points[1];
 	const auto& finish = path.get()->points[2];
 
-	REQUIRE_THAT(start.x, WithinAbs(0.0, 1e-12));
-	REQUIRE_THAT(start.y, WithinAbs(0.0, 1e-12));
-	REQUIRE_THAT(start.z, WithinAbs(0.0, 1e-12));
-	REQUIRE_THAT(middle.x, WithinAbs(5.0, 1e-12));
-	REQUIRE_THAT(middle.y, WithinAbs(10.0, 1e-12));
-	REQUIRE_THAT(middle.z, WithinAbs(15.0, 1e-12));
-	REQUIRE_THAT(finish.x, WithinAbs(10.0, 1e-12));
-	REQUIRE_THAT(finish.y, WithinAbs(20.0, 1e-12));
-	REQUIRE_THAT(finish.z, WithinAbs(30.0, 1e-12));
+	requireMotionPosition(start, 0.0, 0.0, 0.0);
+	requireMotionPosition(middle, 5.0, 10.0, 15.0);
+	requireMotionPosition(finish, 10.0, 20.0, 30.0);
 
 	for (const auto* point : {&start, &middle, &finish})
 	{
-		REQUIRE_THAT(point->vx, WithinAbs(1.0, 1e-12));
-		REQUIRE_THAT(point->vy, WithinAbs(2.0, 1e-12));
-		REQUIRE_THAT(point->vz, WithinAbs(3.0, 1e-12));
+		requireMotionVelocity(*point, 1.0, 2.0, 3.0);
 	}
 }
 

--- a/packages/libfers/tests/api/test_api_paths.cpp
+++ b/packages/libfers/tests/api/test_api_paths.cpp
@@ -15,33 +15,33 @@ TEST_CASE("API motion path interpolation validates arguments", "[api][paths]")
 
 	SECTION("null waypoints")
 	{
-		api_test::MotionPath path(fers_get_interpolated_motion_path(nullptr, 1, FERS_INTERP_LINEAR, 2));
+		api_test::MotionPath const path(fers_get_interpolated_motion_path(nullptr, 1, FERS_INTERP_LINEAR, 2));
 		REQUIRE(path.get() == nullptr);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("waypoints cannot be null"));
 	}
 
 	SECTION("zero waypoint count")
 	{
-		api_test::MotionPath path(fers_get_interpolated_motion_path(&point, 0, FERS_INTERP_LINEAR, 2));
+		api_test::MotionPath const path(fers_get_interpolated_motion_path(&point, 0, FERS_INTERP_LINEAR, 2));
 		REQUIRE(path.get() == nullptr);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("counts must be > 0"));
 	}
 
 	SECTION("zero output count")
 	{
-		api_test::MotionPath path(fers_get_interpolated_motion_path(&point, 1, FERS_INTERP_LINEAR, 0));
+		api_test::MotionPath const path(fers_get_interpolated_motion_path(&point, 1, FERS_INTERP_LINEAR, 0));
 		REQUIRE(path.get() == nullptr);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("counts must be > 0"));
 	}
 
 	SECTION("cubic needs more waypoints")
 	{
-		api_test::MotionPath path(fers_get_interpolated_motion_path(&point, 1, FERS_INTERP_CUBIC, 2));
+		api_test::MotionPath const path(fers_get_interpolated_motion_path(&point, 1, FERS_INTERP_CUBIC, 2));
 		REQUIRE(path.get() == nullptr);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("Cubic interpolation requires at least 2 waypoints"));
 	}
 }
@@ -50,7 +50,7 @@ TEST_CASE("API motion path interpolation returns constant positions for static i
 {
 	api_test::clearLastError();
 	const fers_motion_waypoint_t waypoint{5.0, 1.5, -2.0, 8.25};
-	api_test::MotionPath path(fers_get_interpolated_motion_path(&waypoint, 1, FERS_INTERP_STATIC, 4));
+	api_test::MotionPath const path(fers_get_interpolated_motion_path(&waypoint, 1, FERS_INTERP_STATIC, 4));
 
 	REQUIRE(path.get() != nullptr);
 	REQUIRE(path.get()->count == 4u);
@@ -75,7 +75,7 @@ TEST_CASE("API motion path interpolation falls back to repeated positions for no
 		{1.0, 2.0, 3.0, 4.0},
 		{1.0, 2.0, 3.0, 4.0},
 	};
-	api_test::MotionPath path(fers_get_interpolated_motion_path(waypoints, 2, FERS_INTERP_LINEAR, 3));
+	api_test::MotionPath const path(fers_get_interpolated_motion_path(waypoints, 2, FERS_INTERP_LINEAR, 3));
 
 	REQUIRE(path.get() != nullptr);
 	REQUIRE(path.get()->count == 3u);
@@ -99,7 +99,7 @@ TEST_CASE("API motion path interpolation returns expected linear positions and v
 		{0.0, 0.0, 0.0, 0.0},
 		{10.0, 10.0, 20.0, 30.0},
 	};
-	api_test::MotionPath path(fers_get_interpolated_motion_path(waypoints, 2, FERS_INTERP_LINEAR, 3));
+	api_test::MotionPath const path(fers_get_interpolated_motion_path(waypoints, 2, FERS_INTERP_LINEAR, 3));
 
 	REQUIRE(path.get() != nullptr);
 	REQUIRE(path.get()->count == 3u);
@@ -134,7 +134,7 @@ TEST_CASE("API motion path interpolation maps cubic enum to cubic behavior", "[a
 		{1.0, 1.0, 0.0, 0.0},
 		{2.0, 2.0, 0.0, 0.0},
 	};
-	api_test::MotionPath path(fers_get_interpolated_motion_path(waypoints, 3, FERS_INTERP_CUBIC, 3));
+	api_test::MotionPath const path(fers_get_interpolated_motion_path(waypoints, 3, FERS_INTERP_CUBIC, 3));
 
 	REQUIRE(path.get() != nullptr);
 	REQUIRE(path.get()->count == 3u);
@@ -149,37 +149,37 @@ TEST_CASE("API rotation path interpolation validates arguments", "[api][paths]")
 
 	SECTION("null waypoints")
 	{
-		api_test::RotationPath path(
+		api_test::RotationPath const path(
 			fers_get_interpolated_rotation_path(nullptr, 1, FERS_INTERP_LINEAR, FERS_ANGLE_UNIT_DEG, 2));
 		REQUIRE(path.get() == nullptr);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("waypoints cannot be null"));
 	}
 
 	SECTION("zero waypoint count")
 	{
-		api_test::RotationPath path(
+		api_test::RotationPath const path(
 			fers_get_interpolated_rotation_path(&point, 0, FERS_INTERP_LINEAR, FERS_ANGLE_UNIT_DEG, 2));
 		REQUIRE(path.get() == nullptr);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("counts must be > 0"));
 	}
 
 	SECTION("zero output count")
 	{
-		api_test::RotationPath path(
+		api_test::RotationPath const path(
 			fers_get_interpolated_rotation_path(&point, 1, FERS_INTERP_LINEAR, FERS_ANGLE_UNIT_DEG, 0));
 		REQUIRE(path.get() == nullptr);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("counts must be > 0"));
 	}
 
 	SECTION("cubic needs more waypoints")
 	{
-		api_test::RotationPath path(
+		api_test::RotationPath const path(
 			fers_get_interpolated_rotation_path(&point, 1, FERS_INTERP_CUBIC, FERS_ANGLE_UNIT_DEG, 2));
 		REQUIRE(path.get() == nullptr);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("Cubic interpolation requires at least 2 waypoints"));
 	}
 }
@@ -188,7 +188,7 @@ TEST_CASE("API rotation path interpolation returns constant compass angles for s
 {
 	api_test::clearLastError();
 	const fers_rotation_waypoint_t waypoint{0.0, 15.0, -10.0};
-	api_test::RotationPath path(
+	api_test::RotationPath const path(
 		fers_get_interpolated_rotation_path(&waypoint, 1, FERS_INTERP_STATIC, FERS_ANGLE_UNIT_DEG, 4));
 
 	REQUIRE(path.get() != nullptr);
@@ -208,7 +208,7 @@ TEST_CASE("API rotation path interpolation preserves compass-angle semantics", "
 		{0.0, 0.0, -10.0},
 		{10.0, 180.0, 20.0},
 	};
-	api_test::RotationPath path(
+	api_test::RotationPath const path(
 		fers_get_interpolated_rotation_path(waypoints, 2, FERS_INTERP_LINEAR, FERS_ANGLE_UNIT_DEG, 3));
 
 	REQUIRE(path.get() != nullptr);
@@ -230,7 +230,7 @@ TEST_CASE("API rotation path interpolation maps cubic enum to cubic behavior", "
 		{1.0, 32.7042204869, 57.2957795131},
 		{2.0, -24.5915590262, 114.5915590262},
 	};
-	api_test::RotationPath path(
+	api_test::RotationPath const path(
 		fers_get_interpolated_rotation_path(waypoints, 3, FERS_INTERP_CUBIC, FERS_ANGLE_UNIT_DEG, 3));
 
 	REQUIRE(path.get() != nullptr);
@@ -246,7 +246,7 @@ TEST_CASE("API rotation path interpolation preserves unnormalized winding angles
 		{0.0, -30.0, 0.0},
 		{10.0, 390.0, 0.0},
 	};
-	api_test::RotationPath path(
+	api_test::RotationPath const path(
 		fers_get_interpolated_rotation_path(waypoints, 2, FERS_INTERP_LINEAR, FERS_ANGLE_UNIT_DEG, 3));
 
 	REQUIRE(path.get() != nullptr);
@@ -264,7 +264,7 @@ TEST_CASE("API rotation path interpolation supports radians", "[api][paths]")
 		{0.0, 0.0, 0.0},
 		{1.0, PI / 2.0, PI / 4.0},
 	};
-	api_test::RotationPath path(
+	api_test::RotationPath const path(
 		fers_get_interpolated_rotation_path(waypoints, 2, FERS_INTERP_LINEAR, FERS_ANGLE_UNIT_RAD, 3));
 
 	REQUIRE(path.get() != nullptr);

--- a/packages/libfers/tests/api/test_api_preview.cpp
+++ b/packages/libfers/tests/api/test_api_preview.cpp
@@ -1,14 +1,26 @@
+#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <cmath>
-#include <cstring>
+#include <iterator>
 #include <libfers/api.h>
+#include <string>
 
 #include "api_test_helpers.h"
 
 using Catch::Matchers::ContainsSubstring;
 using Catch::Matchers::WithinAbs;
+
+namespace
+{
+	template <std::size_t N>
+	[[nodiscard]] std::string linkLabelString(const char (&label)[N])
+	{
+		const auto label_end = std::find(std::begin(label), std::end(label), '\0');
+		return std::string(std::begin(label), label_end);
+	}
+}
 
 TEST_CASE("API antenna pattern validates context and antenna existence", "[api][preview]")
 {
@@ -190,8 +202,9 @@ TEST_CASE("API preview links map link metadata into C structs", "[api][preview]"
 	for (size_t i = 0; i < links.get()->count; ++i)
 	{
 		const auto& link = links.get()->links[i];
+		const std::string label = linkLabelString(link.label);
 		REQUIRE(link.label[sizeof(link.label) - 1] == '\0');
-		REQUIRE(std::strlen(link.label) > 0);
+		REQUIRE_FALSE(label.empty());
 		REQUIRE(std::isfinite(link.display_value));
 
 		switch (link.type)
@@ -202,7 +215,7 @@ TEST_CASE("API preview links map link metadata into C structs", "[api][preview]"
 			REQUIRE(link.dest_id == target_id);
 			REQUIRE(link.origin_id == tx_id);
 			REQUIRE(link.quality == FERS_LINK_STRONG);
-			REQUIRE_THAT(link.display_value, WithinAbs(std::stod(link.label), 0.1));
+			REQUIRE_THAT(link.display_value, WithinAbs(std::stod(label), 0.1));
 			break;
 		case FERS_LINK_DIRECT_TX_RX:
 			saw_direct = true;
@@ -217,7 +230,7 @@ TEST_CASE("API preview links map link metadata into C structs", "[api][preview]"
 			REQUIRE(link.dest_id == rx_id);
 			REQUIRE(link.origin_id == tx_id);
 			REQUIRE(link.quality == FERS_LINK_STRONG);
-			REQUIRE_THAT(link.display_value, WithinAbs(std::stod(link.label), 0.1));
+			REQUIRE_THAT(link.display_value, WithinAbs(std::stod(label), 0.1));
 			break;
 		default:
 			break;

--- a/packages/libfers/tests/api/test_api_preview.cpp
+++ b/packages/libfers/tests/api/test_api_preview.cpp
@@ -3,8 +3,10 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <cmath>
+#include <cstdint>
 #include <iterator>
 #include <libfers/api.h>
+#include <nlohmann/json.hpp>
 #include <string>
 
 #include "api_test_helpers.h"
@@ -14,11 +16,165 @@ using Catch::Matchers::WithinAbs;
 
 namespace
 {
+	struct PreviewIds
+	{
+		std::uint64_t tx = 0;
+		std::uint64_t rx = 0;
+		std::uint64_t target = 0;
+	};
+
 	template <std::size_t N>
 	[[nodiscard]] std::string linkLabelString(const char (&label)[N])
 	{
 		const auto label_end = std::find(std::begin(label), std::end(label), '\0');
 		return std::string(std::begin(label), label_end);
+	}
+
+	void requirePreviewIds(const PreviewIds& ids)
+	{
+		REQUIRE(ids.tx != 0);
+		REQUIRE(ids.rx != 0);
+		REQUIRE(ids.target != 0);
+	}
+
+	[[nodiscard]] PreviewIds previewIdsFromBistaticScenario(const nlohmann::json& scenario)
+	{
+		PreviewIds ids;
+		for (const auto& platform : scenario.at("simulation").at("platforms"))
+		{
+			for (const auto& component : platform.at("components"))
+			{
+				if (component.contains("transmitter"))
+				{
+					ids.tx = api_test::parseId(component.at("transmitter").at("id"));
+				}
+				else if (component.contains("receiver"))
+				{
+					ids.rx = api_test::parseId(component.at("receiver").at("id"));
+				}
+				else if (component.contains("target"))
+				{
+					ids.target = api_test::parseId(component.at("target").at("id"));
+				}
+			}
+		}
+		return ids;
+	}
+
+	[[nodiscard]] PreviewIds previewIdsFromMonostaticScenario(const nlohmann::json& scenario)
+	{
+		PreviewIds ids;
+		for (const auto& platform : scenario.at("simulation").at("platforms"))
+		{
+			for (const auto& component : platform.at("components"))
+			{
+				if (component.contains("monostatic"))
+				{
+					ids.tx = api_test::parseId(component.at("monostatic").at("tx_id"));
+					ids.rx = api_test::parseId(component.at("monostatic").at("rx_id"));
+				}
+				else if (component.contains("target"))
+				{
+					ids.target = api_test::parseId(component.at("target").at("id"));
+				}
+			}
+		}
+		return ids;
+	}
+
+	void requireCommonPreviewLinkFields(const fers_visual_link_t& link)
+	{
+		const std::string label = linkLabelString(link.label);
+		REQUIRE(link.label[sizeof(link.label) - 1] == '\0');
+		REQUIRE_FALSE(label.empty());
+		REQUIRE(std::isfinite(link.display_value));
+	}
+
+	void requireBistaticTxTargetLink(const fers_visual_link_t& link, const PreviewIds& ids)
+	{
+		const std::string label = linkLabelString(link.label);
+		REQUIRE(link.source_id == ids.tx);
+		REQUIRE(link.dest_id == ids.target);
+		REQUIRE(link.origin_id == ids.tx);
+		REQUIRE(link.quality == FERS_LINK_STRONG);
+		REQUIRE_THAT(link.display_value, WithinAbs(std::stod(label), 0.1));
+	}
+
+	void requireDirectTxRxLink(const fers_visual_link_t& link, const PreviewIds& ids)
+	{
+		REQUIRE(link.source_id == ids.tx);
+		REQUIRE(link.dest_id == ids.rx);
+		REQUIRE(link.origin_id == ids.tx);
+		REQUIRE(link.quality == FERS_LINK_STRONG);
+	}
+
+	void requireBistaticTargetRxLink(const fers_visual_link_t& link, const PreviewIds& ids)
+	{
+		const std::string label = linkLabelString(link.label);
+		REQUIRE(link.source_id == ids.target);
+		REQUIRE(link.dest_id == ids.rx);
+		REQUIRE(link.origin_id == ids.tx);
+		REQUIRE(link.quality == FERS_LINK_STRONG);
+		REQUIRE_THAT(link.display_value, WithinAbs(std::stod(label), 0.1));
+	}
+
+	void requireBistaticPreviewLinks(const fers_visual_link_list_t& links, const PreviewIds& ids)
+	{
+		bool saw_tx_tgt = false;
+		bool saw_direct = false;
+		bool saw_tgt_rx = false;
+
+		for (size_t i = 0; i < links.count; ++i)
+		{
+			const auto& link = links.links[i];
+			requireCommonPreviewLinkFields(link);
+
+			switch (link.type)
+			{
+			case FERS_LINK_BISTATIC_TX_TGT:
+				saw_tx_tgt = true;
+				requireBistaticTxTargetLink(link, ids);
+				break;
+			case FERS_LINK_DIRECT_TX_RX:
+				saw_direct = true;
+				requireDirectTxRxLink(link, ids);
+				break;
+			case FERS_LINK_BISTATIC_TGT_RX:
+				saw_tgt_rx = true;
+				requireBistaticTargetRxLink(link, ids);
+				break;
+			default:
+				break;
+			}
+		}
+
+		REQUIRE(saw_tx_tgt);
+		REQUIRE(saw_direct);
+		REQUIRE(saw_tgt_rx);
+	}
+
+	void requireMonostaticLink(const fers_visual_link_t& link, const PreviewIds& ids)
+	{
+		REQUIRE(link.source_id == ids.tx);
+		REQUIRE(link.dest_id == ids.target);
+		REQUIRE(link.origin_id == ids.tx);
+		REQUIRE(link.quality == FERS_LINK_STRONG);
+	}
+
+	void requireMonostaticPreviewLinks(const fers_visual_link_list_t& links, const PreviewIds& ids)
+	{
+		bool saw_monostatic = false;
+		for (size_t i = 0; i < links.count; ++i)
+		{
+			const auto& link = links.links[i];
+			if (link.type == FERS_LINK_MONOSTATIC)
+			{
+				saw_monostatic = true;
+				requireMonostaticLink(link, ids);
+			}
+		}
+
+		REQUIRE(saw_monostatic);
 	}
 }
 
@@ -163,83 +319,13 @@ TEST_CASE("API preview links map link metadata into C structs", "[api][preview]"
 	REQUIRE(fers_load_scenario_from_xml_string(context.get(), xml.c_str(), 0) == 0);
 
 	const auto scenario = api_test::parseScenarioJson(context.get());
-	const auto& platforms = scenario.at("simulation").at("platforms");
-
-	std::uint64_t tx_id = 0;
-	std::uint64_t rx_id = 0;
-	std::uint64_t target_id = 0;
-	for (const auto& platform : platforms)
-	{
-		for (const auto& component : platform.at("components"))
-		{
-			if (component.contains("transmitter"))
-			{
-				tx_id = api_test::parseId(component.at("transmitter").at("id"));
-			}
-			else if (component.contains("receiver"))
-			{
-				rx_id = api_test::parseId(component.at("receiver").at("id"));
-			}
-			else if (component.contains("target"))
-			{
-				target_id = api_test::parseId(component.at("target").at("id"));
-			}
-		}
-	}
-
-	REQUIRE(tx_id != 0);
-	REQUIRE(rx_id != 0);
-	REQUIRE(target_id != 0);
+	const PreviewIds ids = previewIdsFromBistaticScenario(scenario);
+	requirePreviewIds(ids);
 
 	api_test::PreviewLinks const links(fers_calculate_preview_links(context.get(), 0.0));
 	REQUIRE(links.get() != nullptr);
 	REQUIRE(links.get()->count > 0u);
-
-	bool saw_tx_tgt = false;
-	bool saw_direct = false;
-	bool saw_tgt_rx = false;
-
-	for (size_t i = 0; i < links.get()->count; ++i)
-	{
-		const auto& link = links.get()->links[i];
-		const std::string label = linkLabelString(link.label);
-		REQUIRE(link.label[sizeof(link.label) - 1] == '\0');
-		REQUIRE_FALSE(label.empty());
-		REQUIRE(std::isfinite(link.display_value));
-
-		switch (link.type)
-		{
-		case FERS_LINK_BISTATIC_TX_TGT:
-			saw_tx_tgt = true;
-			REQUIRE(link.source_id == tx_id);
-			REQUIRE(link.dest_id == target_id);
-			REQUIRE(link.origin_id == tx_id);
-			REQUIRE(link.quality == FERS_LINK_STRONG);
-			REQUIRE_THAT(link.display_value, WithinAbs(std::stod(label), 0.1));
-			break;
-		case FERS_LINK_DIRECT_TX_RX:
-			saw_direct = true;
-			REQUIRE(link.source_id == tx_id);
-			REQUIRE(link.dest_id == rx_id);
-			REQUIRE(link.origin_id == tx_id);
-			REQUIRE(link.quality == FERS_LINK_STRONG);
-			break;
-		case FERS_LINK_BISTATIC_TGT_RX:
-			saw_tgt_rx = true;
-			REQUIRE(link.source_id == target_id);
-			REQUIRE(link.dest_id == rx_id);
-			REQUIRE(link.origin_id == tx_id);
-			REQUIRE(link.quality == FERS_LINK_STRONG);
-			REQUIRE_THAT(link.display_value, WithinAbs(std::stod(label), 0.1));
-			break;
-		default:
-			break;
-		}
-	}
-
-	REQUIRE(saw_tx_tgt);
-	REQUIRE(saw_direct);
-	REQUIRE(saw_tgt_rx);
+	requireBistaticPreviewLinks(*links.get(), ids);
 }
 
 TEST_CASE("API preview links map monostatic link types into C enums", "[api][preview]")
@@ -253,47 +339,10 @@ TEST_CASE("API preview links map monostatic link types into C enums", "[api][pre
 	REQUIRE(fers_load_scenario_from_xml_string(context.get(), xml.c_str(), 0) == 0);
 
 	const auto scenario = api_test::parseScenarioJson(context.get());
-	const auto& platforms = scenario.at("simulation").at("platforms");
-
-	std::uint64_t tx_id = 0;
-	std::uint64_t rx_id = 0;
-	std::uint64_t target_id = 0;
-	for (const auto& platform : platforms)
-	{
-		for (const auto& component : platform.at("components"))
-		{
-			if (component.contains("monostatic"))
-			{
-				tx_id = api_test::parseId(component.at("monostatic").at("tx_id"));
-				rx_id = api_test::parseId(component.at("monostatic").at("rx_id"));
-			}
-			else if (component.contains("target"))
-			{
-				target_id = api_test::parseId(component.at("target").at("id"));
-			}
-		}
-	}
-
-	REQUIRE(tx_id != 0);
-	REQUIRE(rx_id != 0);
-	REQUIRE(target_id != 0);
+	const PreviewIds ids = previewIdsFromMonostaticScenario(scenario);
+	requirePreviewIds(ids);
 
 	api_test::PreviewLinks const links(fers_calculate_preview_links(context.get(), 0.0));
 	REQUIRE(links.get() != nullptr);
-
-	bool saw_monostatic = false;
-	for (size_t i = 0; i < links.get()->count; ++i)
-	{
-		const auto& link = links.get()->links[i];
-		if (link.type == FERS_LINK_MONOSTATIC)
-		{
-			saw_monostatic = true;
-			REQUIRE(link.source_id == tx_id);
-			REQUIRE(link.dest_id == target_id);
-			REQUIRE(link.origin_id == tx_id);
-			REQUIRE(link.quality == FERS_LINK_STRONG);
-		}
-	}
-
-	REQUIRE(saw_monostatic);
+	requireMonostaticPreviewLinks(*links.get(), ids);
 }

--- a/packages/libfers/tests/api/test_api_preview.cpp
+++ b/packages/libfers/tests/api/test_api_preview.cpp
@@ -16,31 +16,31 @@ TEST_CASE("API antenna pattern validates context and antenna existence", "[api][
 
 	SECTION("null context")
 	{
-		api_test::AntennaPattern pattern(fers_get_antenna_pattern(nullptr, 1, 4, 3, 1.0e9));
+		api_test::AntennaPattern const pattern(fers_get_antenna_pattern(nullptr, 1, 4, 3, 1.0e9));
 		REQUIRE(pattern.get() == nullptr);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("context must be non-null"));
 	}
 
 	SECTION("unknown antenna id")
 	{
-		api_test::Context context;
+		api_test::Context const context;
 		REQUIRE(context.get() != nullptr);
 		const std::string xml = api_test::previewScenarioXml();
 		REQUIRE(fers_load_scenario_from_xml_string(context.get(), xml.c_str(), 0) == 0);
 
-		api_test::AntennaPattern pattern(fers_get_antenna_pattern(context.get(), 999999, 4, 3, 1.0e9));
+		api_test::AntennaPattern const pattern(fers_get_antenna_pattern(context.get(), 999999, 4, 3, 1.0e9));
 		REQUIRE(pattern.get() == nullptr);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("not found in the world"));
 	}
 }
 
 TEST_CASE("API antenna pattern normalizes isotropic gains", "[api][preview]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::previewScenarioXml();
@@ -49,7 +49,7 @@ TEST_CASE("API antenna pattern normalizes isotropic gains", "[api][preview]")
 	const auto scenario = api_test::parseScenarioJson(context.get());
 	const auto antenna_id = api_test::parseId(scenario.at("simulation").at("antennas").at(0).at("id"));
 
-	api_test::AntennaPattern pattern(fers_get_antenna_pattern(context.get(), antenna_id, 4, 3, 1.0e9));
+	api_test::AntennaPattern const pattern(fers_get_antenna_pattern(context.get(), antenna_id, 4, 3, 1.0e9));
 	REQUIRE(pattern.get() != nullptr);
 	REQUIRE(pattern.get()->az_count == 4u);
 	REQUIRE(pattern.get()->el_count == 3u);
@@ -63,9 +63,9 @@ TEST_CASE("API antenna pattern normalizes isotropic gains", "[api][preview]")
 
 TEST_CASE("API antenna pattern accepts zero frequency for isotropic previews", "[api][preview]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::previewScenarioXml();
@@ -74,16 +74,16 @@ TEST_CASE("API antenna pattern accepts zero frequency for isotropic previews", "
 	const auto scenario = api_test::parseScenarioJson(context.get());
 	const auto antenna_id = api_test::parseId(scenario.at("simulation").at("antennas").at(0).at("id"));
 
-	api_test::AntennaPattern pattern(fers_get_antenna_pattern(context.get(), antenna_id, 2, 2, 0.0));
+	api_test::AntennaPattern const pattern(fers_get_antenna_pattern(context.get(), antenna_id, 2, 2, 0.0));
 	REQUIRE(pattern.get() != nullptr);
 	REQUIRE(pattern.get()->max_gain > 0.0);
 }
 
 TEST_CASE("API antenna pattern previews XML antennas loaded from standalone files", "[api][preview]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const api_test::ScopedPath antenna_path(api_test::uniqueTempPath("api_preview_xml_antenna", ".xml"));
@@ -121,7 +121,7 @@ TEST_CASE("API antenna pattern previews XML antennas loaded from standalone file
 	const auto scenario = api_test::parseScenarioJson(context.get());
 	const auto antenna_id = api_test::parseId(scenario.at("simulation").at("antennas").at(0).at("id"));
 
-	api_test::AntennaPattern pattern(fers_get_antenna_pattern(context.get(), antenna_id, 5, 3, 1.0e9));
+	api_test::AntennaPattern const pattern(fers_get_antenna_pattern(context.get(), antenna_id, 5, 3, 1.0e9));
 	REQUIRE(pattern.get() != nullptr);
 	REQUIRE(pattern.get()->max_gain > 0.0);
 	REQUIRE_THAT(pattern.get()->gains[1 + 5], WithinAbs(1.0, 1e-12));
@@ -131,10 +131,10 @@ TEST_CASE("API antenna pattern previews XML antennas loaded from standalone file
 TEST_CASE("API preview links return empty list for empty world", "[api][preview]")
 {
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
-	api_test::PreviewLinks links(fers_calculate_preview_links(context.get(), 0.0));
+	api_test::PreviewLinks const links(fers_calculate_preview_links(context.get(), 0.0));
 	REQUIRE(links.get() != nullptr);
 	REQUIRE(links.get()->count == 0u);
 	REQUIRE(links.get()->links == nullptr);
@@ -142,9 +142,9 @@ TEST_CASE("API preview links return empty list for empty world", "[api][preview]
 
 TEST_CASE("API preview links map link metadata into C structs", "[api][preview]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::previewScenarioXml();
@@ -179,7 +179,7 @@ TEST_CASE("API preview links map link metadata into C structs", "[api][preview]"
 	REQUIRE(rx_id != 0);
 	REQUIRE(target_id != 0);
 
-	api_test::PreviewLinks links(fers_calculate_preview_links(context.get(), 0.0));
+	api_test::PreviewLinks const links(fers_calculate_preview_links(context.get(), 0.0));
 	REQUIRE(links.get() != nullptr);
 	REQUIRE(links.get()->count > 0u);
 
@@ -231,9 +231,9 @@ TEST_CASE("API preview links map link metadata into C structs", "[api][preview]"
 
 TEST_CASE("API preview links map monostatic link types into C enums", "[api][preview]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::monostaticPreviewScenarioXml();
@@ -265,7 +265,7 @@ TEST_CASE("API preview links map monostatic link types into C enums", "[api][pre
 	REQUIRE(rx_id != 0);
 	REQUIRE(target_id != 0);
 
-	api_test::PreviewLinks links(fers_calculate_preview_links(context.get(), 0.0));
+	api_test::PreviewLinks const links(fers_calculate_preview_links(context.get(), 0.0));
 	REQUIRE(links.get() != nullptr);
 
 	bool saw_monostatic = false;

--- a/packages/libfers/tests/api/test_api_runtime.cpp
+++ b/packages/libfers/tests/api/test_api_runtime.cpp
@@ -1,10 +1,12 @@
 #include <atomic>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <chrono>
 #include <filesystem>
 #include <libfers/api.h>
 #include <limits>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "api_test_helpers.h"
@@ -57,6 +59,46 @@ namespace
 	{
 		auto* cancel = static_cast<std::atomic_bool*>(user_data);
 		return cancel->load() ? 1 : 0;
+	}
+
+	void replaceOnce(std::string& value, const std::string& from, const std::string& to)
+	{
+		const auto pos = value.find(from);
+		REQUIRE(pos != std::string::npos);
+		value.replace(pos, from.size(), to);
+	}
+
+	[[nodiscard]] std::string vita49DrainTimingScenarioXml()
+	{
+		std::string xml = api_test::previewScenarioXml("API VITA Drain Timing");
+		replaceOnce(xml, "<endtime>0.1</endtime>", "<endtime>0.2</endtime>");
+		replaceOnce(xml, "<rate>1000000</rate>", "<rate>100000</rate>");
+		return xml;
+	}
+
+	[[nodiscard]] std::chrono::steady_clock::time_point messageTime(const CallbackState& state,
+																	const std::string_view message)
+	{
+		for (std::size_t i = 0; i < state.messages.size(); ++i)
+		{
+			if (state.messages.at(i) == message)
+			{
+				return state.message_times.at(i);
+			}
+		}
+		return {};
+	}
+
+	void requireVita49DrainCompletionTiming(const CallbackState& state,
+											const std::chrono::steady_clock::time_point start)
+	{
+		const auto drain_time = messageTime(state, "Waiting for VITA output stream drain...");
+		const auto completion_time = messageTime(state, "Simulation complete");
+
+		REQUIRE(drain_time != std::chrono::steady_clock::time_point{});
+		REQUIRE(completion_time != std::chrono::steady_clock::time_point{});
+		CHECK(drain_time <= completion_time);
+		CHECK(completion_time >= start + std::chrono::milliseconds(180));
 	}
 }
 
@@ -488,15 +530,7 @@ TEST_CASE("API VITA49 completion waits for wall-clock stream drain", "[api][runt
 	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
-	std::string xml = api_test::previewScenarioXml("API VITA Drain Timing");
-	auto replace_once = [](std::string& value, const std::string& from, const std::string& to)
-	{
-		const auto pos = value.find(from);
-		REQUIRE(pos != std::string::npos);
-		value.replace(pos, from.size(), to);
-	};
-	replace_once(xml, "<endtime>0.1</endtime>", "<endtime>0.2</endtime>");
-	replace_once(xml, "<rate>1000000</rate>", "<rate>100000</rate>");
+	const std::string xml = vita49DrainTimingScenarioXml();
 	REQUIRE(fers_load_scenario_from_xml_string(context.get(), xml.c_str(), 0) == 0);
 	REQUIRE(fers_enable_vita49_udp_output(context.get(), "127.0.0.1", 4991) == 0);
 	REQUIRE(fers_set_vita49_fullscale(context.get(), 1.0) == 0);
@@ -505,24 +539,7 @@ TEST_CASE("API VITA49 completion waits for wall-clock stream drain", "[api][runt
 	const auto start = std::chrono::steady_clock::now();
 	REQUIRE(fers_run_simulation(context.get(), recordProgress, &state) == 0);
 
-	auto drain_time = std::chrono::steady_clock::time_point{};
-	auto completion_time = std::chrono::steady_clock::time_point{};
-	for (std::size_t i = 0; i < state.messages.size(); ++i)
-	{
-		if (state.messages.at(i) == "Waiting for VITA output stream drain...")
-		{
-			drain_time = state.message_times.at(i);
-		}
-		if (state.messages.at(i) == "Simulation complete")
-		{
-			completion_time = state.message_times.at(i);
-		}
-	}
-
-	REQUIRE(drain_time != std::chrono::steady_clock::time_point{});
-	REQUIRE(completion_time != std::chrono::steady_clock::time_point{});
-	CHECK(drain_time <= completion_time);
-	CHECK(completion_time >= start + std::chrono::milliseconds(180));
+	requireVita49DrainCompletionTiming(state, start);
 }
 
 TEST_CASE("API run simulation invokes progress callbacks with caller user data", "[api][runtime]")

--- a/packages/libfers/tests/api/test_api_runtime.cpp
+++ b/packages/libfers/tests/api/test_api_runtime.cpp
@@ -63,9 +63,9 @@ namespace
 TEST_CASE("API log level mapping writes emitted enum values", "[api][runtime]")
 {
 	const auto log_path = api_test::uniqueTempPath("api_log_levels", ".log");
-	api_test::ScopedPath log_guard(log_path);
+	api_test::ScopedPath const log_guard(log_path);
 	const auto rollover_path = api_test::uniqueTempPath("api_log_levels_rollover", ".log");
-	api_test::ScopedPath rollover_guard(rollover_path);
+	api_test::ScopedPath const rollover_guard(rollover_path);
 
 	const struct
 	{
@@ -114,9 +114,9 @@ TEST_CASE("API log level getter round-trips configured levels", "[api][runtime]"
 TEST_CASE("API log ignores null messages", "[api][runtime]")
 {
 	const auto log_path = api_test::uniqueTempPath("api_log_null_message", ".log");
-	api_test::ScopedPath log_guard(log_path);
+	api_test::ScopedPath const log_guard(log_path);
 	const auto rollover_path = api_test::uniqueTempPath("api_log_null_message_rollover", ".log");
-	api_test::ScopedPath rollover_guard(rollover_path);
+	api_test::ScopedPath const rollover_guard(rollover_path);
 	const std::string log_path_string = api_test::pathString(log_path);
 	const std::string rollover_path_string = api_test::pathString(rollover_path);
 
@@ -134,20 +134,20 @@ TEST_CASE("API configure logging accepts null and writable file destinations", "
 	SECTION("null log path")
 	{
 		REQUIRE(fers_configure_logging(FERS_LOG_INFO, nullptr) == 0);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE(error.get() == nullptr);
 	}
 
 	SECTION("temp log path")
 	{
 		const auto log_path = api_test::uniqueTempPath("api_runtime", ".log");
-		api_test::ScopedPath log_guard(log_path);
+		api_test::ScopedPath const log_guard(log_path);
 		const std::string log_path_string = api_test::pathString(log_path);
 
 		REQUIRE(fers_configure_logging(FERS_LOG_INFO, log_path_string.c_str()) == 0);
 		REQUIRE(std::filesystem::exists(log_path));
 
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE(error.get() == nullptr);
 	}
 }
@@ -156,13 +156,13 @@ TEST_CASE("API configure logging reports file open failures", "[api][runtime]")
 {
 	api_test::clearLastError();
 	const auto missing_parent = api_test::uniqueTempPath("api_log_dir");
-	api_test::ScopedPath missing_guard(missing_parent);
+	api_test::ScopedPath const missing_guard(missing_parent);
 	const auto log_path = missing_parent / "runtime.log";
 	const std::string log_path_string = api_test::pathString(log_path);
 
 	REQUIRE(fers_configure_logging(FERS_LOG_INFO, log_path_string.c_str()) == 1);
 
-	api_test::ApiString error = api_test::lastError();
+	api_test::ApiString const error = api_test::lastError();
 	REQUIRE(error.get() != nullptr);
 	REQUIRE_THAT(error.str(), ContainsSubstring("Unable to open log file:"));
 }
@@ -171,9 +171,9 @@ TEST_CASE("API log writes to configured file", "[api][runtime]")
 {
 	api_test::clearLastError();
 	const auto log_path = api_test::uniqueTempPath("api_log_smoke", ".log");
-	api_test::ScopedPath log_guard(log_path);
+	api_test::ScopedPath const log_guard(log_path);
 	const auto rollover_path = api_test::uniqueTempPath("api_log_rollover", ".log");
-	api_test::ScopedPath rollover_guard(rollover_path);
+	api_test::ScopedPath const rollover_guard(rollover_path);
 	const std::string log_path_string = api_test::pathString(log_path);
 	const std::string rollover_path_string = api_test::pathString(rollover_path);
 
@@ -191,9 +191,9 @@ TEST_CASE("API OFF log level suppresses file and callback output", "[api][runtim
 {
 	api_test::clearLastError();
 	const auto log_path = api_test::uniqueTempPath("api_log_off", ".log");
-	api_test::ScopedPath log_guard(log_path);
+	api_test::ScopedPath const log_guard(log_path);
 	const auto rollover_path = api_test::uniqueTempPath("api_log_off_rollover", ".log");
-	api_test::ScopedPath rollover_guard(rollover_path);
+	api_test::ScopedPath const rollover_guard(rollover_path);
 	const std::string log_path_string = api_test::pathString(log_path);
 	const std::string rollover_path_string = api_test::pathString(rollover_path);
 
@@ -240,8 +240,8 @@ TEST_CASE("API log callback receives formatted accepted lines", "[api][runtime]"
 
 TEST_CASE("API warning getter returns deduplicated rotation-unit warnings", "[api][runtime]")
 {
-	api_test::ParamGuard guard;
-	api_test::Context context;
+	api_test::ParamGuard const guard;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::minimalScenarioXml("API Warning Runtime");
@@ -253,7 +253,7 @@ TEST_CASE("API warning getter returns deduplicated rotation-unit warnings", "[ap
 
 	REQUIRE(fers_update_scenario_from_json(context.get(), scenario.dump().c_str()) == 0);
 
-	api_test::ApiString warnings_json(fers_get_last_warning_messages_json());
+	api_test::ApiString const warnings_json(fers_get_last_warning_messages_json());
 	REQUIRE(warnings_json.get() != nullptr);
 
 	const auto warnings = api_test::json::parse(warnings_json.str());
@@ -262,7 +262,7 @@ TEST_CASE("API warning getter returns deduplicated rotation-unit warnings", "[ap
 	REQUIRE_THAT(warnings[0].get<std::string>(), ContainsSubstring("platform 'api_sensor' rotation waypoint 0"));
 	REQUIRE_THAT(warnings[0].get<std::string>(), ContainsSubstring("'azimuth'"));
 
-	api_test::ApiString cleared(fers_get_last_warning_messages_json());
+	api_test::ApiString const cleared(fers_get_last_warning_messages_json());
 	REQUIRE(cleared.get() == nullptr);
 }
 
@@ -272,7 +272,7 @@ TEST_CASE("API run simulation rejects null context", "[api][runtime]")
 
 	REQUIRE(fers_run_simulation(nullptr, nullptr, nullptr) == -1);
 
-	api_test::ApiString error = api_test::lastError();
+	api_test::ApiString const error = api_test::lastError();
 	REQUIRE(error.get() != nullptr);
 	REQUIRE_THAT(error.str(), ContainsSubstring("Invalid context provided to fers_run_simulation"));
 }
@@ -280,56 +280,56 @@ TEST_CASE("API run simulation rejects null context", "[api][runtime]")
 TEST_CASE("API VITA49 setters validate control-plane inputs", "[api][runtime][vita49]")
 {
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	REQUIRE(fers_enable_vita49_udp_output(nullptr, "127.0.0.1", 4991) == -1);
-	api_test::ApiString null_context_error = api_test::lastError();
+	api_test::ApiString const null_context_error = api_test::lastError();
 	REQUIRE(null_context_error.get() != nullptr);
 	REQUIRE_THAT(null_context_error.str(), ContainsSubstring("context is NULL"));
 
 	REQUIRE(fers_enable_vita49_udp_output(context.get(), nullptr, 4991) == -1);
-	api_test::ApiString null_host_error = api_test::lastError();
+	api_test::ApiString const null_host_error = api_test::lastError();
 	REQUIRE(null_host_error.get() != nullptr);
 	REQUIRE_THAT(null_host_error.str(), ContainsSubstring("host is NULL"));
 
 	REQUIRE(fers_enable_vita49_udp_output(context.get(), "", 4991) == 1);
-	api_test::ApiString empty_host_error = api_test::lastError();
+	api_test::ApiString const empty_host_error = api_test::lastError();
 	REQUIRE(empty_host_error.get() != nullptr);
 	REQUIRE_THAT(empty_host_error.str(), ContainsSubstring("host must be non-empty"));
 
 	REQUIRE(fers_enable_vita49_udp_output(context.get(), "127.0.0.1", 0) == 1);
-	api_test::ApiString port_error = api_test::lastError();
+	api_test::ApiString const port_error = api_test::lastError();
 	REQUIRE(port_error.get() != nullptr);
 	REQUIRE_THAT(port_error.str(), ContainsSubstring("port must be in the range 1..65535"));
 
 	REQUIRE(fers_set_vita49_fullscale(context.get(), 0.0) == 1);
-	api_test::ApiString fullscale_error = api_test::lastError();
+	api_test::ApiString const fullscale_error = api_test::lastError();
 	REQUIRE(fullscale_error.get() != nullptr);
 	REQUIRE_THAT(fullscale_error.str(), ContainsSubstring("fullscale"));
 
 	REQUIRE(fers_set_vita49_fullscale(context.get(), std::numeric_limits<double>::infinity()) == 1);
-	api_test::ApiString infinite_fullscale_error = api_test::lastError();
+	api_test::ApiString const infinite_fullscale_error = api_test::lastError();
 	REQUIRE(infinite_fullscale_error.get() != nullptr);
 	REQUIRE_THAT(infinite_fullscale_error.str(), ContainsSubstring("positive and finite"));
 
 	REQUIRE(fers_set_vita49_epoch_unix_nanoseconds(context.get(), 4294967296000000000ULL) == 1);
-	api_test::ApiString epoch_error = api_test::lastError();
+	api_test::ApiString const epoch_error = api_test::lastError();
 	REQUIRE(epoch_error.get() != nullptr);
 	REQUIRE_THAT(epoch_error.str(), ContainsSubstring("32-bit UTC seconds"));
 
 	REQUIRE(fers_set_vita49_max_udp_payload(context.get(), 0) == 1);
-	api_test::ApiString payload_error = api_test::lastError();
+	api_test::ApiString const payload_error = api_test::lastError();
 	REQUIRE(payload_error.get() != nullptr);
 	REQUIRE_THAT(payload_error.str(), ContainsSubstring("max UDP payload"));
 
 	REQUIRE(fers_set_vita49_queue_depth(context.get(), 0) == 1);
-	api_test::ApiString queue_error = api_test::lastError();
+	api_test::ApiString const queue_error = api_test::lastError();
 	REQUIRE(queue_error.get() != nullptr);
 	REQUIRE_THAT(queue_error.str(), ContainsSubstring("queue depth"));
 
 	REQUIRE(fers_set_vita49_packet_trace_enabled(nullptr, 0) == -1);
-	api_test::ApiString trace_error = api_test::lastError();
+	api_test::ApiString const trace_error = api_test::lastError();
 	REQUIRE(trace_error.get() != nullptr);
 	REQUIRE_THAT(trace_error.str(), ContainsSubstring("context is NULL"));
 
@@ -339,9 +339,9 @@ TEST_CASE("API VITA49 setters validate control-plane inputs", "[api][runtime][vi
 
 TEST_CASE("API run simulation rejects VITA49 mode without fullscale", "[api][runtime][vita49]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::minimalScenarioXml("API VITA Missing Fullscale");
@@ -349,16 +349,16 @@ TEST_CASE("API run simulation rejects VITA49 mode without fullscale", "[api][run
 	REQUIRE(fers_enable_vita49_udp_output(context.get(), "127.0.0.1", 4991) == 0);
 
 	REQUIRE(fers_run_simulation(context.get(), nullptr, nullptr) == 1);
-	api_test::ApiString error = api_test::lastError();
+	api_test::ApiString const error = api_test::lastError();
 	REQUIRE(error.get() != nullptr);
 	REQUIRE_THAT(error.str(), ContainsSubstring("VITA49 fullscale must be a positive finite value"));
 }
 
 TEST_CASE("API HDF5 reset clears stale VITA49 output mode", "[api][runtime][vita49]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::minimalScenarioXml("API HDF5 Reset");
@@ -368,7 +368,7 @@ TEST_CASE("API HDF5 reset clears stale VITA49 output mode", "[api][runtime][vita
 
 	REQUIRE(fers_run_simulation(context.get(), nullptr, nullptr) == 0);
 
-	api_test::ApiString metadata_json(fers_get_last_output_metadata_json(context.get()));
+	api_test::ApiString const metadata_json(fers_get_last_output_metadata_json(context.get()));
 	REQUIRE(metadata_json.get() != nullptr);
 	const auto metadata = api_test::json::parse(metadata_json.str());
 	CHECK_FALSE(metadata.contains("vita49"));
@@ -376,9 +376,9 @@ TEST_CASE("API HDF5 reset clears stale VITA49 output mode", "[api][runtime][vita
 
 TEST_CASE("API extended simulation reports cooperative cancellation with metadata", "[api][runtime]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::minimalScenarioXml("API Cancel Runtime");
@@ -387,7 +387,7 @@ TEST_CASE("API extended simulation reports cooperative cancellation with metadat
 	std::atomic_bool cancel{true};
 	REQUIRE(fers_run_simulation_ex(context.get(), nullptr, nullptr, requestCancel, &cancel, nullptr, nullptr) == 2);
 
-	api_test::ApiString metadata_json(fers_get_last_output_metadata_json(context.get()));
+	api_test::ApiString const metadata_json(fers_get_last_output_metadata_json(context.get()));
 	REQUIRE(metadata_json.get() != nullptr);
 	const auto metadata = api_test::json::parse(metadata_json.str());
 	CHECK(metadata.at("simulation_name").get<std::string>() == "API Cancel Runtime");
@@ -395,14 +395,14 @@ TEST_CASE("API extended simulation reports cooperative cancellation with metadat
 
 TEST_CASE("API run simulation accepts a minimal valid scenario", "[api][runtime]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const auto out_dir = api_test::uniqueTempPath("api_out_dir");
 	std::filesystem::create_directories(out_dir);
-	api_test::ScopedPath dir_guard(out_dir);
+	api_test::ScopedPath const dir_guard(out_dir);
 
 	const std::string unique_rx_name =
 		"api_preview_rx_" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
@@ -420,11 +420,11 @@ TEST_CASE("API run simulation accepts a minimal valid scenario", "[api][runtime]
 	REQUIRE(fers_load_scenario_from_xml_string(context.get(), xml.c_str(), 0) == 0);
 	REQUIRE(fers_run_simulation(context.get(), nullptr, nullptr) == 0);
 
-	api_test::ApiString error = api_test::lastError();
+	api_test::ApiString const error = api_test::lastError();
 	REQUIRE(error.get() == nullptr);
 	REQUIRE(std::filesystem::exists(output_path));
 
-	api_test::ApiString metadata_json(fers_get_last_output_metadata_json(context.get()));
+	api_test::ApiString const metadata_json(fers_get_last_output_metadata_json(context.get()));
 	REQUIRE(metadata_json.get() != nullptr);
 	const auto metadata = api_test::json::parse(metadata_json.str());
 	CHECK_FALSE(metadata.contains("vita49"));
@@ -483,9 +483,9 @@ TEST_CASE("VITA49 metadata section records runtime output config", "[api][runtim
 
 TEST_CASE("API VITA49 completion waits for wall-clock stream drain", "[api][runtime][vita49]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	std::string xml = api_test::previewScenarioXml("API VITA Drain Timing");
@@ -527,14 +527,14 @@ TEST_CASE("API VITA49 completion waits for wall-clock stream drain", "[api][runt
 
 TEST_CASE("API run simulation invokes progress callbacks with caller user data", "[api][runtime]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const auto out_dir = api_test::uniqueTempPath("api_out_dir_cb");
 	std::filesystem::create_directories(out_dir);
-	api_test::ScopedPath dir_guard(out_dir);
+	api_test::ScopedPath const dir_guard(out_dir);
 
 	const std::string unique_rx_name =
 		"api_preview_rx_cb_" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());

--- a/packages/libfers/tests/api/test_api_runtime.cpp
+++ b/packages/libfers/tests/api/test_api_runtime.cpp
@@ -40,7 +40,7 @@ namespace
 		auto* state = static_cast<CallbackState*>(user_data);
 		++state->calls;
 		state->seen_user_data = user_data;
-		state->messages.emplace_back(message ? message : "");
+		state->messages.emplace_back((message != nullptr) ? message : "");
 		state->message_times.push_back(std::chrono::steady_clock::now());
 	}
 
@@ -50,7 +50,7 @@ namespace
 		++state->calls;
 		state->seen_user_data = user_data;
 		state->levels.push_back(level);
-		state->lines.emplace_back(line ? line : "");
+		state->lines.emplace_back((line != nullptr) ? line : "");
 	}
 
 	int requestCancel(void* user_data)

--- a/packages/libfers/tests/api/test_api_scenario_io.cpp
+++ b/packages/libfers/tests/api/test_api_scenario_io.cpp
@@ -17,21 +17,21 @@ using Catch::Matchers::WithinAbs;
 TEST_CASE("API loading scenario from XML string rejects null arguments", "[api][scenario]")
 {
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 	const std::string xml = api_test::minimalScenarioXml();
 
 	SECTION("null context")
 	{
 		REQUIRE(fers_load_scenario_from_xml_string(nullptr, xml.c_str(), 0) == -1);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("context or xml_content is NULL"));
 	}
 
 	SECTION("null xml")
 	{
 		REQUIRE(fers_load_scenario_from_xml_string(context.get(), nullptr, 0) == -1);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("context or xml_content is NULL"));
 	}
 }
@@ -39,20 +39,20 @@ TEST_CASE("API loading scenario from XML string rejects null arguments", "[api][
 TEST_CASE("API set output directory rejects null arguments", "[api][scenario]")
 {
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	SECTION("null context")
 	{
 		REQUIRE(fers_set_output_directory(nullptr, "/tmp") == -1);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("context or out_dir is NULL"));
 	}
 
 	SECTION("null out_dir")
 	{
 		REQUIRE(fers_set_output_directory(context.get(), nullptr) == -1);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("context or out_dir is NULL"));
 	}
 }
@@ -60,50 +60,50 @@ TEST_CASE("API set output directory rejects null arguments", "[api][scenario]")
 TEST_CASE("API set output directory succeeds with valid arguments", "[api][scenario]")
 {
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	REQUIRE(fers_set_output_directory(context.get(), "/tmp/custom_dir") == 0);
-	api_test::ApiString error = api_test::lastError();
+	api_test::ApiString const error = api_test::lastError();
 	REQUIRE(error.get() == nullptr);
 }
 
 TEST_CASE("API loading scenario from XML file rejects null arguments", "[api][scenario]")
 {
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 	const auto xml_path = api_test::uniqueTempPath("api_minimal_scenario", ".xml");
-	api_test::ScopedPath xml_guard(xml_path);
+	api_test::ScopedPath const xml_guard(xml_path);
 	api_test::writeTextFile(xml_path, api_test::minimalScenarioXml());
 	const std::string xml_path_string = api_test::pathString(xml_path);
 
 	SECTION("null context")
 	{
 		REQUIRE(fers_load_scenario_from_xml_file(nullptr, xml_path_string.c_str(), 0) == -1);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("context or xml_filepath is NULL"));
 	}
 
 	SECTION("null path")
 	{
 		REQUIRE(fers_load_scenario_from_xml_file(context.get(), nullptr, 0) == -1);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("context or xml_filepath is NULL"));
 	}
 }
 
 TEST_CASE("API loads a minimal scenario from XML string and exports JSON", "[api][scenario]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::minimalScenarioXml("XML String Scenario");
 	REQUIRE(fers_load_scenario_from_xml_string(context.get(), xml.c_str(), 0) == 0);
 
-	api_test::ApiString json_text = api_test::scenarioAsJson(context.get());
+	api_test::ApiString const json_text = api_test::scenarioAsJson(context.get());
 	REQUIRE(json_text.get() != nullptr);
 
 	const json scenario = json::parse(json_text.str());
@@ -114,19 +114,19 @@ TEST_CASE("API loads a minimal scenario from XML string and exports JSON", "[api
 
 TEST_CASE("API loads a minimal scenario from XML file and exports XML", "[api][scenario]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const auto xml_path = api_test::uniqueTempPath("api_minimal_scenario", ".xml");
-	api_test::ScopedPath xml_guard(xml_path);
+	api_test::ScopedPath const xml_guard(xml_path);
 	api_test::writeTextFile(xml_path, api_test::minimalScenarioXml("XML File Scenario"));
 	const std::string xml_path_string = api_test::pathString(xml_path);
 
 	REQUIRE(fers_load_scenario_from_xml_file(context.get(), xml_path_string.c_str(), 0) == 0);
 
-	api_test::ApiString xml_text = api_test::scenarioAsXml(context.get());
+	api_test::ApiString const xml_text = api_test::scenarioAsXml(context.get());
 	REQUIRE(xml_text.get() != nullptr);
 	REQUIRE_FALSE(xml_text.view().empty());
 	REQUIRE_THAT(xml_text.str(), ContainsSubstring("<simulation"));
@@ -134,15 +134,15 @@ TEST_CASE("API loads a minimal scenario from XML file and exports XML", "[api][s
 
 TEST_CASE("API exposes memory projection JSON", "[api][scenario][memory_projection]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::previewScenarioXml("Memory Projection Scenario");
 	REQUIRE(fers_load_scenario_from_xml_string(context.get(), xml.c_str(), 0) == 0);
 
-	api_test::ApiString projection_text(fers_get_memory_projection_json(context.get()));
+	api_test::ApiString const projection_text(fers_get_memory_projection_json(context.get()));
 	REQUIRE(projection_text.get() != nullptr);
 
 	const json projection = json::parse(projection_text.str());
@@ -153,7 +153,7 @@ TEST_CASE("API exposes memory projection JSON", "[api][scenario][memory_projecti
 	REQUIRE(projection["projected_total_footprint"].contains("bytes"));
 
 	REQUIRE(fers_get_memory_projection_json(nullptr) == nullptr);
-	api_test::ApiString error = api_test::lastError();
+	api_test::ApiString const error = api_test::lastError();
 	REQUIRE(error.get() != nullptr);
 	REQUIRE_THAT(error.str(), ContainsSubstring("Invalid context provided to fers_get_memory_projection_json"));
 }
@@ -161,57 +161,57 @@ TEST_CASE("API exposes memory projection JSON", "[api][scenario][memory_projecti
 TEST_CASE("API scenario serialization and update helpers reject null arguments", "[api][scenario]")
 {
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	SECTION("json export rejects null context")
 	{
 		REQUIRE(fers_get_scenario_as_json(nullptr) == nullptr);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("Invalid context provided to fers_get_scenario_as_json"));
 	}
 
 	SECTION("xml export rejects null context")
 	{
 		REQUIRE(fers_get_scenario_as_xml(nullptr) == nullptr);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("Invalid context provided to fers_get_scenario_as_xml"));
 	}
 
 	SECTION("json update rejects null context")
 	{
 		REQUIRE(fers_update_scenario_from_json(nullptr, "{}") == -1);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("context or scenario_json is NULL"));
 	}
 
 	SECTION("json update rejects null content")
 	{
 		REQUIRE(fers_update_scenario_from_json(context.get(), nullptr) == -1);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("context or scenario_json is NULL"));
 	}
 
 	SECTION("kml generation rejects null context")
 	{
 		REQUIRE(fers_generate_kml(nullptr, "out.kml") == -1);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("context or output_kml_filepath is NULL"));
 	}
 
 	SECTION("kml generation rejects null path")
 	{
 		REQUIRE(fers_generate_kml(context.get(), nullptr) == -1);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("context or output_kml_filepath is NULL"));
 	}
 }
 
 TEST_CASE("API update scenario from JSON modifies serialized state", "[api][scenario]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::minimalScenarioXml("Before Update");
@@ -228,9 +228,9 @@ TEST_CASE("API update scenario from JSON modifies serialized state", "[api][scen
 
 TEST_CASE("API failed JSON scenario update preserves previous world for later granular edits", "[api][scenario]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::minimalScenarioXml("Before Failed Update");
@@ -255,28 +255,28 @@ TEST_CASE("API failed JSON scenario update preserves previous world for later gr
 TEST_CASE("API update scenario from malformed JSON returns JSON-specific error code", "[api][scenario]")
 {
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	REQUIRE(fers_update_scenario_from_json(context.get(), api_test::malformedJson().c_str()) == 2);
 
-	api_test::ApiString error = api_test::lastError();
+	api_test::ApiString const error = api_test::lastError();
 	REQUIRE(error.get() != nullptr);
 	REQUIRE_THAT(error.str(), ContainsSubstring("JSON parsing/deserialization error:"));
 }
 
 TEST_CASE("API generate KML writes a file for a loaded scenario", "[api][scenario]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::minimalScenarioXml("KML Scenario");
 	REQUIRE(fers_load_scenario_from_xml_string(context.get(), xml.c_str(), 0) == 0);
 
 	const auto kml_path = api_test::uniqueTempPath("api_scenario", ".kml");
-	api_test::ScopedPath kml_guard(kml_path);
+	api_test::ScopedPath const kml_guard(kml_path);
 	const std::string kml_path_string = api_test::pathString(kml_path);
 	REQUIRE(fers_generate_kml(context.get(), kml_path_string.c_str()) == 0);
 	REQUIRE(std::filesystem::exists(kml_path));
@@ -286,16 +286,16 @@ TEST_CASE("API generate KML writes a file for a loaded scenario", "[api][scenari
 TEST_CASE("API missing XML file returns a populated last error", "[api][scenario]")
 {
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const auto missing_path = api_test::uniqueTempPath("api_missing", ".xml");
-	api_test::ScopedPath missing_guard(missing_path);
+	api_test::ScopedPath const missing_guard(missing_path);
 	const std::string missing_path_string = api_test::pathString(missing_path);
 
 	REQUIRE(fers_load_scenario_from_xml_file(context.get(), missing_path_string.c_str(), 0) == 1);
 
-	api_test::ApiString error = api_test::lastError();
+	api_test::ApiString const error = api_test::lastError();
 	REQUIRE(error.get() != nullptr);
 	REQUIRE_THAT(error.str(), ContainsSubstring("Failed to load main XML file"));
 }
@@ -303,43 +303,43 @@ TEST_CASE("API missing XML file returns a populated last error", "[api][scenario
 TEST_CASE("API malformed XML string returns a populated last error", "[api][scenario]")
 {
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	REQUIRE(fers_load_scenario_from_xml_string(context.get(), api_test::malformedXml().c_str(), 0) == 1);
 
-	api_test::ApiString error = api_test::lastError();
+	api_test::ApiString const error = api_test::lastError();
 	REQUIRE(error.get() != nullptr);
 	REQUIRE_THAT(error.str(), ContainsSubstring("Failed to parse XML from memory string"));
 }
 
 TEST_CASE("API KML generation reports non-creatable output paths", "[api][scenario]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::minimalScenarioXml("Bad KML Path");
 	REQUIRE(fers_load_scenario_from_xml_string(context.get(), xml.c_str(), 0) == 0);
 
 	const auto missing_parent = api_test::uniqueTempPath("api_missing_kml_dir");
-	api_test::ScopedPath missing_guard(missing_parent);
+	api_test::ScopedPath const missing_guard(missing_parent);
 	const auto kml_path = missing_parent / "out.kml";
 	const std::string kml_path_string = api_test::pathString(kml_path);
 
 	REQUIRE(fers_generate_kml(context.get(), kml_path_string.c_str()) == 2);
 
-	api_test::ApiString error = api_test::lastError();
+	api_test::ApiString const error = api_test::lastError();
 	REQUIRE(error.get() != nullptr);
 	REQUIRE_THAT(error.str(), ContainsSubstring("Error opening output KML file"));
 }
 
 TEST_CASE("API granular updates modify specific objects", "[api][scenario]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::minimalScenarioXml("Granular Update Test");
@@ -364,7 +364,7 @@ TEST_CASE("API granular updates modify specific objects", "[api][scenario]")
 	SECTION("Platform update")
 	{
 		auto plat = scenario["simulation"]["platforms"][0];
-		uint64_t plat_id = api_test::parseId(plat["id"]);
+		uint64_t const plat_id = api_test::parseId(plat["id"]);
 		plat["name"] = "UpdatedPlatform";
 
 		REQUIRE(fers_update_platform_from_json(context.get(), plat_id, plat.dump().c_str()) == 0);
@@ -402,9 +402,9 @@ TEST_CASE("API granular updates modify specific objects", "[api][scenario]")
 
 TEST_CASE("API granular updates modify specific objects (Preview Scenario)", "[api][scenario]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::previewScenarioXml("Granular Update Preview");
@@ -415,7 +415,7 @@ TEST_CASE("API granular updates modify specific objects (Preview Scenario)", "[a
 	SECTION("Transmitter update")
 	{
 		auto tx = scenario["simulation"]["platforms"][0]["components"][0]["transmitter"];
-		uint64_t tx_id = api_test::parseId(tx["id"]);
+		uint64_t const tx_id = api_test::parseId(tx["id"]);
 		tx["name"] = "UpdatedTx";
 		tx["cw_mode"] = json::object();
 		tx.erase("pulsed_mode");
@@ -431,7 +431,7 @@ TEST_CASE("API granular updates modify specific objects (Preview Scenario)", "[a
 	SECTION("Receiver update")
 	{
 		auto rx = scenario["simulation"]["platforms"][1]["components"][0]["receiver"];
-		uint64_t rx_id = api_test::parseId(rx["id"]);
+		uint64_t const rx_id = api_test::parseId(rx["id"]);
 		rx["name"] = "UpdatedRx";
 		rx["noise_temp"] = 400.0;
 
@@ -446,7 +446,7 @@ TEST_CASE("API granular updates modify specific objects (Preview Scenario)", "[a
 	SECTION("Target update")
 	{
 		auto tgt = scenario["simulation"]["platforms"][2]["components"][0]["target"];
-		uint64_t tgt_id = api_test::parseId(tgt["id"]);
+		uint64_t const tgt_id = api_test::parseId(tgt["id"]);
 		tgt["name"] = "UpdatedTgt";
 		tgt["rcs"]["value"] = 99.0;
 
@@ -461,7 +461,7 @@ TEST_CASE("API granular updates modify specific objects (Preview Scenario)", "[a
 	SECTION("Timing update")
 	{
 		auto timing = scenario["simulation"]["timings"][0];
-		uint64_t timing_id = api_test::parseId(timing["id"]);
+		uint64_t const timing_id = api_test::parseId(timing["id"]);
 		timing["name"] = "UpdatedTiming";
 		timing["frequency"] = 2e6;
 
@@ -476,9 +476,9 @@ TEST_CASE("API granular updates modify specific objects (Preview Scenario)", "[a
 
 TEST_CASE("API granular updates modify specific objects (Monostatic Scenario)", "[api][scenario]")
 {
-	api_test::ParamGuard guard;
+	api_test::ParamGuard const guard;
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 
 	const std::string xml = api_test::monostaticPreviewScenarioXml("Granular Update Monostatic");
@@ -504,7 +504,7 @@ TEST_CASE("API granular updates modify specific objects (Monostatic Scenario)", 
 TEST_CASE("API granular updates handle errors gracefully", "[api][scenario]")
 {
 	api_test::clearLastError();
-	api_test::Context context;
+	api_test::Context const context;
 	REQUIRE(context.get() != nullptr);
 	const std::string xml = api_test::minimalScenarioXml();
 	REQUIRE(fers_load_scenario_from_xml_string(context.get(), xml.c_str(), 0) == 0);
@@ -547,7 +547,7 @@ TEST_CASE("API granular updates handle errors gracefully", "[api][scenario]")
 	SECTION("Object not found")
 	{
 		REQUIRE(fers_update_platform_from_json(context.get(), 999999, "{}") == 1);
-		api_test::ApiString error = api_test::lastError();
+		api_test::ApiString const error = api_test::lastError();
 		REQUIRE_THAT(error.str(), ContainsSubstring("Platform not found"));
 
 		REQUIRE(fers_update_transmitter_from_json(context.get(), 999999, "{}") == 1);

--- a/packages/libfers/tests/core/test_fers_context.cpp
+++ b/packages/libfers/tests/core/test_fers_context.cpp
@@ -8,7 +8,7 @@
 
 TEST_CASE("FersContext constructs world and seeder", "[core][context]")
 {
-	FersContext context;
+	FersContext const context;
 
 	core::World* world_ptr = context.getWorld();
 	REQUIRE(world_ptr != nullptr);

--- a/packages/libfers/tests/core/test_logging.cpp
+++ b/packages/libfers/tests/core/test_logging.cpp
@@ -61,8 +61,8 @@ TEST_CASE("getLevelString maps levels", "[core][logging]")
 
 TEST_CASE("Logger respects log level filtering", "[core][logging]")
 {
-	LogLevelGuard guard(logging::Level::ERROR);
-	CerrCapture capture;
+	LogLevelGuard const guard(logging::Level::ERROR);
+	CerrCapture const capture;
 
 	logging::logger.log(logging::Level::INFO, "ignored message");
 	REQUIRE(capture.str().empty());
@@ -75,8 +75,8 @@ TEST_CASE("Logger respects log level filtering", "[core][logging]")
 
 TEST_CASE("Logger OFF level suppresses all log output", "[core][logging]")
 {
-	LogLevelGuard guard(logging::Level::OFF);
-	CerrCapture capture;
+	LogLevelGuard const guard(logging::Level::OFF);
+	CerrCapture const capture;
 
 	logging::logger.log(logging::Level::FATAL, "ignored fatal message");
 	logging::logger.log(logging::Level::OFF, "ignored off message");
@@ -87,8 +87,8 @@ TEST_CASE("Logger OFF level suppresses all log output", "[core][logging]")
 
 TEST_CASE("Logger includes source location and formats messages", "[core][logging]")
 {
-	LogLevelGuard guard(logging::Level::TRACE);
-	CerrCapture capture;
+	LogLevelGuard const guard(logging::Level::TRACE);
+	CerrCapture const capture;
 
 	const std::source_location location = std::source_location::current();
 	logging::logger.log(logging::Level::INFO, location, "value {}", 7);
@@ -104,7 +104,7 @@ TEST_CASE("Logger includes source location and formats messages", "[core][loggin
 
 TEST_CASE("Logger can write to a file", "[core][logging]")
 {
-	LogLevelGuard guard(logging::Level::INFO);
+	LogLevelGuard const guard(logging::Level::INFO);
 
 	const auto log_path = std::filesystem::temp_directory_path() / "fers_logging_test.log";
 	const auto result = logging::logger.logToFile(log_path.string());
@@ -112,7 +112,7 @@ TEST_CASE("Logger can write to a file", "[core][logging]")
 
 	logging::logger.log(logging::Level::INFO, "file message");
 
-	std::ifstream file(log_path);
+	std::ifstream const file(log_path);
 	REQUIRE(file.good());
 	std::stringstream contents;
 	contents << file.rdbuf();
@@ -131,9 +131,9 @@ TEST_CASE("Logger reports file open errors", "[core][logging]")
 
 TEST_CASE("Logger forwards accepted lines to callback", "[core][logging]")
 {
-	LogLevelGuard level_guard(logging::Level::WARNING);
-	LogCallbackGuard callback_guard;
-	CerrCapture capture;
+	LogLevelGuard const level_guard(logging::Level::WARNING);
+	LogCallbackGuard const callback_guard;
+	CerrCapture const capture;
 	LogCallbackState state;
 
 	logging::logger.setCallback(recordLogCallback, &state);

--- a/packages/libfers/tests/core/test_logging.cpp
+++ b/packages/libfers/tests/core/test_logging.cpp
@@ -13,7 +13,7 @@ namespace
 	{
 		std::ostringstream buffer;
 		std::streambuf* old{nullptr};
-		CerrCapture() { old = std::cerr.rdbuf(buffer.rdbuf()); }
+		CerrCapture() : old(std::cerr.rdbuf(buffer.rdbuf())) {}
 		CerrCapture(const CerrCapture&) = delete;
 		CerrCapture& operator=(const CerrCapture&) = delete;
 		CerrCapture(CerrCapture&&) = delete;

--- a/packages/libfers/tests/core/test_logging.cpp
+++ b/packages/libfers/tests/core/test_logging.cpp
@@ -14,6 +14,10 @@ namespace
 		std::ostringstream buffer;
 		std::streambuf* old{nullptr};
 		CerrCapture() { old = std::cerr.rdbuf(buffer.rdbuf()); }
+		CerrCapture(const CerrCapture&) = delete;
+		CerrCapture& operator=(const CerrCapture&) = delete;
+		CerrCapture(CerrCapture&&) = delete;
+		CerrCapture& operator=(CerrCapture&&) = delete;
 		~CerrCapture() { std::cerr.rdbuf(old); }
 		[[nodiscard]] std::string str() const { return buffer.str(); }
 	};
@@ -21,11 +25,20 @@ namespace
 	struct LogLevelGuard
 	{
 		explicit LogLevelGuard(logging::Level level) { logging::logger.setLevel(level); }
+		LogLevelGuard(const LogLevelGuard&) = delete;
+		LogLevelGuard& operator=(const LogLevelGuard&) = delete;
+		LogLevelGuard(LogLevelGuard&&) = delete;
+		LogLevelGuard& operator=(LogLevelGuard&&) = delete;
 		~LogLevelGuard() { logging::logger.setLevel(logging::Level::INFO); }
 	};
 
 	struct LogCallbackGuard
 	{
+		LogCallbackGuard() = default;
+		LogCallbackGuard(const LogCallbackGuard&) = delete;
+		LogCallbackGuard& operator=(const LogCallbackGuard&) = delete;
+		LogCallbackGuard(LogCallbackGuard&&) = delete;
+		LogCallbackGuard& operator=(LogCallbackGuard&&) = delete;
 		~LogCallbackGuard() { logging::logger.setCallback(nullptr, nullptr); }
 	};
 

--- a/packages/libfers/tests/core/test_memory_projection.cpp
+++ b/packages/libfers/tests/core/test_memory_projection.cpp
@@ -48,7 +48,7 @@ namespace
 	{
 		std::ostringstream buffer;
 		std::streambuf* old{nullptr};
-		CerrCapture() { old = std::cerr.rdbuf(buffer.rdbuf()); }
+		CerrCapture() : old(std::cerr.rdbuf(buffer.rdbuf())) {}
 		CerrCapture(const CerrCapture&) = delete;
 		CerrCapture& operator=(const CerrCapture&) = delete;
 		CerrCapture(CerrCapture&&) = delete;

--- a/packages/libfers/tests/core/test_memory_projection.cpp
+++ b/packages/libfers/tests/core/test_memory_projection.cpp
@@ -109,7 +109,7 @@ namespace
 
 TEST_CASE("Simulation memory projection totals core categories", "[core][memory_projection]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 1.0);
 	params::setRate(10.0);
 	params::setOversampleRatio(2);
@@ -139,7 +139,7 @@ TEST_CASE("Simulation memory projection totals core categories", "[core][memory_
 
 TEST_CASE("Simulation memory projection counts dechirped streaming output at RF rate", "[core][memory_projection]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 1.0);
 	params::setRate(10.0);
 	params::setOversampleRatio(2);
@@ -167,7 +167,7 @@ TEST_CASE("Simulation memory projection counts dechirped streaming output at RF 
 TEST_CASE("Simulation memory projection counts IF-rate dechirped output at receiver rate",
 		  "[core][memory_projection][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 1.0);
 	params::setRate(10.0);
 	params::setOversampleRatio(2);
@@ -198,7 +198,7 @@ TEST_CASE("Simulation memory projection counts IF-rate dechirped output at recei
 TEST_CASE("Simulation memory projection starts phase-noise lookup at earliest streaming receiver",
 		  "[core][memory_projection]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 2.0);
 	params::setRate(10.0);
 	params::setOversampleRatio(1);
@@ -215,14 +215,14 @@ TEST_CASE("Simulation memory projection starts phase-noise lookup at earliest st
 
 TEST_CASE("Simulation memory projection log names required categories", "[core][memory_projection][logging]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 1.0);
 	params::setRate(10.0);
 	params::setOversampleRatio(2);
 
 	const auto world = makeProjectionWorld();
-	LogLevelGuard level_guard(logging::Level::DEBUG);
-	CerrCapture capture;
+	LogLevelGuard const level_guard(logging::Level::DEBUG);
+	CerrCapture const capture;
 
 	core::logSimulationMemoryProjection(*world);
 

--- a/packages/libfers/tests/core/test_memory_projection.cpp
+++ b/packages/libfers/tests/core/test_memory_projection.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <nlohmann/json.hpp>
@@ -140,7 +141,7 @@ TEST_CASE("Simulation memory projection totals core categories", "[core][memory_
 
 	REQUIRE(projection.phase_noise_lookup.bytes == 21 * sizeof(RealType));
 	REQUIRE(projection.streaming_iq_buffers.bytes == 20 * sizeof(ComplexType));
-	REQUIRE(projection.rendered_hdf5_payload.bytes == 16 * 2 * sizeof(RealType));
+	REQUIRE(projection.rendered_hdf5_payload.bytes == std::uint64_t{16} * 2 * sizeof(RealType));
 
 	const auto json = nlohmann::json::parse(core::memoryProjectionToJsonString(projection));
 	REQUIRE(json["phase_noise_lookups"]["bytes"] == projection.phase_noise_lookup.bytes);
@@ -173,7 +174,7 @@ TEST_CASE("Simulation memory projection counts dechirped streaming output at RF 
 	REQUIRE(projection.streaming_sample_count == 20);
 	REQUIRE(projection.streaming_receiver_count == 2);
 	REQUIRE(projection.rendered_hdf5_sample_count == 36);
-	REQUIRE(projection.rendered_hdf5_payload.bytes == 36 * 2 * sizeof(RealType));
+	REQUIRE(projection.rendered_hdf5_payload.bytes == std::uint64_t{36} * 2 * sizeof(RealType));
 }
 
 TEST_CASE("Simulation memory projection counts IF-rate dechirped output at receiver rate",
@@ -204,7 +205,7 @@ TEST_CASE("Simulation memory projection counts IF-rate dechirped output at recei
 	REQUIRE(projection.streaming_receiver_count == 2);
 	REQUIRE(projection.rendered_hdf5_sample_count == 21);
 	REQUIRE(projection.streaming_iq_buffers.bytes == 25 * sizeof(ComplexType));
-	REQUIRE(projection.rendered_hdf5_payload.bytes == 21 * 2 * sizeof(RealType));
+	REQUIRE(projection.rendered_hdf5_payload.bytes == std::uint64_t{21} * 2 * sizeof(RealType));
 }
 
 TEST_CASE("Simulation memory projection starts phase-noise lookup at earliest streaming receiver",

--- a/packages/libfers/tests/core/test_memory_projection.cpp
+++ b/packages/libfers/tests/core/test_memory_projection.cpp
@@ -27,12 +27,20 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 
 	struct LogLevelGuard
 	{
 		explicit LogLevelGuard(const logging::Level level) { logging::logger.setLevel(level); }
+		LogLevelGuard(const LogLevelGuard&) = delete;
+		LogLevelGuard& operator=(const LogLevelGuard&) = delete;
+		LogLevelGuard(LogLevelGuard&&) = delete;
+		LogLevelGuard& operator=(LogLevelGuard&&) = delete;
 		~LogLevelGuard() { logging::logger.setLevel(logging::Level::DEBUG); }
 	};
 
@@ -41,6 +49,10 @@ namespace
 		std::ostringstream buffer;
 		std::streambuf* old{nullptr};
 		CerrCapture() { old = std::cerr.rdbuf(buffer.rdbuf()); }
+		CerrCapture(const CerrCapture&) = delete;
+		CerrCapture& operator=(const CerrCapture&) = delete;
+		CerrCapture(CerrCapture&&) = delete;
+		CerrCapture& operator=(CerrCapture&&) = delete;
 		~CerrCapture() { std::cerr.rdbuf(old); }
 		[[nodiscard]] std::string str() const { return buffer.str(); }
 	};

--- a/packages/libfers/tests/core/test_parameters.cpp
+++ b/packages/libfers/tests/core/test_parameters.cpp
@@ -15,6 +15,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 }

--- a/packages/libfers/tests/core/test_parameters.cpp
+++ b/packages/libfers/tests/core/test_parameters.cpp
@@ -21,7 +21,7 @@ namespace
 
 TEST_CASE("Parameters default values are consistent", "[core][parameters]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	REQUIRE_THAT(params::c(), WithinAbs(params::Parameters::DEFAULT_C, 0.0));
@@ -43,7 +43,7 @@ TEST_CASE("Parameters default values are consistent", "[core][parameters]")
 
 TEST_CASE("Parameters setters update getters", "[core][parameters]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	params::setC(300000000.0);
@@ -74,7 +74,7 @@ TEST_CASE("Parameters setters update getters", "[core][parameters]")
 
 TEST_CASE("Parameters setters validate inputs", "[core][parameters]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	REQUIRE_THROWS_AS(params::setRate(0.0), std::runtime_error);
@@ -86,7 +86,7 @@ TEST_CASE("Parameters setters validate inputs", "[core][parameters]")
 
 TEST_CASE("Parameters origin and coordinate settings", "[core][parameters]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	params::setOrigin(1.5, 2.5, 3.5);
@@ -102,7 +102,7 @@ TEST_CASE("Parameters origin and coordinate settings", "[core][parameters]")
 
 TEST_CASE("Parameters setThreads returns expected", "[core][parameters]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	const auto error = params::setThreads(0);
@@ -115,7 +115,7 @@ TEST_CASE("Parameters setThreads returns expected", "[core][parameters]")
 
 TEST_CASE("Parameters reset restores defaults", "[core][parameters]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setC(1.0);
 	params::setTime(5.0, 10.0);
 	params::setSimSamplingRate(500.0);

--- a/packages/libfers/tests/core/test_sim_events.cpp
+++ b/packages/libfers/tests/core/test_sim_events.cpp
@@ -5,7 +5,7 @@
 
 TEST_CASE("EventComparator orders earliest timestamps first", "[core][events]")
 {
-	core::EventComparator comparator;
+	core::EventComparator const comparator;
 
 	const core::Event early{1.0, core::EventType::TX_PULSED_START, nullptr};
 	const core::Event late{5.0, core::EventType::RX_STREAMING_END, nullptr};

--- a/packages/libfers/tests/core/test_sim_threading.cpp
+++ b/packages/libfers/tests/core/test_sim_threading.cpp
@@ -58,7 +58,7 @@ namespace
 	{
 		std::ostringstream buffer;
 		std::streambuf* old{nullptr};
-		CerrCapture() { old = std::cerr.rdbuf(buffer.rdbuf()); }
+		CerrCapture() : old(std::cerr.rdbuf(buffer.rdbuf())) {}
 		CerrCapture(const CerrCapture&) = delete;
 		CerrCapture& operator=(const CerrCapture&) = delete;
 		CerrCapture(CerrCapture&&) = delete;

--- a/packages/libfers/tests/core/test_sim_threading.cpp
+++ b/packages/libfers/tests/core/test_sim_threading.cpp
@@ -470,7 +470,7 @@ TEST_CASE("makeActiveSource caches streaming scalars and clips FMCW chirp count"
 	REQUIRE_THAT(source.two_pi_f0, WithinAbs(2.0 * PI * 1.0e6, 1.0e-9));
 	REQUIRE_THAT(source.s_pi_alpha, WithinAbs(PI * 200.0e9, 1.0e-3));
 	REQUIRE(source.chirp_count.has_value());
-	REQUIRE(*source.chirp_count == std::size_t{1000});
+	REQUIRE(source.chirp_count.value_or(0u) == std::size_t{1000});
 }
 
 TEST_CASE("makeActiveSource caches signed FMCW down-chirp coefficient", "[core][threading][fmcw]")

--- a/packages/libfers/tests/core/test_sim_threading.cpp
+++ b/packages/libfers/tests/core/test_sim_threading.cpp
@@ -429,7 +429,7 @@ TEST_CASE("ProgressReporter safely wraps and calls callback", "[core][threading]
 
 TEST_CASE("makeActiveSource caches streaming scalars and clips FMCW chirp count", "[core][threading][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 
 	radar::Platform platform("TxPlatform");
 	antenna::Isotropic antenna("Iso");
@@ -463,7 +463,7 @@ TEST_CASE("makeActiveSource caches streaming scalars and clips FMCW chirp count"
 
 TEST_CASE("makeActiveSource caches signed FMCW down-chirp coefficient", "[core][threading][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 
 	radar::Platform platform("TxPlatform");
 	antenna::Isotropic antenna("Iso");
@@ -487,7 +487,7 @@ TEST_CASE("makeActiveSource caches signed FMCW down-chirp coefficient", "[core][
 
 TEST_CASE("SimulationEngine handles streaming state events", "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 10.0);
 	auto world = createPhysicsWorld();
 	pool::ThreadPool pool(1);
@@ -527,7 +527,7 @@ TEST_CASE("SimulationEngine handles streaming state events", "[core][threading]"
 
 TEST_CASE("SimulationEngine handles Pulsed Window events", "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 10.0);
@@ -592,7 +592,7 @@ TEST_CASE("SimulationEngine handles Pulsed Window events", "[core][threading]")
 
 TEST_CASE("SimulationEngine handles Tx Pulsed Start and routes responses", "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 10.0);
@@ -643,12 +643,12 @@ TEST_CASE("SimulationEngine handles Tx Pulsed Start and routes responses", "[cor
 
 TEST_CASE("SimulationEngine calculates mathematically correct CW physics", "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setC(3e8); // Override c to 3e8 for clean math
 
 	auto world = createPhysicsWorld();
 	pool::ThreadPool pool(1);
-	core::SimulationEngine engine(world.get(), pool, nullptr, ".");
+	core::SimulationEngine const engine(world.get(), pool, nullptr, ".");
 
 	auto* tx = world->getTransmitters().front().get();
 	auto* rx = world->getReceivers().front().get();
@@ -678,11 +678,11 @@ TEST_CASE("SimulationEngine calculates mathematically correct CW physics", "[cor
 		const RealType expected_refl_amp = 0.3 / (20000.0 * PI * std::sqrt(PI));
 		const RealType expected_phase = -2000.0 * PI / 3.0;
 
-		ComplexType expected_direct = std::polar(expected_direct_amp, expected_phase);
-		ComplexType expected_refl = std::polar(expected_refl_amp, expected_phase);
-		ComplexType expected_total = expected_direct + expected_refl;
+		ComplexType const expected_direct = std::polar(expected_direct_amp, expected_phase);
+		ComplexType const expected_refl = std::polar(expected_refl_amp, expected_phase);
+		ComplexType const expected_total = expected_direct + expected_refl;
 
-		ComplexType actual_total = simulation::calculateDirectPathContribution(tx, rx, 0.0) +
+		ComplexType const actual_total = simulation::calculateDirectPathContribution(tx, rx, 0.0) +
 			simulation::calculateReflectedPathContribution(tx, rx, world->getTargets().front().get(), 0.0);
 
 		REQUIRE_THAT(actual_total.real(), WithinAbs(expected_total.real(), 1e-12));
@@ -692,7 +692,7 @@ TEST_CASE("SimulationEngine calculates mathematically correct CW physics", "[cor
 
 TEST_CASE("SimulationEngine processStreamingPhysics steps through time and emits sink blocks", "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 10.0);
@@ -729,7 +729,7 @@ TEST_CASE("SimulationEngine processStreamingPhysics steps through time and emits
 
 TEST_CASE("SimulationEngine live streaming output emits bounded CW blocks", "[core][threading][vita49][bounded]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 10.0);
@@ -758,7 +758,7 @@ TEST_CASE("SimulationEngine live streaming output emits bounded CW blocks", "[co
 
 TEST_CASE("SimulationEngine emits output heartbeats on streaming simulation time", "[core][threading][vita49]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(10.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 5.0);
@@ -788,7 +788,7 @@ TEST_CASE("SimulationEngine emits output heartbeats on streaming simulation time
 
 TEST_CASE("SimulationEngine does not burst historical heartbeats after schedule gaps", "[core][threading][vita49]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(0.1);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 4000.0);
@@ -816,7 +816,7 @@ TEST_CASE("SimulationEngine does not burst historical heartbeats after schedule 
 TEST_CASE("SimulationEngine streaming output applies logged pulsed interference through block path",
 		  "[core][threading][interference]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(4.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 1.0);
@@ -849,7 +849,7 @@ TEST_CASE("SimulationEngine streaming output applies logged pulsed interference 
 
 TEST_CASE("SimulationEngine keeps streaming source through propagation tail after transmit end", "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 0.4);
@@ -890,7 +890,7 @@ TEST_CASE("SimulationEngine keeps streaming source through propagation tail afte
 
 TEST_CASE("SimulationEngine cleanup preserves moving direct streaming tails", "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
@@ -941,7 +941,7 @@ TEST_CASE("SimulationEngine cleanup preserves moving direct streaming tails", "[
 
 TEST_CASE("SimulationEngine cleanup preserves reflected-only streaming tails", "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
@@ -973,7 +973,7 @@ TEST_CASE("SimulationEngine cleanup preserves reflected-only streaming tails", "
 
 TEST_CASE("SimulationEngine cleanup keeps sources through receiver gaps when tails resume", "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
@@ -1009,7 +1009,7 @@ TEST_CASE("SimulationEngine cleanup keeps sources through receiver gaps when tai
 
 TEST_CASE("SimulationEngine cleanup removes an old segment before a same-time next segment", "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1024.0);
 	params::setOversampleRatio(1);
@@ -1039,7 +1039,7 @@ TEST_CASE("SimulationEngine cleanup removes an old segment before a same-time ne
 
 TEST_CASE("SimulationEngine cleanup skips long future sample-grid scans", "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1.0e9);
 	params::setOversampleRatio(1);
@@ -1064,7 +1064,7 @@ TEST_CASE("SimulationEngine cleanup skips long future sample-grid scans", "[core
 TEST_CASE("SimulationEngine processStreamingPhysics handles active streaming receiver without streaming transmitters",
 		  "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 10.0);
@@ -1093,7 +1093,7 @@ TEST_CASE("SimulationEngine processStreamingPhysics handles active streaming rec
 TEST_CASE("SimulationEngine processStreamingPhysics uses buffered shared timing for streaming samples",
 		  "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(10.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 1.0);
@@ -1163,7 +1163,7 @@ TEST_CASE("SimulationEngine processStreamingPhysics uses buffered shared timing 
 
 TEST_CASE("SimulationEngine phase-noise lookup covers pre-start retarded streaming emissions", "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(10.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 1.0);
@@ -1222,7 +1222,7 @@ TEST_CASE("SimulationEngine phase-noise lookup covers pre-start retarded streami
 TEST_CASE("SimulationEngine native FMCW dechirp produces positive stationary-target beat",
 		  "[core][threading][fmcw][dechirp]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1.0e6);
 	params::setOversampleRatio(1);
@@ -1310,7 +1310,7 @@ TEST_CASE("SimulationEngine native FMCW dechirp produces positive stationary-tar
 TEST_CASE("SimulationEngine physical FMCW dechirp keeps timing decorrelation absent from ideal mode",
 		  "[core][threading][fmcw][dechirp]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(2.0e6);
 	params::setOversampleRatio(1);
@@ -1392,7 +1392,7 @@ TEST_CASE("SimulationEngine physical FMCW dechirp keeps timing decorrelation abs
 
 TEST_CASE("SimulationEngine runEventDrivenSim executes full loop", "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 0.005); // Very short simulation
@@ -1422,7 +1422,7 @@ TEST_CASE("SimulationEngine runEventDrivenSim executes full loop", "[core][threa
 
 TEST_CASE("SimulationEngine reports progress while processing long streaming spans", "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(100.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 1.0);
@@ -1460,7 +1460,7 @@ TEST_CASE("SimulationEngine reports progress while processing long streaming spa
 
 TEST_CASE("SimulationEngine logs FMCW derived chirp counts at startup", "[core][threading][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
 
@@ -1469,8 +1469,8 @@ TEST_CASE("SimulationEngine logs FMCW derived chirp counts at startup", "[core][
 		params::setTime(0.0, 0.26);
 		auto world = createFmcwLoggingWorld(std::nullopt);
 		pool::ThreadPool pool(1);
-		LogLevelGuard log_level(logging::Level::INFO);
-		CerrCapture capture;
+		LogLevelGuard const log_level(logging::Level::INFO);
+		CerrCapture const capture;
 
 		core::SimulationEngine engine(world.get(), pool, nullptr, ".");
 		engine.run();
@@ -1486,8 +1486,8 @@ TEST_CASE("SimulationEngine logs FMCW derived chirp counts at startup", "[core][
 		params::setTime(0.05, 0.45);
 		auto world = createFmcwLoggingWorld(std::size_t{3}, {{-0.05, 0.25}, {0.3, 0.36}});
 		pool::ThreadPool pool(1);
-		LogLevelGuard log_level(logging::Level::INFO);
-		CerrCapture capture;
+		LogLevelGuard const log_level(logging::Level::INFO);
+		CerrCapture const capture;
 
 		core::SimulationEngine engine(world.get(), pool, nullptr, ".");
 		engine.run();
@@ -1507,7 +1507,7 @@ TEST_CASE("SimulationEngine handles Pulsed receiver finalizer thread lifecycle",
 	// This test covers:
 	// 1. initializeFinalizers() -> _finalizer_threads.emplace_back(...)
 	// 6. shutdown() -> else if (PULSED_MODE) { enqueue shutdown_job }
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 0.005);
@@ -1543,7 +1543,7 @@ TEST_CASE("SimulationEngine processStreamingPhysics exits early if t_event <= t_
 {
 	// This test covers:
 	// 2. processStreamingPhysics(t_event) -> if (t_event <= t_current) { return; }
-	ParamGuard guard;
+	ParamGuard const guard;
 	auto world = createPhysicsWorld();
 	pool::ThreadPool pool(1);
 	RecordingOutputSink sink;
@@ -1567,7 +1567,7 @@ TEST_CASE("SimulationEngine processStreamingPhysics exits early if t_event <= t_
 
 TEST_CASE("SimulationEngine processEvent dispatches all event types correctly", "[core][threading]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 10.0);
@@ -1620,7 +1620,7 @@ TEST_CASE("SimulationEngine routeResponse handles null responses safely", "[core
 {
 	// This test covers:
 	// 4. routeResponse(...) -> if (!response) { return; }
-	ParamGuard guard;
+	ParamGuard const guard;
 	auto world = std::make_unique<core::World>();
 
 	// Put Tx and Rx on the EXACT SAME platform to force calculateResponse to return nullptr
@@ -1674,7 +1674,7 @@ TEST_CASE("SimulationEngine updateProgress safely handles null reporter", "[core
 {
 	// This test covers:
 	// 5. updateProgress() -> if (!_reporter) { return; }
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 1.0);
 	auto world = createPhysicsWorld();
 	pool::ThreadPool pool(1);

--- a/packages/libfers/tests/core/test_sim_threading.cpp
+++ b/packages/libfers/tests/core/test_sim_threading.cpp
@@ -47,6 +47,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 
@@ -55,6 +59,10 @@ namespace
 		std::ostringstream buffer;
 		std::streambuf* old{nullptr};
 		CerrCapture() { old = std::cerr.rdbuf(buffer.rdbuf()); }
+		CerrCapture(const CerrCapture&) = delete;
+		CerrCapture& operator=(const CerrCapture&) = delete;
+		CerrCapture(CerrCapture&&) = delete;
+		CerrCapture& operator=(CerrCapture&&) = delete;
 		~CerrCapture() { std::cerr.rdbuf(old); }
 		[[nodiscard]] std::string str() const { return buffer.str(); }
 	};
@@ -62,6 +70,10 @@ namespace
 	struct LogLevelGuard
 	{
 		explicit LogLevelGuard(const logging::Level level) { logging::logger.setLevel(level); }
+		LogLevelGuard(const LogLevelGuard&) = delete;
+		LogLevelGuard& operator=(const LogLevelGuard&) = delete;
+		LogLevelGuard(LogLevelGuard&&) = delete;
+		LogLevelGuard& operator=(LogLevelGuard&&) = delete;
 		~LogLevelGuard() { logging::logger.setLevel(logging::Level::INFO); }
 	};
 

--- a/packages/libfers/tests/core/test_thread_pool.cpp
+++ b/packages/libfers/tests/core/test_thread_pool.cpp
@@ -34,7 +34,7 @@ TEST_CASE("ThreadPool wait tracks pending tasks", "[core][thread_pool]")
 	pool::ThreadPool pool(2);
 
 	std::promise<void> gate;
-	std::shared_future<void> gate_future = gate.get_future().share();
+	std::shared_future<void> const gate_future = gate.get_future().share();
 	std::atomic<int> started{0};
 
 	auto task = [&started, gate_future]

--- a/packages/libfers/tests/core/test_world.cpp
+++ b/packages/libfers/tests/core/test_world.cpp
@@ -49,7 +49,7 @@ namespace
 			EventSnapshot snapshot;
 			snapshot.timestamp = timestamp;
 			snapshot.type = type;
-			snapshot.source_name = source ? source->getName() : std::string{};
+			snapshot.source_name = (source != nullptr) ? source->getName() : std::string{};
 			events.push_back(std::move(snapshot));
 		}
 		return events;

--- a/packages/libfers/tests/core/test_world.cpp
+++ b/packages/libfers/tests/core/test_world.cpp
@@ -24,6 +24,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/core/test_world.cpp
+++ b/packages/libfers/tests/core/test_world.cpp
@@ -418,13 +418,13 @@ TEST_CASE("World clear resets storage and state", "[core][world]")
 
 TEST_CASE("World schedules pulsed transmitter events", "[core][world]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 10.0);
 
 	core::World world;
 	auto platform = std::make_unique<radar::Platform>("Platform-Tx", 1);
 	auto tx = std::make_unique<radar::Transmitter>(platform.get(), "Tx-Pulsed", radar::OperationMode::PULSED_MODE, 2);
-	std::vector<radar::SchedulePeriod> schedule = {{2.0, 3.0}, {6.0, 7.0}};
+	std::vector<radar::SchedulePeriod> const schedule = {{2.0, 3.0}, {6.0, 7.0}};
 	tx->setSchedule(schedule);
 	world.add(std::move(platform));
 	world.add(std::move(tx));
@@ -440,13 +440,13 @@ TEST_CASE("World schedules pulsed transmitter events", "[core][world]")
 
 TEST_CASE("World schedules CW transmitter events with bounds", "[core][world]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 10.0);
 
 	core::World world;
 	auto platform = std::make_unique<radar::Platform>("Platform-Tx", 1);
 	auto tx = std::make_unique<radar::Transmitter>(platform.get(), "Tx-CW", radar::OperationMode::CW_MODE, 2);
-	std::vector<radar::SchedulePeriod> schedule = {{-5.0, 1.0}, {3.0, 5.0}, {9.0, 12.0}};
+	std::vector<radar::SchedulePeriod> const schedule = {{-5.0, 1.0}, {3.0, 5.0}, {9.0, 12.0}};
 	tx->setSchedule(schedule);
 	world.add(std::move(platform));
 	world.add(std::move(tx));
@@ -475,7 +475,7 @@ TEST_CASE("World schedules CW transmitter events with bounds", "[core][world]")
 
 TEST_CASE("World schedules CW transmitter always-on when schedule empty", "[core][world]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(1.5, 4.5);
 
 	core::World world;
@@ -496,7 +496,7 @@ TEST_CASE("World schedules CW transmitter always-on when schedule empty", "[core
 
 TEST_CASE("World schedules pulsed receiver events", "[core][world]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 10.0);
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
@@ -506,7 +506,7 @@ TEST_CASE("World schedules pulsed receiver events", "[core][world]")
 	auto rx = std::make_unique<radar::Receiver>(platform.get(), "Rx-Pulsed", 3, radar::OperationMode::PULSED_MODE, 4);
 	rx->setWindowProperties(1.0, 2.0, 0.5);
 	rx->setTiming(std::make_shared<timing::Timing>("RxClock", 11));
-	std::vector<radar::SchedulePeriod> schedule = {{2.0, 3.0}, {6.0, 7.0}};
+	std::vector<radar::SchedulePeriod> const schedule = {{2.0, 3.0}, {6.0, 7.0}};
 	rx->setSchedule(schedule);
 	world.add(std::move(platform));
 	world.add(std::move(rx));
@@ -522,13 +522,13 @@ TEST_CASE("World schedules pulsed receiver events", "[core][world]")
 
 TEST_CASE("World schedules CW receiver events with bounds", "[core][world]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 10.0);
 
 	core::World world;
 	auto platform = std::make_unique<radar::Platform>("Platform-Rx", 1);
 	auto rx = std::make_unique<radar::Receiver>(platform.get(), "Rx-CW", 3, radar::OperationMode::CW_MODE, 4);
-	std::vector<radar::SchedulePeriod> schedule = {{-1.0, 2.0}, {4.0, 6.0}, {9.0, 11.0}};
+	std::vector<radar::SchedulePeriod> const schedule = {{-1.0, 2.0}, {4.0, 6.0}, {9.0, 11.0}};
 	rx->setSchedule(schedule);
 	world.add(std::move(platform));
 	world.add(std::move(rx));
@@ -557,7 +557,7 @@ TEST_CASE("World schedules CW receiver events with bounds", "[core][world]")
 
 TEST_CASE("World schedules CW receiver always-on when schedule empty", "[core][world]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(2.0, 5.0);
 
 	core::World world;

--- a/packages/libfers/tests/interpolation/test_interpolation_filter.cpp
+++ b/packages/libfers/tests/interpolation/test_interpolation_filter.cpp
@@ -20,7 +20,7 @@ TEST_CASE("InterpFilter Kaiser window symmetry", "[interpolation][filter]")
 {
 	const auto length = params::renderFilterLength();
 	const RealType alpha = std::floor(length / 2.0);
-	interp::InterpFilter& filter = interp::InterpFilter::getInstance();
+	interp::InterpFilter const& filter = interp::InterpFilter::getInstance();
 
 	auto left = filter.kaiserWinCompute(alpha - 0.25);
 	auto right = filter.kaiserWinCompute(alpha + 0.25);
@@ -33,7 +33,7 @@ TEST_CASE("InterpFilter Kaiser window normalization", "[interpolation][filter]")
 {
 	const auto length = params::renderFilterLength();
 	const RealType alpha = std::floor(length / 2.0);
-	interp::InterpFilter& filter = interp::InterpFilter::getInstance();
+	interp::InterpFilter const& filter = interp::InterpFilter::getInstance();
 
 	auto center = filter.kaiserWinCompute(alpha);
 	REQUIRE(center.has_value());
@@ -44,7 +44,7 @@ TEST_CASE("InterpFilter Kaiser window clamps outside support", "[interpolation][
 {
 	const auto length = params::renderFilterLength();
 	const RealType alpha = std::floor(length / 2.0);
-	interp::InterpFilter& filter = interp::InterpFilter::getInstance();
+	interp::InterpFilter const& filter = interp::InterpFilter::getInstance();
 
 	auto below = filter.kaiserWinCompute(-0.1);
 	REQUIRE(below.has_value());
@@ -57,7 +57,7 @@ TEST_CASE("InterpFilter Kaiser window clamps outside support", "[interpolation][
 
 TEST_CASE("InterpFilter windowed sinc at zero", "[interpolation][filter]")
 {
-	interp::InterpFilter& filter = interp::InterpFilter::getInstance();
+	interp::InterpFilter const& filter = interp::InterpFilter::getInstance();
 	auto value = filter.interpFilter(0.0);
 	REQUIRE(value.has_value());
 	REQUIRE_THAT(*value, WithinAbs(1.0, 1e-9));
@@ -67,7 +67,7 @@ TEST_CASE("InterpFilter windowed sinc outside support", "[interpolation][filter]
 {
 	const auto length = params::renderFilterLength();
 	const RealType alpha = std::floor(length / 2.0);
-	interp::InterpFilter& filter = interp::InterpFilter::getInstance();
+	interp::InterpFilter const& filter = interp::InterpFilter::getInstance();
 
 	auto value = filter.interpFilter(-alpha - 0.5);
 	REQUIRE(value.has_value());
@@ -78,7 +78,7 @@ TEST_CASE("InterpFilter getFilter returns length and center", "[interpolation][f
 {
 	const auto length = params::renderFilterLength();
 	const RealType alpha = std::floor(length / 2.0);
-	interp::InterpFilter& filter = interp::InterpFilter::getInstance();
+	interp::InterpFilter const& filter = interp::InterpFilter::getInstance();
 
 	auto span = filter.getFilter(0.0);
 	REQUIRE(span.size() == length);
@@ -87,14 +87,14 @@ TEST_CASE("InterpFilter getFilter returns length and center", "[interpolation][f
 
 TEST_CASE("InterpFilter getFilter rejects out of range", "[interpolation][filter]")
 {
-	interp::InterpFilter& filter = interp::InterpFilter::getInstance();
+	interp::InterpFilter const& filter = interp::InterpFilter::getInstance();
 	REQUIRE_THROWS_AS(filter.getFilter(1.1), std::runtime_error);
 	REQUIRE_THROWS_AS(filter.getFilter(-1.1), std::runtime_error);
 }
 
 TEST_CASE("InterpFilter getFilter keeps the upper boundary in range", "[interpolation][filter]")
 {
-	interp::InterpFilter& filter = interp::InterpFilter::getInstance();
+	interp::InterpFilter const& filter = interp::InterpFilter::getInstance();
 
 	const auto last_filter = filter.getFilter(1.0);
 	const auto near_last_filter = filter.getFilter(0.999);

--- a/packages/libfers/tests/interpolation/test_interpolation_set.cpp
+++ b/packages/libfers/tests/interpolation/test_interpolation_set.cpp
@@ -31,7 +31,7 @@ TEST_CASE("InterpSetData clamps before first sample", "[interpolation][set]")
 
 	auto value = data.value(1.0);
 	REQUIRE(value.has_value());
-	REQUIRE_THAT(*value, WithinAbs(10.0, 1e-12));
+	REQUIRE_THAT(value.value_or(0.0), WithinAbs(10.0, 1e-12));
 }
 
 TEST_CASE("InterpSetData clamps after last sample", "[interpolation][set]")
@@ -42,7 +42,7 @@ TEST_CASE("InterpSetData clamps after last sample", "[interpolation][set]")
 
 	auto value = data.value(10.0);
 	REQUIRE(value.has_value());
-	REQUIRE_THAT(*value, WithinAbs(-15.0, 1e-12));
+	REQUIRE_THAT(value.value_or(0.0), WithinAbs(-15.0, 1e-12));
 }
 
 TEST_CASE("InterpSetData returns exact sample", "[interpolation][set]")
@@ -53,7 +53,7 @@ TEST_CASE("InterpSetData returns exact sample", "[interpolation][set]")
 
 	auto value = data.value(2.0);
 	REQUIRE(value.has_value());
-	REQUIRE_THAT(*value, WithinAbs(4.0, 1e-12));
+	REQUIRE_THAT(value.value_or(0.0), WithinAbs(4.0, 1e-12));
 }
 
 TEST_CASE("InterpSetData linearly interpolates", "[interpolation][set]")
@@ -64,7 +64,7 @@ TEST_CASE("InterpSetData linearly interpolates", "[interpolation][set]")
 
 	auto mid = data.value(2.5);
 	REQUIRE(mid.has_value());
-	REQUIRE_THAT(*mid, WithinAbs(5.0, 1e-12));
+	REQUIRE_THAT(mid.value_or(0.0), WithinAbs(5.0, 1e-12));
 }
 
 TEST_CASE("InterpSetData linearly interpolates float queries", "[interpolation][set]")
@@ -75,7 +75,7 @@ TEST_CASE("InterpSetData linearly interpolates float queries", "[interpolation][
 
 	auto mid = data.value(2.5f);
 	REQUIRE(mid.has_value());
-	REQUIRE_THAT(*mid, WithinAbs(5.0f, 1e-6f));
+	REQUIRE_THAT(mid.value_or(0.0f), WithinAbs(5.0f, 1e-6f));
 }
 
 TEST_CASE("InterpSetData max uses absolute magnitude", "[interpolation][set]")
@@ -97,7 +97,7 @@ TEST_CASE("InterpSetData divide scales values", "[interpolation][set]")
 
 	auto value = data.value(2.0);
 	REQUIRE(value.has_value());
-	REQUIRE_THAT(*value, WithinAbs(3.0, 1e-12));
+	REQUIRE_THAT(value.value_or(0.0), WithinAbs(3.0, 1e-12));
 }
 
 TEST_CASE("InterpSetData divide rejects zero", "[interpolation][set]")
@@ -115,12 +115,12 @@ TEST_CASE("InterpSet wrapper supports float interpolation", "[interpolation][set
 
 	auto value = set.getValueAt(0.5f);
 	REQUIRE(value.has_value());
-	REQUIRE_THAT(*value, WithinAbs(0.5f, 1e-6f));
+	REQUIRE_THAT(value.value_or(0.0f), WithinAbs(0.5f, 1e-6f));
 
 	set.divide(2.0f);
 	auto scaled = set.getValueAt(0.5f);
 	REQUIRE(scaled.has_value());
-	REQUIRE_THAT(*scaled, WithinAbs(0.25f, 1e-6f));
+	REQUIRE_THAT(scaled.value_or(0.0f), WithinAbs(0.25f, 1e-6f));
 }
 
 TEST_CASE("InterpSet wrapper exposes max", "[interpolation][set]")

--- a/packages/libfers/tests/interpolation/test_interpolation_set.cpp
+++ b/packages/libfers/tests/interpolation/test_interpolation_set.cpp
@@ -18,7 +18,7 @@ TEST_CASE("InterpPoint defaults to zeros", "[interpolation][point]")
 
 TEST_CASE("InterpSetData returns nullopt when empty", "[interpolation][set]")
 {
-	interp::InterpSetData data;
+	interp::InterpSetData const data;
 	REQUIRE_FALSE(data.value(0.0).has_value());
 	REQUIRE_THAT(data.max(), WithinAbs(0.0, 0.0));
 }
@@ -109,7 +109,7 @@ TEST_CASE("InterpSetData divide rejects zero", "[interpolation][set]")
 
 TEST_CASE("InterpSet wrapper supports float interpolation", "[interpolation][set]")
 {
-	interp::InterpSet set;
+	interp::InterpSet const set;
 	set.insertSample(0.0f, 0.0f);
 	set.insertSample(1.0f, 1.0f);
 
@@ -125,7 +125,7 @@ TEST_CASE("InterpSet wrapper supports float interpolation", "[interpolation][set
 
 TEST_CASE("InterpSet wrapper exposes max", "[interpolation][set]")
 {
-	interp::InterpSet set;
+	interp::InterpSet const set;
 	set.insertSample(0.0, -2.0);
 	set.insertSample(1.0, 1.0);
 	REQUIRE_THAT(set.getMax(), WithinAbs(2.0, 1e-12));

--- a/packages/libfers/tests/math/test_coord.cpp
+++ b/packages/libfers/tests/math/test_coord.cpp
@@ -28,8 +28,8 @@ TEST_CASE("Coord Struct Operations", "[math][coord]")
 
 	SECTION("Coord Arithmetic")
 	{
-		Coord c1{Vec3(1, 2, 3), 1.0};
-		Coord c2{Vec3(4, 5, 6), 1.0};
+		Coord const c1{Vec3(1, 2, 3), 1.0};
+		Coord const c2{Vec3(4, 5, 6), 1.0};
 
 		Coord sum = c1 + c2;
 		REQUIRE_THAT(sum.pos.x, WithinAbs(5.0, 1e-9));
@@ -47,7 +47,7 @@ TEST_CASE("Coord Struct Operations", "[math][coord]")
 
 	SECTION("Coord Scalar Arithmetic")
 	{
-		Coord c{Vec3(2, 4, 8), 10.0};
+		Coord const c{Vec3(2, 4, 8), 10.0};
 
 		Coord res = c * 2.0;
 		REQUIRE_THAT(res.pos.x, WithinAbs(4.0, 1e-9));
@@ -68,7 +68,7 @@ TEST_CASE("RotationCoord Struct Operations", "[math][coord]")
 {
 	SECTION("Constructors and Assignment")
 	{
-		RotationCoord r1;
+		RotationCoord const r1;
 		REQUIRE(r1.azimuth == 0.0);
 
 		RotationCoord r2(5.0);
@@ -89,8 +89,8 @@ TEST_CASE("RotationCoord Struct Operations", "[math][coord]")
 
 	SECTION("Arithmetic")
 	{
-		RotationCoord a(1.0, 2.0, 10.0);
-		RotationCoord b(2.0, 3.0, 20.0);
+		RotationCoord const a(1.0, 2.0, 10.0);
+		RotationCoord const b(2.0, 3.0, 20.0);
 
 		RotationCoord c = a + b;
 		REQUIRE_THAT(c.azimuth, WithinAbs(3.0, 1e-9));
@@ -108,7 +108,7 @@ TEST_CASE("RotationCoord Struct Operations", "[math][coord]")
 
 	SECTION("Scalar Arithmetic")
 	{
-		RotationCoord a(2.0, 4.0, 10.0);
+		RotationCoord const a(2.0, 4.0, 10.0);
 
 		RotationCoord c = a * 2.0;
 		REQUIRE_THAT(c.elevation, WithinAbs(8.0, 1e-9));

--- a/packages/libfers/tests/math/test_geometry_ops.cpp
+++ b/packages/libfers/tests/math/test_geometry_ops.cpp
@@ -11,12 +11,12 @@ constexpr RealType PI_VAL = std::numbers::pi_v<RealType>;
 
 TEST_CASE("Vec3 Construction and Basic Access", "[math][geometry][vec3]")
 {
-	Vec3 v_default;
+	Vec3 const v_default;
 	REQUIRE(v_default.x == 0.0);
 	REQUIRE(v_default.y == 0.0);
 	REQUIRE(v_default.z == 0.0);
 
-	Vec3 v_param(1.0, -2.5, 3.14);
+	Vec3 const v_param(1.0, -2.5, 3.14);
 	REQUIRE(v_param.x == 1.0);
 	REQUIRE(v_param.y == -2.5);
 	REQUIRE(v_param.z == 3.14);
@@ -64,7 +64,7 @@ TEST_CASE("Vec3 Arithmetic Operators", "[math][geometry][vec3]")
 TEST_CASE("Vec3 Scalar Operations", "[math][geometry][vec3]")
 {
 	Vec3 v(2.0, 4.0, 8.0);
-	RealType s = 2.0;
+	RealType const s = 2.0;
 
 	SECTION("Multiplication")
 	{
@@ -87,15 +87,15 @@ TEST_CASE("Vec3 Scalar Operations", "[math][geometry][vec3]")
 
 TEST_CASE("Vec3 Advanced Math", "[math][geometry][vec3]")
 {
-	Vec3 v(3.0, 4.0, 0.0);
+	Vec3 const v(3.0, 4.0, 0.0);
 
 	SECTION("Length") { REQUIRE_THAT(v.length(), WithinAbs(5.0, 1e-9)); }
 
 	SECTION("Dot Product")
 	{
-		Vec3 a(1, 0, 0);
-		Vec3 b(0, 1, 0);
-		Vec3 c(2, 2, 0);
+		Vec3 const a(1, 0, 0);
+		Vec3 const b(0, 1, 0);
+		Vec3 const c(2, 2, 0);
 		REQUIRE_THAT(dotProduct(a, b), WithinAbs(0.0, 1e-9)); // Orthogonal
 		REQUIRE_THAT(dotProduct(a, c), WithinAbs(2.0, 1e-9));
 	}
@@ -114,12 +114,12 @@ TEST_CASE("SVec3 (Spherical) Operations", "[math][geometry][svec3]")
 {
 	SECTION("Conversion from Vec3")
 	{
-		Vec3 vx(10.0, 0.0, 0.0);
+		Vec3 const vx(10.0, 0.0, 0.0);
 		SVec3 svx(vx);
 		REQUIRE_THAT(svx.length, WithinAbs(10.0, 1e-9));
 		REQUIRE_THAT(svx.azimuth, WithinAbs(0.0, 1e-9));
 
-		Vec3 vz(0.0, 0.0, 5.0);
+		Vec3 const vz(0.0, 0.0, 5.0);
 		SVec3 svz(vz);
 		REQUIRE_THAT(svz.elevation, WithinAbs(PI_VAL / 2.0, 1e-9));
 
@@ -139,14 +139,14 @@ TEST_CASE("SVec3 (Spherical) Operations", "[math][geometry][svec3]")
 	SECTION("Addition with Wrapping")
 	{
 		// Normal addition
-		SVec3 s1(1.0, 0.5, 0.0);
-		SVec3 s2(1.0, 0.5, 0.0);
+		SVec3 const s1(1.0, 0.5, 0.0);
+		SVec3 const s2(1.0, 0.5, 0.0);
 		SVec3 sum = s1 + s2;
 		REQUIRE_THAT(sum.azimuth, WithinAbs(1.0, 1e-9));
 
 		// fmod(-1.5 * PI, 2 * PI) = -1.5 * PI in C++. We must wrap this to +0.5 * PI.
-		SVec3 s3(1.0, -PI_VAL, 0.0);
-		SVec3 s4(1.0, -PI_VAL / 2.0, 0.0);
+		SVec3 const s3(1.0, -PI_VAL, 0.0);
+		SVec3 const s4(1.0, -PI_VAL / 2.0, 0.0);
 		SVec3 sum_neg = s3 + s4;
 		REQUIRE_THAT(sum_neg.azimuth, WithinAbs(PI_VAL / 2.0, 1e-9)); // Physically correct wrapping
 	}
@@ -154,20 +154,20 @@ TEST_CASE("SVec3 (Spherical) Operations", "[math][geometry][svec3]")
 	SECTION("Subtraction with Shortest Path Wrapping")
 	{
 		// Normal subtraction
-		SVec3 s1(1.0, 1.0, 0.0);
-		SVec3 s2(1.0, 0.5, 0.0);
+		SVec3 const s1(1.0, 1.0, 0.0);
+		SVec3 const s2(1.0, 0.5, 0.0);
 		SVec3 diff = s1 - s2;
 		REQUIRE_THAT(diff.azimuth, WithinAbs(0.5, 1e-9));
 
 		// 10 degrees - 350 degrees = -340 degrees -> should wrap to +20 degrees
-		SVec3 s3(1.0, 0.1, 0.0);
-		SVec3 s4(1.0, 2 * PI_VAL - 0.1, 0.0);
+		SVec3 const s3(1.0, 0.1, 0.0);
+		SVec3 const s4(1.0, 2 * PI_VAL - 0.1, 0.0);
 		SVec3 diff_neg_wrap = s3 - s4;
 		REQUIRE_THAT(diff_neg_wrap.azimuth, WithinAbs(0.2, 1e-9));
 
 		// 350 degrees - 10 degrees = 340 degrees -> should wrap to -20 degrees
-		SVec3 s5(1.0, 2 * PI_VAL - 0.1, 0.0);
-		SVec3 s6(1.0, 0.1, 0.0);
+		SVec3 const s5(1.0, 2 * PI_VAL - 0.1, 0.0);
+		SVec3 const s6(1.0, 0.1, 0.0);
 		SVec3 diff_pos_wrap = s5 - s6;
 		REQUIRE_THAT(diff_pos_wrap.azimuth, WithinAbs(-0.2, 1e-9)); // Physically shortest path
 	}

--- a/packages/libfers/tests/math/test_path.cpp
+++ b/packages/libfers/tests/math/test_path.cpp
@@ -30,7 +30,7 @@ TEST_CASE("Path: Error Handling and Edge Cases", "[math][path]")
 	SECTION("Velocity on Empty Path")
 	{
 		p.finalize();
-		Vec3 v = p.getVelocity(0);
+		Vec3 const v = p.getVelocity(0);
 		REQUIRE(v.length() == 0.0);
 	}
 
@@ -46,7 +46,7 @@ TEST_CASE("Path: Error Handling and Edge Cases", "[math][path]")
 		Path p_invalid(static_cast<Path::InterpType>(999));
 		p_invalid.addCoord({Vec3(0, 0, 0), 0.0});
 		p_invalid.finalize();
-		Vec3 v = p_invalid.getVelocity(0.0);
+		Vec3 const v = p_invalid.getVelocity(0.0);
 		REQUIRE(v.length() == 0.0);
 	}
 }
@@ -61,7 +61,7 @@ TEST_CASE("Path: Static Interpolation", "[math][path]")
 	Vec3 pos = p.getPosition(5.0);
 	REQUIRE_THAT(pos.x, WithinAbs(1.0, 1e-9));
 
-	Vec3 vel = p.getVelocity(5.0);
+	Vec3 const vel = p.getVelocity(5.0);
 	REQUIRE(vel.length() == 0.0);
 }
 
@@ -73,7 +73,7 @@ TEST_CASE("Path: Linear Interpolation Velocity Edge Cases", "[math][path]")
 	{
 		p.addCoord({Vec3(10, 0, 0), 1.0});
 		p.finalize();
-		Vec3 vel = p.getVelocity(1.0);
+		Vec3 const vel = p.getVelocity(1.0);
 		REQUIRE(vel.length() == 0.0); // No delta T, velocity is 0
 	}
 
@@ -82,7 +82,7 @@ TEST_CASE("Path: Linear Interpolation Velocity Edge Cases", "[math][path]")
 		p.addCoord({Vec3(0, 0, 0), 1.0});
 		p.addCoord({Vec3(10, 0, 0), 1.0}); // Physically impossible, but mathematically handled
 		p.finalize();
-		Vec3 vel = p.getVelocity(1.0);
+		Vec3 const vel = p.getVelocity(1.0);
 		REQUIRE(vel.length() == 0.0); // Prevent divide by zero
 	}
 
@@ -111,10 +111,10 @@ TEST_CASE("Path: Cubic Interpolation Velocity Edge Cases", "[math][path]")
 		p.addCoord({Vec3(20, 0, 0), 3.0});
 		p.finalize();
 
-		Vec3 vel_before = p.getVelocity(0.0);
+		Vec3 const vel_before = p.getVelocity(0.0);
 		REQUIRE(vel_before.x > 0.0); // Velocity should be correctly extrapolated
 
-		Vec3 vel_after = p.getVelocity(4.0);
+		Vec3 const vel_after = p.getVelocity(4.0);
 		REQUIRE(vel_after.x > 0.0);
 	}
 
@@ -125,14 +125,14 @@ TEST_CASE("Path: Cubic Interpolation Velocity Edge Cases", "[math][path]")
 		p.addCoord({Vec3(20, 0, 0), 2.0});
 		p.finalize();
 
-		Vec3 vel = p.getVelocity(0.5);
+		Vec3 const vel = p.getVelocity(0.5);
 		REQUIRE(vel.length() == 0.0); // Prevent divide by zero
 	}
 }
 
 TEST_CASE("Path Utils: Direct Template Calls", "[math][path]")
 {
-	std::vector<Coord> empty_coords;
+	std::vector<Coord> const empty_coords;
 	Coord out;
 	std::vector<Coord> dd;
 
@@ -140,7 +140,8 @@ TEST_CASE("Path Utils: Direct Template Calls", "[math][path]")
 
 	REQUIRE_THROWS_AS(getPositionCubic(0.0, out, empty_coords, dd), PathException);
 
-	std::vector<Coord> coords = {Coord{Vec3(0, 0, 0), 1.0}, Coord{Vec3(10, 0, 0), 2.0}, Coord{Vec3(20, 0, 0), 3.0}};
+	std::vector<Coord> const coords = {Coord{Vec3(0, 0, 0), 1.0}, Coord{Vec3(10, 0, 0), 2.0},
+									   Coord{Vec3(20, 0, 0), 3.0}};
 	finalizeCubic(coords, dd);
 
 	getPositionCubic(0.0, out, coords, dd);

--- a/packages/libfers/tests/math/test_rotation_path.cpp
+++ b/packages/libfers/tests/math/test_rotation_path.cpp
@@ -39,7 +39,7 @@ TEST_CASE("RotationPath: Accessors and State", "[math][rotation_path]")
 
 	SECTION("Start Coordinate Accessor")
 	{
-		RotationCoord start_val(1.5, 2.5, 0.0);
+		RotationCoord const start_val(1.5, 2.5, 0.0);
 		rp.setStart(start_val);
 
 		RotationCoord s = rp.getStart();
@@ -49,7 +49,7 @@ TEST_CASE("RotationPath: Accessors and State", "[math][rotation_path]")
 
 	SECTION("Rate Accessor")
 	{
-		RotationCoord rate_val(0.1, 0.2, 0.0);
+		RotationCoord const rate_val(0.1, 0.2, 0.0);
 		rp.setRate(rate_val);
 
 		RotationCoord r = rp.getRate();
@@ -84,8 +84,8 @@ TEST_CASE("RotationPath: Cubic Interpolation", "[math][rotation_path]")
 TEST_CASE("RotationPath: Constant Rate", "[math][rotation_path]")
 {
 	RotationPath rp;
-	RotationCoord start(0.0, 0.0, 0.0);
-	RotationCoord rate(PI_VAL, 0.0, 0.0);
+	RotationCoord const start(0.0, 0.0, 0.0);
+	RotationCoord const rate(PI_VAL, 0.0, 0.0);
 
 	rp.setConstantRate(start, rate);
 

--- a/packages/libfers/tests/noise/test_falpha_branch.cpp
+++ b/packages/libfers/tests/noise/test_falpha_branch.cpp
@@ -94,9 +94,9 @@ TEST_CASE("FAlphaBranch non-last branch matches upsampled pre-offset buffer", "[
 		}
 	}
 
-	for (size_t i = 0; i < expected.size(); ++i)
+	for (const RealType expected_sample : expected)
 	{
-		REQUIRE_THAT(branch.getSample(), WithinAbs(expected[i], 1e-12));
+		REQUIRE_THAT(branch.getSample(), WithinAbs(expected_sample, 1e-12));
 	}
 }
 

--- a/packages/libfers/tests/noise/test_falpha_branch.cpp
+++ b/packages/libfers/tests/noise/test_falpha_branch.cpp
@@ -67,7 +67,7 @@ TEST_CASE("FAlphaBranch non-last branch matches upsampled pre-offset buffer", "[
 	noise::FAlphaBranch branch(rng_branch, ffrac, fint, std::move(pre), false);
 
 	fers_signal::IirFilter highpass(kHighpassDen.data(), kHighpassNum.data(), kHighpassDen.size());
-	fers_signal::DecadeUpsampler upsampler;
+	fers_signal::DecadeUpsampler const upsampler;
 	std::normal_distribution<> dist_main(0.0, 1.0);
 	std::normal_distribution<> dist_pre(0.0, 1.0);
 

--- a/packages/libfers/tests/noise/test_noise_generators.cpp
+++ b/packages/libfers/tests/noise/test_noise_generators.cpp
@@ -127,7 +127,7 @@ TEST_CASE("MultirateGenerator skipSamples handles short and long skips", "[noise
 
 TEST_CASE("ClockModelGenerator applies offsets and respects sample count", "[noise][clock]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.rate = 100.0;
 
 	std::mt19937 rng(11);
@@ -154,7 +154,7 @@ TEST_CASE("ClockModelGenerator applies offsets and respects sample count", "[noi
 
 TEST_CASE("ClockModelGenerator handles weight scaling branches", "[noise][clock]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.rate = 100.0;
 
 	std::mt19937 rng(29);

--- a/packages/libfers/tests/noise/test_noise_generators.cpp
+++ b/packages/libfers/tests/noise/test_noise_generators.cpp
@@ -19,6 +19,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/processing/test_finalizer.cpp
+++ b/packages/libfers/tests/processing/test_finalizer.cpp
@@ -316,7 +316,7 @@ TEST_CASE("buildReceiverSampleBlock captures receiver identity, timing, and samp
 	REQUIRE_THAT(block.stream.fmcw.chirp_period, WithinAbs(3.0e-3, 1e-12));
 	REQUIRE_THAT(block.stream.fmcw.chirp_rate, WithinAbs(20.0e9, 1e-3));
 	REQUIRE(block.stream.fmcw.chirp_count.has_value());
-	REQUIRE(*block.stream.fmcw.chirp_count == 7u);
+	REQUIRE(block.stream.fmcw.chirp_count.value_or(0u) == 7u);
 	REQUIRE_THAT(block.stream.sample_rate, WithinAbs(2.0e6, 1e-12));
 	REQUIRE_THAT(block.stream.reference_frequency, WithinAbs(10.5e9, 1e-6));
 	REQUIRE_THAT(block.first_sample_time, WithinAbs(1.25, 1e-12));
@@ -389,11 +389,13 @@ TEST_CASE("buildStreamingOutputMetadata records FMCW source metadata for detache
 	REQUIRE_THAT(source_metadata.waveform.chirp_rate_signed, WithinAbs(200'000.0, 1e-12));
 	REQUIRE(source_metadata.waveform.chirp_count == std::optional<std::uint64_t>{4});
 	REQUIRE(source_metadata.segments.size() == 1u);
-	REQUIRE_THAT(*source_metadata.segments.front().first_chirp_start_time, WithinAbs(0.0, 1e-12));
+	REQUIRE(source_metadata.segments.front().first_chirp_start_time.has_value());
+	REQUIRE_THAT(source_metadata.segments.front().first_chirp_start_time.value_or(1.0), WithinAbs(0.0, 1e-12));
 	REQUIRE(source_metadata.segments.front().emitted_chirp_count == std::optional<std::uint64_t>{4});
 
 	const auto& streaming_segment = metadata.streaming_segments.front();
-	REQUIRE_THAT(*streaming_segment.first_chirp_start_time, WithinAbs(0.0, 1e-12));
+	REQUIRE(streaming_segment.first_chirp_start_time.has_value());
+	REQUIRE_THAT(streaming_segment.first_chirp_start_time.value_or(1.0), WithinAbs(0.0, 1e-12));
 	REQUIRE(streaming_segment.emitted_chirp_count == std::optional<std::uint64_t>{4});
 }
 
@@ -440,7 +442,8 @@ TEST_CASE("buildStreamingOutputMetadata writes IF-rate FMCW metadata", "[process
 	REQUIRE(metadata.fmcw_if_resample_numerator == 1u);
 	REQUIRE(metadata.fmcw_if_resample_denominator == 4u);
 	REQUIRE(metadata.fmcw_if_sample_rate == std::optional<RealType>{64.0});
-	REQUIRE_THAT(*metadata.fmcw_if_filter_group_delay_seconds, WithinAbs(plan.group_delay_seconds, 1e-12));
+	REQUIRE(metadata.fmcw_if_filter_group_delay_seconds.has_value());
+	REQUIRE_THAT(metadata.fmcw_if_filter_group_delay_seconds.value_or(0.0), WithinAbs(plan.group_delay_seconds, 1e-12));
 	REQUIRE(metadata.fmcw_if_group_delay_compensated);
 	REQUIRE(metadata.streaming_segments.front().sample_count == 64u);
 }

--- a/packages/libfers/tests/processing/test_finalizer.cpp
+++ b/packages/libfers/tests/processing/test_finalizer.cpp
@@ -175,6 +175,55 @@ namespace
 		int total;
 	};
 
+	void requireJitteredPulsedChunks(const std::filesystem::path& output_path)
+	{
+		HighFive::File const file(output_path.string(), HighFive::File::ReadOnly);
+		const auto i_chunk_0 = readDataset(file, "chunk_000000_I");
+		const auto q_chunk_0 = readDataset(file, "chunk_000000_Q");
+		const auto i_chunk_1 = readDataset(file, "chunk_000001_I");
+		const auto q_chunk_1 = readDataset(file, "chunk_000001_Q");
+
+		RealType time_attr_0 = 0.0;
+		RealType time_attr_1 = 0.0;
+		file.getDataSet("chunk_000000_I").getAttribute("time").read(time_attr_0);
+		file.getDataSet("chunk_000001_I").getAttribute("time").read(time_attr_1);
+
+		REQUIRE(i_chunk_0.size() == 4u);
+		REQUIRE(q_chunk_0.size() == 4u);
+		REQUIRE(i_chunk_1.size() == 4u);
+		REQUIRE(q_chunk_1.size() == 4u);
+
+		for (const auto& sample : i_chunk_0)
+		{
+			REQUIRE_THAT(sample, WithinAbs(0.0, 1e-12));
+		}
+		for (const auto& sample : i_chunk_1)
+		{
+			REQUIRE_THAT(sample, WithinAbs(0.0, 1e-12));
+		}
+		REQUIRE_THAT(q_chunk_0[0], WithinAbs(1.0, 1e-12));
+		REQUIRE_THAT(q_chunk_0[1], WithinAbs(1.0, 1e-12));
+		REQUIRE_THAT(q_chunk_0[2], WithinAbs(0.0, 1e-12));
+		REQUIRE_THAT(q_chunk_0[3], WithinAbs(0.0, 1e-12));
+		REQUIRE_THAT(q_chunk_1[0], WithinAbs(1.0, 1e-12));
+		REQUIRE_THAT(q_chunk_1[1], WithinAbs(1.0, 1e-12));
+		REQUIRE_THAT(q_chunk_1[2], WithinAbs(0.0, 1e-12));
+		REQUIRE_THAT(q_chunk_1[3], WithinAbs(0.0, 1e-12));
+		REQUIRE_THAT(time_attr_0, WithinAbs(0.125, 1e-12));
+		REQUIRE_THAT(time_attr_1, WithinAbs(1.125, 1e-12));
+	}
+
+	[[nodiscard]] bool hasCompletionProgress(const std::vector<ProgressCall>& progress_calls,
+											 const std::string& receiver_name)
+	{
+		return std::ranges::any_of(progress_calls,
+								   [&receiver_name](const ProgressCall& call)
+								   {
+									   return call.message == "Finished Exporting " + receiver_name &&
+										   call.current == 100 && call.total == 100;
+								   });
+	}
+
 	struct CapturedSinkBlock
 	{
 		core::ReceiverStreamDescriptor stream;
@@ -540,46 +589,8 @@ TEST_CASE("runPulsedFinalizer writes jittered chunks and emits completion progre
 	worker.join();
 	hdf5_sink->finalize();
 
-	{
-		HighFive::File const file(output_path.string(), HighFive::File::ReadOnly);
-		const auto i_chunk_0 = readDataset(file, "chunk_000000_I");
-		const auto q_chunk_0 = readDataset(file, "chunk_000000_Q");
-		const auto i_chunk_1 = readDataset(file, "chunk_000001_I");
-		const auto q_chunk_1 = readDataset(file, "chunk_000001_Q");
-
-		RealType time_attr_0 = 0.0;
-		RealType time_attr_1 = 0.0;
-		file.getDataSet("chunk_000000_I").getAttribute("time").read(time_attr_0);
-		file.getDataSet("chunk_000001_I").getAttribute("time").read(time_attr_1);
-
-		REQUIRE(i_chunk_0.size() == 4u);
-		REQUIRE(q_chunk_0.size() == 4u);
-		REQUIRE(i_chunk_1.size() == 4u);
-		REQUIRE(q_chunk_1.size() == 4u);
-
-		for (const auto& sample : i_chunk_0)
-		{
-			REQUIRE_THAT(sample, WithinAbs(0.0, 1e-12));
-		}
-		for (const auto& sample : i_chunk_1)
-		{
-			REQUIRE_THAT(sample, WithinAbs(0.0, 1e-12));
-		}
-		REQUIRE_THAT(q_chunk_0[0], WithinAbs(1.0, 1e-12));
-		REQUIRE_THAT(q_chunk_0[1], WithinAbs(1.0, 1e-12));
-		REQUIRE_THAT(q_chunk_0[2], WithinAbs(0.0, 1e-12));
-		REQUIRE_THAT(q_chunk_0[3], WithinAbs(0.0, 1e-12));
-		REQUIRE_THAT(q_chunk_1[0], WithinAbs(1.0, 1e-12));
-		REQUIRE_THAT(q_chunk_1[1], WithinAbs(1.0, 1e-12));
-		REQUIRE_THAT(q_chunk_1[2], WithinAbs(0.0, 1e-12));
-		REQUIRE_THAT(q_chunk_1[3], WithinAbs(0.0, 1e-12));
-		REQUIRE_THAT(time_attr_0, WithinAbs(0.125, 1e-12));
-		REQUIRE_THAT(time_attr_1, WithinAbs(1.125, 1e-12));
-	}
-
-	REQUIRE(std::ranges::any_of(
-		progress_calls, [&receiver_name](const ProgressCall& call)
-		{ return call.message == "Finished Exporting " + receiver_name && call.current == 100 && call.total == 100; }));
+	requireJitteredPulsedChunks(output_path);
+	REQUIRE(hasCompletionProgress(progress_calls, receiver_name));
 
 	std::filesystem::remove_all(out_dir);
 }

--- a/packages/libfers/tests/processing/test_finalizer.cpp
+++ b/packages/libfers/tests/processing/test_finalizer.cpp
@@ -38,6 +38,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/processing/test_finalizer.cpp
+++ b/packages/libfers/tests/processing/test_finalizer.cpp
@@ -225,7 +225,7 @@ namespace
 TEST_CASE("Hdf5OutputSink writes streaming blocks through the receiver output contract",
 		  "[processing][finalizer][hdf5]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setAdcBits(0);
 
 	const std::string receiver_name = uniqueName("hdf5_sink");
@@ -254,7 +254,7 @@ TEST_CASE("Hdf5OutputSink writes streaming blocks through the receiver output co
 	sink.finalize();
 
 	{
-		HighFive::File file(output_path.string(), HighFive::File::ReadOnly);
+		HighFive::File const file(output_path.string(), HighFive::File::ReadOnly);
 		const auto i_data = readDataset(file, "I_data");
 		const auto q_data = readDataset(file, "Q_data");
 
@@ -271,7 +271,7 @@ TEST_CASE("Hdf5OutputSink writes streaming blocks through the receiver output co
 TEST_CASE("buildReceiverSampleBlock captures receiver identity, timing, and sample basis",
 		  "[processing][finalizer][vita49]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setAdcBits(12);
 	params::setOrigin(-33.5, 18.25, 123.0);
 	params::setCoordinateSystem(params::CoordinateFrame::UTM, 34, false);
@@ -323,7 +323,7 @@ TEST_CASE("buildReceiverSampleBlock captures receiver identity, timing, and samp
 TEST_CASE("buildReceiverStreamDescriptor keeps CW metadata isolated from active FMCW sources",
 		  "[processing][finalizer][vita49]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 1.0);
 	params::setRate(1'000.0);
 	params::setOversampleRatio(1);
@@ -333,7 +333,7 @@ TEST_CASE("buildReceiverStreamDescriptor keeps CW metadata isolated from active 
 	auto timing_owner = makeQuietTiming("cw_metadata_clk", 27, 5.0e9);
 	receiver.setTiming(timing_owner.timing);
 
-	FmcwTxFixture source_fixture("MixedFmcwTx", 1101, 1102, 200.0, 0.001, 0.002, 0.0, std::size_t{4});
+	FmcwTxFixture const source_fixture("MixedFmcwTx", 1101, 1102, 200.0, 0.001, 0.002, 0.0, std::size_t{4});
 	const std::vector sources = {core::makeActiveSource(&source_fixture.transmitter, 0.0, params::endTime())};
 
 	const auto descriptor = processing::buildReceiverStreamDescriptor(&receiver, params::rate(), sources);
@@ -347,7 +347,7 @@ TEST_CASE("buildReceiverStreamDescriptor keeps CW metadata isolated from active 
 TEST_CASE("buildStreamingOutputMetadata records FMCW source metadata for detached receivers",
 		  "[processing][finalizer][fmcw][metadata]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 0.01);
 	params::setRate(1'000.0);
 	params::setOversampleRatio(1);
@@ -363,7 +363,7 @@ TEST_CASE("buildStreamingOutputMetadata records FMCW source metadata for detache
 	receiver.setTiming(timing_owner.timing);
 	receiver.setNoiseTemperature(0.0);
 
-	FmcwTxFixture source_fixture("DetachedTx", 901, 902, 200.0, 0.001, 0.002, 5.0, std::size_t{4});
+	FmcwTxFixture const source_fixture("DetachedTx", 901, 902, 200.0, 0.001, 0.002, 5.0, std::size_t{4});
 	const auto source = core::makeActiveSource(&source_fixture.transmitter, 0.0, params::endTime());
 
 	const auto metadata =
@@ -395,7 +395,7 @@ TEST_CASE("buildStreamingOutputMetadata records FMCW source metadata for detache
 
 TEST_CASE("buildStreamingOutputMetadata writes IF-rate FMCW metadata", "[processing][finalizer][fmcw][if]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 1.0);
 	params::setRate(256.0);
 	params::setOversampleRatio(1);
@@ -417,7 +417,7 @@ TEST_CASE("buildStreamingOutputMetadata writes IF-rate FMCW metadata", "[process
 								  .waveform_name = ""});
 	receiver.setFmcwIfChainRequest(
 		{.sample_rate_hz = 64.0, .filter_bandwidth_hz = 16.0, .filter_transition_width_hz = 8.0});
-	FmcwTxFixture source_fixture("IfTx", 1001, 1002, 1.0, 1.0, 1.0, 0.0, std::size_t{1});
+	FmcwTxFixture const source_fixture("IfTx", 1001, 1002, 1.0, 1.0, 1.0, 0.0, std::size_t{1});
 	const auto source = core::makeActiveSource(&source_fixture.transmitter, params::startTime(), params::endTime());
 	receiver.setResolvedDechirpSources({source});
 
@@ -444,7 +444,7 @@ TEST_CASE("buildStreamingOutputMetadata writes IF-rate FMCW metadata", "[process
 TEST_CASE("buildStreamingOutputMetadata keeps multiple FMCW sources unambiguous",
 		  "[processing][finalizer][fmcw][metadata]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 0.01);
 	params::setRate(1'000.0);
 	params::setOversampleRatio(1);
@@ -460,8 +460,8 @@ TEST_CASE("buildStreamingOutputMetadata keeps multiple FMCW sources unambiguous"
 	receiver.setTiming(timing_owner.timing);
 	receiver.setNoiseTemperature(0.0);
 
-	FmcwTxFixture first_source("FirstTx", 911, 912, 200.0, 0.001, 0.002, 0.0, std::size_t{4});
-	FmcwTxFixture second_source("SecondTx", 921, 922, 300.0, 0.0015, 0.003, 10.0, std::size_t{2});
+	FmcwTxFixture const first_source("FirstTx", 911, 912, 200.0, 0.001, 0.002, 0.0, std::size_t{4});
+	FmcwTxFixture const second_source("SecondTx", 921, 922, 300.0, 0.0015, 0.003, 10.0, std::size_t{2});
 
 	const std::vector sources = {core::makeActiveSource(&first_source.transmitter, 0.0, params::endTime()),
 								 core::makeActiveSource(&second_source.transmitter, 0.0, params::endTime())};
@@ -479,7 +479,7 @@ TEST_CASE("buildStreamingOutputMetadata keeps multiple FMCW sources unambiguous"
 
 TEST_CASE("runPulsedFinalizer writes jittered chunks and emits completion progress", "[processing][finalizer]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(8.0);
 	params::setOversampleRatio(1);
 	params::setAdcBits(0);
@@ -501,7 +501,7 @@ TEST_CASE("runPulsedFinalizer writes jittered chunks and emits completion progre
 	receiver.setWindowProperties(0.5, 1.0, 0.125);
 
 	radar::Platform tx_platform("TxPlatform");
-	radar::Transmitter transmitter(&tx_platform, "TxA", radar::OperationMode::PULSED_MODE, 701);
+	radar::Transmitter const transmitter(&tx_platform, "TxA", radar::OperationMode::PULSED_MODE, 701);
 	std::vector<std::unique_ptr<fers_signal::RadarSignal>> wave_store;
 
 	core::RenderingJob first_job{};
@@ -534,7 +534,7 @@ TEST_CASE("runPulsedFinalizer writes jittered chunks and emits completion progre
 	hdf5_sink->finalize();
 
 	{
-		HighFive::File file(output_path.string(), HighFive::File::ReadOnly);
+		HighFive::File const file(output_path.string(), HighFive::File::ReadOnly);
 		const auto i_chunk_0 = readDataset(file, "chunk_000000_I");
 		const auto q_chunk_0 = readDataset(file, "chunk_000000_Q");
 		const auto i_chunk_1 = readDataset(file, "chunk_000001_I");
@@ -580,7 +580,7 @@ TEST_CASE("runPulsedFinalizer writes jittered chunks and emits completion progre
 TEST_CASE("runPulsedFinalizer routes completed acquisition windows to an output sink without HDF5",
 		  "[processing][finalizer][vita49]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 1.0);
 	params::setRate(4.0);
 	params::setOversampleRatio(1);
@@ -603,7 +603,7 @@ TEST_CASE("runPulsedFinalizer routes completed acquisition windows to an output 
 	receiver.setWindowProperties(0.5, 1.0, 0.0);
 
 	radar::Platform tx_platform("TxPlatform");
-	radar::Transmitter transmitter(&tx_platform, "TxA", radar::OperationMode::PULSED_MODE, 701);
+	radar::Transmitter const transmitter(&tx_platform, "TxA", radar::OperationMode::PULSED_MODE, 701);
 	std::vector<std::unique_ptr<fers_signal::RadarSignal>> wave_store;
 
 	core::RenderingJob job{};

--- a/packages/libfers/tests/processing/test_finalizer_pipeline_interference.cpp
+++ b/packages/libfers/tests/processing/test_finalizer_pipeline_interference.cpp
@@ -86,7 +86,7 @@ namespace
 TEST_CASE("applyStreamingInterference adds direct-path streaming energy sample by sample",
 		  "[processing][finalizer][interference]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	radar::Platform tx_platform("TxPlatform");
@@ -133,7 +133,7 @@ TEST_CASE("applyStreamingInterference adds direct-path streaming energy sample b
 TEST_CASE("applyStreamingInterference respects FLAG_NODIRECT and keeps only physically reflected energy",
 		  "[processing][finalizer][interference]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	radar::Platform tx_platform("TxPlatform");
@@ -183,7 +183,7 @@ TEST_CASE("applyStreamingInterference respects FLAG_NODIRECT and keeps only phys
 TEST_CASE("applyPulsedInterference clips rendered pulses to LO-active sample spans",
 		  "[processing][finalizer][interference][dechirp]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(10.0);
 	params::setTime(0.0, 1.0);
@@ -221,7 +221,7 @@ TEST_CASE("applyPulsedInterference clips rendered pulses to LO-active sample spa
 TEST_CASE("applyPulsedInterference rejects pulse resampling across mismatched rates",
 		  "[processing][finalizer][interference][dechirp]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(10.0);
 	params::setTime(0.0, 1.0);
@@ -252,7 +252,7 @@ TEST_CASE("applyPulsedInterference rejects pulse resampling across mismatched ra
 TEST_CASE("applyStreamingInterference adds FMCW energy to pulsed receiver windows",
 		  "[processing][finalizer][interference][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1.0e6);
 	params::setOversampleRatio(1);
@@ -294,7 +294,7 @@ TEST_CASE("applyStreamingInterference adds FMCW energy to pulsed receiver window
 TEST_CASE("applyStreamingInterference supports FMCW transmitter with CW streaming receiver",
 		  "[processing][finalizer][interference][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1.0e6);
 	params::setOversampleRatio(1);
@@ -341,7 +341,7 @@ TEST_CASE("applyStreamingInterference supports FMCW transmitter with CW streamin
 TEST_CASE("applyStreamingInterference superposes up- and down-chirp FMCW transmitters",
 		  "[processing][finalizer][interference][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1.0e6);
 	params::setOversampleRatio(1);
@@ -400,7 +400,7 @@ TEST_CASE("applyStreamingInterference superposes up- and down-chirp FMCW transmi
 TEST_CASE("applyStreamingInterference reuses tracker cache without carrying window state",
 		  "[processing][finalizer][interference][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1.0e6);
 	params::setOversampleRatio(1);
@@ -463,13 +463,13 @@ TEST_CASE("applyStreamingInterference reuses tracker cache without carrying wind
 TEST_CASE("applyPulsedInterference maps pulse start times to simulation sample indices and clips overflow",
 		  "[processing][finalizer][interference]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(10.0, 11.0);
 	params::setRate(4.0);
 	params::setOversampleRatio(1);
 
 	radar::Platform tx_platform("TxPlatform");
-	radar::Transmitter transmitter(&tx_platform, "TxA", radar::OperationMode::PULSED_MODE, 401);
+	radar::Transmitter const transmitter(&tx_platform, "TxA", radar::OperationMode::PULSED_MODE, 401);
 
 	std::vector<std::unique_ptr<fers_signal::RadarSignal>> wave_store;
 	std::vector<std::unique_ptr<serial::Response>> interference_log;
@@ -499,13 +499,13 @@ TEST_CASE("applyPulsedInterference maps pulse start times to simulation sample i
 TEST_CASE("applyPulsedInterference uses RF simulation rate for oversampled full-buffer path",
 		  "[processing][finalizer][interference]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(10.0, 11.0);
 	params::setRate(4.0);
 	params::setOversampleRatio(2);
 
 	radar::Platform tx_platform("TxPlatform");
-	radar::Transmitter transmitter(&tx_platform, "TxA", radar::OperationMode::PULSED_MODE, 402);
+	radar::Transmitter const transmitter(&tx_platform, "TxA", radar::OperationMode::PULSED_MODE, 402);
 
 	std::vector<std::unique_ptr<fers_signal::RadarSignal>> wave_store;
 	std::vector<std::unique_ptr<serial::Response>> interference_log;

--- a/packages/libfers/tests/processing/test_finalizer_pipeline_interference.cpp
+++ b/packages/libfers/tests/processing/test_finalizer_pipeline_interference.cpp
@@ -29,6 +29,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/processing/test_finalizer_pipeline_io.cpp
+++ b/packages/libfers/tests/processing/test_finalizer_pipeline_io.cpp
@@ -41,7 +41,7 @@ namespace
 TEST_CASE("applyDownsamplingAndQuantization reduces to direct normalization when no oversampling is configured",
 		  "[processing][finalizer][io]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setOversampleRatio(1);
 	params::setAdcBits(0);
 
@@ -59,7 +59,7 @@ TEST_CASE("applyDownsamplingAndQuantization reduces to direct normalization when
 TEST_CASE("applyDownsamplingAndQuantization preserves low-frequency oversampled content after decimation",
 		  "[processing][finalizer][io]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.filter_length = 8;
 	params::setOversampleRatio(2);
 	params::setAdcBits(0);
@@ -97,7 +97,7 @@ TEST_CASE("applyDownsamplingAndQuantization preserves low-frequency oversampled 
 
 TEST_CASE("DownsamplingSink matches whole-buffer downsample across chunk boundaries", "[processing][finalizer][io]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.filter_length = 8;
 	params::setOversampleRatio(2);
 
@@ -134,7 +134,7 @@ TEST_CASE("DownsamplingSink matches whole-buffer downsample across chunk boundar
 TEST_CASE("applyDownsamplingAndQuantization fails fast when oversample ratio exceeds fixed-filter limit",
 		  "[processing][finalizer][io]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.oversample_ratio = 16;
 	params::setAdcBits(0);
 
@@ -146,7 +146,7 @@ TEST_CASE("applyDownsamplingAndQuantization fails fast when oversample ratio exc
 
 TEST_CASE("exportStreamingToHdf5 writes physically meaningful datasets and metadata", "[processing][finalizer][io]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(2000.0);
 	params::setTime(1.25, 3.0);
 
@@ -156,7 +156,7 @@ TEST_CASE("exportStreamingToHdf5 writes physically meaningful datasets and metad
 	const std::vector<ComplexType> iq_buffer = {ComplexType{1.5, -0.5}, ComplexType{-2.0, 3.0}};
 	processing::pipeline::exportStreamingToHdf5(path.string(), iq_buffer, 4096.0, 9.0e8);
 
-	HighFive::File file(path.string(), HighFive::File::ReadOnly);
+	HighFive::File const file(path.string(), HighFive::File::ReadOnly);
 	std::vector<RealType> i_data;
 	std::vector<RealType> q_data;
 	file.getDataSet("I_data").read(i_data);

--- a/packages/libfers/tests/processing/test_finalizer_pipeline_io.cpp
+++ b/packages/libfers/tests/processing/test_finalizer_pipeline_io.cpp
@@ -22,6 +22,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/processing/test_finalizer_pipeline_timing.cpp
+++ b/packages/libfers/tests/processing/test_finalizer_pipeline_timing.cpp
@@ -20,6 +20,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/processing/test_finalizer_pipeline_timing.cpp
+++ b/packages/libfers/tests/processing/test_finalizer_pipeline_timing.cpp
@@ -34,7 +34,7 @@ TEST_CASE("advanceTimingModel safely ignores null and disabled timing models", "
 	processing::pipeline::advanceTimingModel(nullptr, nullptr, 1000.0);
 
 	radar::Platform platform("RxPlatform");
-	radar::Receiver receiver(&platform, "RxA", 1, radar::OperationMode::PULSED_MODE);
+	radar::Receiver const receiver(&platform, "RxA", 1, radar::OperationMode::PULSED_MODE);
 	auto timing_model = std::make_unique<timing::Timing>("clk", 123);
 
 	processing::pipeline::advanceTimingModel(timing_model.get(), &receiver, 1000.0);
@@ -45,7 +45,7 @@ TEST_CASE("advanceTimingModel safely ignores null and disabled timing models", "
 TEST_CASE("advanceTimingModel resets sync-on-pulse timing before skipping receiver dead time",
 		  "[processing][finalizer][timing]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
 
@@ -72,7 +72,7 @@ TEST_CASE("advanceTimingModel resets sync-on-pulse timing before skipping receiv
 
 TEST_CASE("advanceTimingModel free-running mode skips only the inter-pulse interval", "[processing][finalizer][timing]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
 

--- a/packages/libfers/tests/processing/test_signal_processor.cpp
+++ b/packages/libfers/tests/processing/test_signal_processor.cpp
@@ -28,6 +28,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/processing/test_signal_processor.cpp
+++ b/packages/libfers/tests/processing/test_signal_processor.cpp
@@ -80,24 +80,24 @@ namespace
 
 TEST_CASE("renderWindow accumulates overlapping responses with offsets", "[processing][signal]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(4.0);
 	params::setOversampleRatio(1);
 
 	radar::Platform platform("RxPlatform");
-	radar::Transmitter transmitter(&platform, "TxA", radar::OperationMode::PULSED_MODE, 11);
+	radar::Transmitter const transmitter(&platform, "TxA", radar::OperationMode::PULSED_MODE, 11);
 
 	auto signal_a = std::make_unique<TestSignal>();
 	signal_a->data = {ComplexType{1.0, 0.0}, ComplexType{2.0, 1.0}, ComplexType{3.0, -1.0}};
-	fers_signal::RadarSignal wave_a("wave_a", 1.0, 1.0, 1.0, std::move(signal_a), 101);
+	fers_signal::RadarSignal const wave_a("wave_a", 1.0, 1.0, 1.0, std::move(signal_a), 101);
 
 	auto signal_b = std::make_unique<TestSignal>();
 	signal_b->data = {ComplexType{1.0, 1.0}, ComplexType{1.0, -1.0}};
-	fers_signal::RadarSignal wave_b("wave_b", 1.0, 1.0, 1.0, std::move(signal_b), 102);
+	fers_signal::RadarSignal const wave_b("wave_b", 1.0, 1.0, 1.0, std::move(signal_b), 102);
 
 	auto signal_c = std::make_unique<TestSignal>();
 	signal_c->data = {ComplexType{9.0, 9.0}};
-	fers_signal::RadarSignal wave_c("wave_c", 1.0, 1.0, 1.0, std::move(signal_c), 103);
+	fers_signal::RadarSignal const wave_c("wave_c", 1.0, 1.0, 1.0, std::move(signal_c), 103);
 
 	std::vector<std::unique_ptr<serial::Response>> responses;
 	responses.emplace_back(makeResponse(wave_a, transmitter, {{1.0, -0.25, 0.0, 0.0}, {1.0, 0.1, 0.0, 0.0}}));
@@ -128,7 +128,7 @@ TEST_CASE("renderWindow accumulates overlapping responses with offsets", "[proce
 
 TEST_CASE("applyThermalNoise respects zero temperature", "[processing][signal]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
 
@@ -145,7 +145,7 @@ TEST_CASE("applyThermalNoise respects zero temperature", "[processing][signal]")
 
 TEST_CASE("applyThermalNoise produces expected power", "[processing][signal]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(2000.0);
 	params::setOversampleRatio(2);
 
@@ -174,7 +174,7 @@ TEST_CASE("applyThermalNoise produces expected power", "[processing][signal]")
 
 TEST_CASE("applyThermalNoiseAtSampleRate scales complex variance to IF rate", "[processing][signal][fmcw][if]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 
 	const RealType temperature = 290.0;
 	const RealType if_rate = 64'000.0;
@@ -200,7 +200,7 @@ TEST_CASE("applyThermalNoiseAtSampleRate scales complex variance to IF rate", "[
 
 TEST_CASE("quantizeAndScaleWindow normalizes when adc disabled", "[processing][signal]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setAdcBits(0);
 
 	std::vector<ComplexType> window = {ComplexType{2.0, 0.0}, ComplexType{-1.0, -3.0}};
@@ -216,7 +216,7 @@ TEST_CASE("quantizeAndScaleWindow normalizes when adc disabled", "[processing][s
 
 TEST_CASE("quantizeAndScaleWindow applies adc quantization", "[processing][signal]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setAdcBits(3);
 
 	std::vector<ComplexType> window = {ComplexType{2.0, -2.0}, ComplexType{1.0, -0.5}};
@@ -232,7 +232,7 @@ TEST_CASE("quantizeAndScaleWindow applies adc quantization", "[processing][signa
 
 TEST_CASE("quantizeAndScaleWindow leaves zeros unchanged", "[processing][signal]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setAdcBits(0);
 
 	std::vector<ComplexType> window = {ComplexType{0.0, 0.0}, ComplexType{0.0, 0.0}};

--- a/packages/libfers/tests/radar/test_object.cpp
+++ b/packages/libfers/tests/radar/test_object.cpp
@@ -36,7 +36,7 @@ namespace
 TEST_CASE("Object exposes platform linkage and identity", "[radar][object]")
 {
 	radar::Platform platform("ObjectPlatform");
-	radar::Object object(&platform, "TestObject", ObjectType::Transmitter, 9001);
+	radar::Object const object(&platform, "TestObject", ObjectType::Transmitter, 9001);
 
 	REQUIRE(object.getPlatform() == &platform);
 	REQUIRE(object.getName() == "TestObject");
@@ -59,7 +59,7 @@ TEST_CASE("Object delegates position and rotation to platform", "[radar][object]
 	platform.setMotionPath(makeLinearPath({0.0, 0.0, 0.0}, 0.0, {100.0, 0.0, 0.0}, 10.0));
 	platform.setRotationPath(makeLinearRotation({0.0, 0.0, 0.0}, {1.0, 0.5, 4.0}));
 
-	radar::Object object(&platform, "MovingObject", ObjectType::Target);
+	radar::Object const object(&platform, "MovingObject", ObjectType::Target);
 
 	const math::Vec3 position = object.getPosition(2.5);
 	REQUIRE_THAT(position.x, WithinAbs(25.0, 1e-9));

--- a/packages/libfers/tests/radar/test_platform.cpp
+++ b/packages/libfers/tests/radar/test_platform.cpp
@@ -34,7 +34,7 @@ namespace
 
 TEST_CASE("Platform exposes default paths and identity", "[radar][platform]")
 {
-	radar::Platform platform("TestPlatform", 4242);
+	radar::Platform const platform("TestPlatform", 4242);
 
 	REQUIRE(platform.getMotionPath() != nullptr);
 	REQUIRE(platform.getRotationPath() != nullptr);

--- a/packages/libfers/tests/radar/test_radar_obj.cpp
+++ b/packages/libfers/tests/radar/test_radar_obj.cpp
@@ -62,7 +62,7 @@ TEST_CASE("Radar attachment enforces single attached object", "[radar][radar_obj
 	radar::Platform platform("RadarPlatform");
 	radar::Radar radar_a(&platform, "RadarA");
 	radar::Radar radar_b(&platform, "RadarB");
-	radar::Radar radar_c(&platform, "RadarC");
+	radar::Radar const radar_c(&platform, "RadarC");
 
 	REQUIRE(radar_a.getAttached() == nullptr);
 

--- a/packages/libfers/tests/radar/test_receiver.cpp
+++ b/packages/libfers/tests/radar/test_receiver.cpp
@@ -26,6 +26,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/radar/test_receiver.cpp
+++ b/packages/libfers/tests/radar/test_receiver.cpp
@@ -115,7 +115,7 @@ TEST_CASE("Receiver exposes RNG", "[radar][receiver]")
 
 TEST_CASE("Receiver windows quantize to sampling rate", "[radar][receiver]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 10.0);
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
@@ -148,7 +148,7 @@ TEST_CASE("Receiver inbox and interference log", "[radar][receiver]")
 {
 	radar::Platform platform("RxPlatform");
 	radar::Receiver rx(&platform, "RxA", 5, radar::OperationMode::CW_MODE);
-	radar::Transmitter tx(&platform, "TxA", radar::OperationMode::CW_MODE, 9001);
+	radar::Transmitter const tx(&platform, "TxA", radar::OperationMode::CW_MODE, 9001);
 
 	std::vector<std::unique_ptr<fers_signal::RadarSignal>> waves;
 	rx.addResponseToInbox(makeResponse(&tx, waves));
@@ -166,7 +166,7 @@ TEST_CASE("Receiver inbox and interference log", "[radar][receiver]")
 
 TEST_CASE("Receiver IF resampling preserves absolute output positions across schedule gaps", "[radar][receiver][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 1.0);
 	params::setRate(10.0);
 	params::setOversampleRatio(1);
@@ -206,7 +206,7 @@ TEST_CASE("Receiver IF resampling preserves absolute output positions across sch
 
 TEST_CASE("Receiver IF live output reports absolute sample positions", "[radar][receiver][fmcw][vita49]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 1.0);
 	params::setRate(10.0);
 	params::setOversampleRatio(1);
@@ -249,7 +249,7 @@ TEST_CASE("Receiver IF live output reports absolute sample positions", "[radar][
 
 TEST_CASE("Receiver IF resampling aligns off-grid segments to the global IF grid", "[radar][receiver][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 1.0);
 	params::setRate(100.0);
 	params::setOversampleRatio(1);
@@ -296,7 +296,7 @@ TEST_CASE("Receiver IF resampling aligns off-grid segments to the global IF grid
 TEST_CASE("Receiver IF resampling flushes filtered tail samples after scheduled segment ends",
 		  "[radar][receiver][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 1.0);
 	params::setRate(100.0);
 	params::setOversampleRatio(1);
@@ -343,7 +343,7 @@ TEST_CASE("Receiver IF resampling flushes filtered tail samples after scheduled 
 
 TEST_CASE("Receiver IF resampling skips long inactive gaps without zero-sample work", "[radar][receiver][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 1000.0);
 	params::setRate(100000.0);
 	params::setOversampleRatio(1);
@@ -394,7 +394,7 @@ TEST_CASE("Receiver schedule determines next window time", "[radar][receiver]")
 
 	SECTION("Schedule enforces active windows")
 	{
-		std::vector<radar::SchedulePeriod> schedule = {{1.0, 2.0}, {4.0, 5.0}};
+		std::vector<radar::SchedulePeriod> const schedule = {{1.0, 2.0}, {4.0, 5.0}};
 		rx.setSchedule(schedule);
 		REQUIRE(rx.getSchedule().size() == 2);
 

--- a/packages/libfers/tests/radar/test_receiver.cpp
+++ b/packages/libfers/tests/radar/test_receiver.cpp
@@ -393,7 +393,7 @@ TEST_CASE("Receiver schedule determines next window time", "[radar][receiver]")
 	{
 		const auto next = rx.getNextWindowTime(2.0);
 		REQUIRE(next.has_value());
-		REQUIRE_THAT(*next, WithinAbs(2.0, 1e-12));
+		REQUIRE_THAT(next.value_or(0.0), WithinAbs(2.0, 1e-12));
 	}
 
 	SECTION("Schedule enforces active windows")
@@ -404,11 +404,11 @@ TEST_CASE("Receiver schedule determines next window time", "[radar][receiver]")
 
 		const auto inside = rx.getNextWindowTime(1.25);
 		REQUIRE(inside.has_value());
-		REQUIRE_THAT(*inside, WithinAbs(1.25, 1e-12));
+		REQUIRE_THAT(inside.value_or(0.0), WithinAbs(1.25, 1e-12));
 
 		const auto before = rx.getNextWindowTime(3.5);
 		REQUIRE(before.has_value());
-		REQUIRE_THAT(*before, WithinAbs(4.0, 1e-12));
+		REQUIRE_THAT(before.value_or(0.0), WithinAbs(4.0, 1e-12));
 
 		const auto after = rx.getNextWindowTime(6.0);
 		REQUIRE_FALSE(after.has_value());

--- a/packages/libfers/tests/radar/test_receiver.cpp
+++ b/packages/libfers/tests/radar/test_receiver.cpp
@@ -136,7 +136,7 @@ TEST_CASE("Receiver windows quantize to sampling rate", "[radar][receiver]")
 	REQUIRE_THAT(rx.getWindowSkip(), WithinAbs(expected_skip, 1e-12));
 	REQUIRE_THAT(rx.getWindowLength(), WithinAbs(2.0, 1e-12));
 
-	const unsigned expected_count = static_cast<unsigned>(std::ceil((10.0 - 0.0) * expected_prf));
+	const auto expected_count = static_cast<unsigned>(std::ceil((10.0 - 0.0) * expected_prf));
 	REQUIRE(rx.getWindowCount() == expected_count);
 
 	REQUIRE_THROWS_AS(rx.getWindowStart(0), std::logic_error);

--- a/packages/libfers/tests/radar/test_schedule_period.cpp
+++ b/packages/libfers/tests/radar/test_schedule_period.cpp
@@ -27,8 +27,8 @@ TEST_CASE("SchedulePeriod filters invalid and out-of-bounds periods", "[radar][s
 	ParamGuard const guard;
 	params::setTime(0.0, 10.0);
 
-	std::vector<radar::SchedulePeriod> raw = {{-1.0, -0.5}, {12.0, 15.0}, {5.0, 5.0},
-											  {7.0, 3.0},	{1.0, 2.0},	  {2.0, 3.0}};
+	const std::vector<radar::SchedulePeriod> raw = {{-1.0, -0.5}, {12.0, 15.0}, {5.0, 5.0},
+													{7.0, 3.0},	  {1.0, 2.0},	{2.0, 3.0}};
 
 	const auto processed = radar::processRawSchedule(raw, "TestRadar", false, 1.0);
 
@@ -42,8 +42,8 @@ TEST_CASE("SchedulePeriod sorts and merges overlaps and adjacency", "[radar][sch
 	ParamGuard const guard;
 	params::setTime(0.0, 100.0);
 
-	std::vector<radar::SchedulePeriod> raw = {{5.0, 6.0},	{1.0, 4.0},	  {4.0, 5.0},
-											  {10.0, 12.0}, {11.0, 20.0}, {30.0, 31.0}};
+	const std::vector<radar::SchedulePeriod> raw = {{5.0, 6.0},	  {1.0, 4.0},	{4.0, 5.0},
+													{10.0, 12.0}, {11.0, 20.0}, {30.0, 31.0}};
 
 	const auto processed = radar::processRawSchedule(raw, "MergeRadar", false, 1.0);
 
@@ -61,7 +61,7 @@ TEST_CASE("SchedulePeriod keeps periods that intersect simulation bounds", "[rad
 	ParamGuard const guard;
 	params::setTime(5.0, 15.0);
 
-	std::vector<radar::SchedulePeriod> raw = {{0.0, 6.0}, {5.0, 6.0}, {14.0, 16.0}, {20.0, 25.0}};
+	const std::vector<radar::SchedulePeriod> raw = {{0.0, 6.0}, {5.0, 6.0}, {14.0, 16.0}, {20.0, 25.0}};
 
 	const auto processed = radar::processRawSchedule(raw, "BoundsRadar", false, 1.0);
 
@@ -102,7 +102,7 @@ TEST_CASE("SchedulePeriod returns empty after filtering all invalid periods", "[
 	ParamGuard const guard;
 	params::setTime(0.0, 10.0);
 
-	std::vector<radar::SchedulePeriod> raw = {{5.0, 5.0}, {7.0, 3.0}, {-5.0, -1.0}, {12.0, 20.0}};
+	const std::vector<radar::SchedulePeriod> raw = {{5.0, 5.0}, {7.0, 3.0}, {-5.0, -1.0}, {12.0, 20.0}};
 
 	const auto processed = radar::processRawSchedule(raw, "FilteredRadar", false, 1.0);
 	REQUIRE(processed.empty());

--- a/packages/libfers/tests/radar/test_schedule_period.cpp
+++ b/packages/libfers/tests/radar/test_schedule_period.cpp
@@ -30,7 +30,7 @@ TEST_CASE("SchedulePeriod filters invalid and out-of-bounds periods", "[radar][s
 	std::vector<radar::SchedulePeriod> raw = {{-1.0, -0.5}, {12.0, 15.0}, {5.0, 5.0},
 											  {7.0, 3.0},	{1.0, 2.0},	  {2.0, 3.0}};
 
-	const auto processed = radar::processRawSchedule(std::move(raw), "TestRadar", false, 1.0);
+	const auto processed = radar::processRawSchedule(raw, "TestRadar", false, 1.0);
 
 	REQUIRE(processed.size() == 1);
 	REQUIRE_THAT(processed.front().start, WithinAbs(1.0, 1e-12));
@@ -45,7 +45,7 @@ TEST_CASE("SchedulePeriod sorts and merges overlaps and adjacency", "[radar][sch
 	std::vector<radar::SchedulePeriod> raw = {{5.0, 6.0},	{1.0, 4.0},	  {4.0, 5.0},
 											  {10.0, 12.0}, {11.0, 20.0}, {30.0, 31.0}};
 
-	const auto processed = radar::processRawSchedule(std::move(raw), "MergeRadar", false, 1.0);
+	const auto processed = radar::processRawSchedule(raw, "MergeRadar", false, 1.0);
 
 	REQUIRE(processed.size() == 3);
 	REQUIRE_THAT(processed[0].start, WithinAbs(1.0, 1e-12));
@@ -63,7 +63,7 @@ TEST_CASE("SchedulePeriod keeps periods that intersect simulation bounds", "[rad
 
 	std::vector<radar::SchedulePeriod> raw = {{0.0, 6.0}, {5.0, 6.0}, {14.0, 16.0}, {20.0, 25.0}};
 
-	const auto processed = radar::processRawSchedule(std::move(raw), "BoundsRadar", false, 1.0);
+	const auto processed = radar::processRawSchedule(raw, "BoundsRadar", false, 1.0);
 
 	REQUIRE(processed.size() == 2);
 	REQUIRE_THAT(processed[0].start, WithinAbs(0.0, 1e-12));
@@ -104,6 +104,6 @@ TEST_CASE("SchedulePeriod returns empty after filtering all invalid periods", "[
 
 	std::vector<radar::SchedulePeriod> raw = {{5.0, 5.0}, {7.0, 3.0}, {-5.0, -1.0}, {12.0, 20.0}};
 
-	const auto processed = radar::processRawSchedule(std::move(raw), "FilteredRadar", false, 1.0);
+	const auto processed = radar::processRawSchedule(raw, "FilteredRadar", false, 1.0);
 	REQUIRE(processed.empty());
 }

--- a/packages/libfers/tests/radar/test_schedule_period.cpp
+++ b/packages/libfers/tests/radar/test_schedule_period.cpp
@@ -20,7 +20,7 @@ namespace
 
 TEST_CASE("SchedulePeriod filters invalid and out-of-bounds periods", "[radar][schedule_period]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 10.0);
 
 	std::vector<radar::SchedulePeriod> raw = {{-1.0, -0.5}, {12.0, 15.0}, {5.0, 5.0},
@@ -35,7 +35,7 @@ TEST_CASE("SchedulePeriod filters invalid and out-of-bounds periods", "[radar][s
 
 TEST_CASE("SchedulePeriod sorts and merges overlaps and adjacency", "[radar][schedule_period]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 100.0);
 
 	std::vector<radar::SchedulePeriod> raw = {{5.0, 6.0},	{1.0, 4.0},	  {4.0, 5.0},
@@ -54,7 +54,7 @@ TEST_CASE("SchedulePeriod sorts and merges overlaps and adjacency", "[radar][sch
 
 TEST_CASE("SchedulePeriod keeps periods that intersect simulation bounds", "[radar][schedule_period]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(5.0, 15.0);
 
 	std::vector<radar::SchedulePeriod> raw = {{0.0, 6.0}, {5.0, 6.0}, {14.0, 16.0}, {20.0, 25.0}};
@@ -70,10 +70,10 @@ TEST_CASE("SchedulePeriod keeps periods that intersect simulation bounds", "[rad
 
 TEST_CASE("SchedulePeriod honors PRI checks without altering periods", "[radar][schedule_period]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 10.0);
 
-	std::vector<radar::SchedulePeriod> raw = {{1.0, 1.2}, {2.0, 3.0}};
+	std::vector<radar::SchedulePeriod> const raw = {{1.0, 1.2}, {2.0, 3.0}};
 
 	const auto processed = radar::processRawSchedule(raw, "PulsedRadar", true, 0.5);
 
@@ -86,7 +86,7 @@ TEST_CASE("SchedulePeriod honors PRI checks without altering periods", "[radar][
 
 TEST_CASE("SchedulePeriod handles empty input", "[radar][schedule_period]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 10.0);
 
 	const auto processed = radar::processRawSchedule({}, "EmptyRadar", false, 1.0);
@@ -95,7 +95,7 @@ TEST_CASE("SchedulePeriod handles empty input", "[radar][schedule_period]")
 
 TEST_CASE("SchedulePeriod returns empty after filtering all invalid periods", "[radar][schedule_period]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 10.0);
 
 	std::vector<radar::SchedulePeriod> raw = {{5.0, 5.0}, {7.0, 3.0}, {-5.0, -1.0}, {12.0, 20.0}};

--- a/packages/libfers/tests/radar/test_schedule_period.cpp
+++ b/packages/libfers/tests/radar/test_schedule_period.cpp
@@ -14,6 +14,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 }

--- a/packages/libfers/tests/radar/test_target.cpp
+++ b/packages/libfers/tests/radar/test_target.cpp
@@ -123,7 +123,7 @@ TEST_CASE("RcsChiSquare sample mean matches configured mean power", "[radar][tar
 TEST_CASE("IsoTarget returns constant RCS", "[radar][target]")
 {
 	radar::Platform platform("TargetPlatform");
-	radar::IsoTarget target(&platform, "Iso", 12.5, 42, 9002);
+	radar::IsoTarget const target(&platform, "Iso", 12.5, 42, 9002);
 
 	math::SVec3 in_angle(1.0, 0.0, 0.0);
 	math::SVec3 out_angle(1.0, 0.0, 0.0);
@@ -175,7 +175,7 @@ TEST_CASE("Target RNG is deterministic per seed", "[radar][target]")
 TEST_CASE("IsoTarget defaults to no fluctuation model and target-typed id", "[radar][target]")
 {
 	radar::Platform platform("TargetPlatform");
-	radar::IsoTarget target(&platform, "Iso", 1.0, 99);
+	radar::IsoTarget const target(&platform, "Iso", 1.0, 99);
 
 	REQUIRE(target.getFluctuationModel() == nullptr);
 	REQUIRE(SimIdGenerator::getType(target.getId()) == ObjectType::Target);
@@ -191,7 +191,7 @@ TEST_CASE("FileTarget multiplies interpolated azimuth and elevation RCS in the t
 	setStaticRotation(platform);
 
 	constexpr SimId explicit_id = 4001;
-	radar::FileTarget target(&platform, "File", path.string(), 12, explicit_id);
+	radar::FileTarget const target(&platform, "File", path.string(), 12, explicit_id);
 
 	math::SVec3 in_angle = unitDirection(0.6, 0.2);
 	math::SVec3 out_angle = unitDirection(0.4, 0.6);
@@ -216,7 +216,7 @@ TEST_CASE("FileTarget uses time-dependent platform rotation to look up body-fram
 	radar::Platform platform("TargetPlatform");
 	setConstantRotation(platform, 0.1, 0.2, 0.2, 0.1);
 
-	radar::FileTarget target(&platform, "File", path.string(), 34, 5002);
+	radar::FileTarget const target(&platform, "File", path.string(), 34, 5002);
 
 	math::SVec3 in_angle = unitDirection(0.4, 0.2);
 	math::SVec3 out_angle = unitDirection(0.5, 0.4);
@@ -292,7 +292,7 @@ TEST_CASE("FileTarget skips incomplete sample nodes and uses the valid samples t
 	radar::Platform platform("TargetPlatform");
 	setStaticRotation(platform);
 
-	radar::FileTarget target(&platform, "File", path.string(), 90, 8005);
+	radar::FileTarget const target(&platform, "File", path.string(), 90, 8005);
 	math::SVec3 in_angle = unitDirection(1.0, 1.0);
 	math::SVec3 out_angle = unitDirection(1.0, 1.0);
 
@@ -346,7 +346,7 @@ TEST_CASE("FileTarget currently throws at lookup time when an RCS axis has no sa
 	radar::Platform platform("TargetPlatform");
 	setStaticRotation(platform);
 
-	radar::FileTarget target(&platform, "File", path.string(), 333, 11008);
+	radar::FileTarget const target(&platform, "File", path.string(), 333, 11008);
 	math::SVec3 in_angle = unitDirection(0.0, 0.0);
 	math::SVec3 out_angle = unitDirection(0.0, 0.0);
 
@@ -358,7 +358,7 @@ TEST_CASE("FileTarget currently throws at lookup time when an RCS axis has no sa
 TEST_CASE("Target exposes initial seed", "[radar][target]")
 {
 	radar::Platform platform("TargetPlatform");
-	radar::IsoTarget target(&platform, "Iso", 1.0, 12345);
+	radar::IsoTarget const target(&platform, "Iso", 1.0, 12345);
 	REQUIRE(target.getSeed() == 12345);
 }
 

--- a/packages/libfers/tests/radar/test_transmitter.cpp
+++ b/packages/libfers/tests/radar/test_transmitter.cpp
@@ -16,6 +16,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 }

--- a/packages/libfers/tests/radar/test_transmitter.cpp
+++ b/packages/libfers/tests/radar/test_transmitter.cpp
@@ -70,7 +70,7 @@ TEST_CASE("Transmitter schedule resolves next pulse time", "[radar][transmitter]
 	{
 		const auto next = tx.getNextPulseTime(2.5);
 		REQUIRE(next.has_value());
-		REQUIRE_THAT(*next, WithinAbs(2.5, 1e-12));
+		REQUIRE_THAT(next.value_or(0.0), WithinAbs(2.5, 1e-12));
 	}
 
 	SECTION("Schedule enforces active windows")
@@ -82,11 +82,11 @@ TEST_CASE("Transmitter schedule resolves next pulse time", "[radar][transmitter]
 
 		const auto inside = tx.getNextPulseTime(1.5);
 		REQUIRE(inside.has_value());
-		REQUIRE_THAT(*inside, WithinAbs(1.5, 1e-12));
+		REQUIRE_THAT(inside.value_or(0.0), WithinAbs(1.5, 1e-12));
 
 		const auto before = tx.getNextPulseTime(3.0);
 		REQUIRE(before.has_value());
-		REQUIRE_THAT(*before, WithinAbs(4.0, 1e-12));
+		REQUIRE_THAT(before.value_or(0.0), WithinAbs(4.0, 1e-12));
 
 		const auto after = tx.getNextPulseTime(6.0);
 		REQUIRE_FALSE(after.has_value());

--- a/packages/libfers/tests/radar/test_transmitter.cpp
+++ b/packages/libfers/tests/radar/test_transmitter.cpp
@@ -44,7 +44,7 @@ TEST_CASE("Transmitter basic accessors and signal setters", "[radar][transmitter
 
 TEST_CASE("Transmitter setPrf quantizes to sample rate", "[radar][transmitter]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
 
@@ -71,7 +71,7 @@ TEST_CASE("Transmitter schedule resolves next pulse time", "[radar][transmitter]
 
 	SECTION("Schedule enforces active windows")
 	{
-		std::vector<radar::SchedulePeriod> schedule = {{1.0, 2.0}, {4.0, 5.0}};
+		std::vector<radar::SchedulePeriod> const schedule = {{1.0, 2.0}, {4.0, 5.0}};
 		tx.setSchedule(schedule);
 
 		REQUIRE(tx.getSchedule().size() == 2);

--- a/packages/libfers/tests/serial/test_hdf5_handler.cpp
+++ b/packages/libfers/tests/serial/test_hdf5_handler.cpp
@@ -114,7 +114,7 @@ TEST_CASE("addChunkToFile writes I/Q datasets with attributes", "[serial][hdf5]"
 	const std::string path = tempFilePath(uniqueFileName("chunks"));
 	removeIfExists(path);
 
-	RateGuard rate_guard(2'000.0);
+	RateGuard const rate_guard(2'000.0);
 	const std::vector<ComplexType> samples = {ComplexType(1.25, -0.75), ComplexType(-2.5, 3.0)};
 	const RealType time = 1.5;
 	const RealType fullscale = 4096.0;
@@ -125,7 +125,7 @@ TEST_CASE("addChunkToFile writes I/Q datasets with attributes", "[serial][hdf5]"
 	}
 
 	{
-		HighFive::File file(path, HighFive::File::ReadOnly);
+		HighFive::File const file(path, HighFive::File::ReadOnly);
 		const auto i_dataset = file.getDataSet("chunk_000007_I");
 		const auto q_dataset = file.getDataSet("chunk_000007_Q");
 
@@ -169,7 +169,7 @@ TEST_CASE("HDF5 writer adds backward-compatible output metadata attributes", "[s
 	const std::string path = tempFilePath(uniqueFileName("metadata"));
 	removeIfExists(path);
 
-	RateGuard rate_guard(4'000.0);
+	RateGuard const rate_guard(4'000.0);
 	core::OutputFileMetadata file_metadata{.receiver_id = 42,
 										   .receiver_name = "RxMetadata",
 										   .mode = "pulsed",
@@ -181,24 +181,24 @@ TEST_CASE("HDF5 writer adds backward-compatible output metadata attributes", "[s
 										   .min_pulse_length_samples = 2,
 										   .max_pulse_length_samples = 2,
 										   .uniform_pulse_length = true};
-	core::PulseChunkMetadata chunk_metadata{.chunk_index = 0,
-											.i_dataset = "chunk_000000_I",
-											.q_dataset = "chunk_000000_Q",
-											.start_time = 1.25,
-											.sample_count = 2,
-											.sample_start = 0,
-											.sample_end_exclusive = 2};
+	core::PulseChunkMetadata const chunk_metadata{.chunk_index = 0,
+												  .i_dataset = "chunk_000000_I",
+												  .q_dataset = "chunk_000000_Q",
+												  .start_time = 1.25,
+												  .sample_count = 2,
+												  .sample_start = 0,
+												  .sample_end_exclusive = 2};
 	file_metadata.chunks.push_back(chunk_metadata);
 
 	{
 		HighFive::File file(path, HighFive::File::Overwrite);
 		serial::addChunkToFile(file, {ComplexType(1.0, 0.0), ComplexType(2.0, 0.5)}, 1.25, 8.0, 0, &chunk_metadata);
-		std::scoped_lock lock(serial::hdf5_global_mutex);
+		std::scoped_lock const lock(serial::hdf5_global_mutex);
 		serial::writeOutputFileMetadataAttributes(file, file_metadata);
 	}
 
 	{
-		HighFive::File file(path, HighFive::File::ReadOnly);
+		HighFive::File const file(path, HighFive::File::ReadOnly);
 		unsigned schema_version = 0;
 		unsigned long long total_samples = 0;
 		std::string receiver_name;
@@ -285,12 +285,12 @@ TEST_CASE("HDF5 writer exposes FMCW segment metadata without cw_segments JSON al
 
 	{
 		HighFive::File file(path, HighFive::File::Overwrite);
-		std::scoped_lock lock(serial::hdf5_global_mutex);
+		std::scoped_lock const lock(serial::hdf5_global_mutex);
 		serial::writeOutputFileMetadataAttributes(file, file_metadata);
 	}
 
 	{
-		HighFive::File file(path, HighFive::File::ReadOnly);
+		HighFive::File const file(path, HighFive::File::ReadOnly);
 		unsigned long long segment_count = 0;
 		RealType signed_rate = 0.0;
 		std::string direction;
@@ -326,7 +326,7 @@ TEST_CASE("addChunkToFile throws when dataset already exists", "[serial][hdf5]")
 	const std::string path = tempFilePath(uniqueFileName("chunk_exists"));
 	removeIfExists(path);
 
-	RateGuard rate_guard(1'000.0);
+	RateGuard const rate_guard(1'000.0);
 	const std::vector<ComplexType> samples = {ComplexType(1.0, 1.0)};
 
 	{
@@ -345,7 +345,7 @@ TEST_CASE("readPattern returns 2D dataset", "[serial][hdf5]")
 
 	{
 		HighFive::File file(path, HighFive::File::Overwrite);
-		std::vector<std::vector<RealType>> pattern = {{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}};
+		std::vector<std::vector<RealType>> const pattern = {{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}};
 		auto dataset = file.createDataSet<RealType>("pattern", HighFive::DataSpace::From(pattern));
 		dataset.write(pattern);
 	}
@@ -368,7 +368,7 @@ TEST_CASE("readPattern throws for non-2D dataset", "[serial][hdf5]")
 
 	{
 		HighFive::File file(path, HighFive::File::Overwrite);
-		std::vector<RealType> values = {1.0, 2.0, 3.0};
+		std::vector<RealType> const values = {1.0, 2.0, 3.0};
 		auto dataset = file.createDataSet<RealType>("pattern", HighFive::DataSpace::From(values));
 		dataset.write(values);
 	}
@@ -385,7 +385,7 @@ TEST_CASE("readPattern throws when dataset missing", "[serial][hdf5]")
 
 	{
 		HighFive::File file(path, HighFive::File::Overwrite);
-		std::vector<std::vector<RealType>> pattern = {{0.0}};
+		std::vector<std::vector<RealType>> const pattern = {{0.0}};
 		auto dataset = file.createDataSet<RealType>("other", HighFive::DataSpace::From(pattern));
 		dataset.write(pattern);
 	}

--- a/packages/libfers/tests/serial/test_hdf5_handler.cpp
+++ b/packages/libfers/tests/serial/test_hdf5_handler.cpp
@@ -21,6 +21,10 @@ namespace
 		RealType previous_rate = params::rate();
 
 		explicit RateGuard(RealType rate) { params::setRate(rate); }
+		RateGuard(const RateGuard&) = delete;
+		RateGuard& operator=(const RateGuard&) = delete;
+		RateGuard(RateGuard&&) = delete;
+		RateGuard& operator=(RateGuard&&) = delete;
 
 		~RateGuard() { params::params.rate = previous_rate; }
 	};

--- a/packages/libfers/tests/serial/test_json_serializer.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer.cpp
@@ -8,6 +8,7 @@
 #include <nlohmann/json.hpp>
 #include <random>
 #include <sstream>
+#include <string>
 #include <string_view>
 
 #include "antenna/antenna_factory.h"
@@ -111,7 +112,8 @@ namespace
 		fers_signal::to_json(serialized, *wf);
 		REQUIRE(serialized.contains("fmcw_linear_chirp"));
 		REQUIRE_FALSE(serialized.contains("fmcw_up_chirp"));
-		REQUIRE(serialized.at("fmcw_linear_chirp").at("direction") == direction);
+		const auto serialized_direction = serialized.at("fmcw_linear_chirp").at("direction").get<std::string>();
+		REQUIRE(serialized_direction == std::string(direction));
 
 		auto reparsed = serial::parse_waveform_from_json(serialized);
 		REQUIRE(reparsed != nullptr);

--- a/packages/libfers/tests/serial/test_json_serializer.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer.cpp
@@ -71,11 +71,11 @@ namespace
 
 TEST_CASE("JSON: Granular parsing of Antenna and Waveform", "[serial][json]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 
 	SECTION("Parse Antenna")
 	{
-		json ant_json = {{"id", 123}, {"name", "TestAntenna"}, {"pattern", "isotropic"}, {"efficiency", 0.85}};
+		json const ant_json = {{"id", 123}, {"name", "TestAntenna"}, {"pattern", "isotropic"}, {"efficiency", 0.85}};
 
 		auto ant = serial::parse_antenna_from_json(ant_json);
 		REQUIRE(ant != nullptr);
@@ -86,11 +86,11 @@ TEST_CASE("JSON: Granular parsing of Antenna and Waveform", "[serial][json]")
 
 	SECTION("Parse Waveform")
 	{
-		json wf_json = {{"id", 456},
-						{"name", "TestWaveform"},
-						{"power", 500.0},
-						{"carrier_frequency", 2e9},
-						{"cw", json::object()}};
+		json const wf_json = {{"id", 456},
+							  {"name", "TestWaveform"},
+							  {"power", 500.0},
+							  {"carrier_frequency", 2e9},
+							  {"cw", json::object()}};
 
 		auto wf = serial::parse_waveform_from_json(wf_json);
 		REQUIRE(wf != nullptr);
@@ -103,15 +103,15 @@ TEST_CASE("JSON: Granular parsing of Antenna and Waveform", "[serial][json]")
 
 TEST_CASE("JSON: FMCW waveform emits large-buffer warning", "[serial][json]")
 {
-	ParamGuard guard;
-	LogLevelGuard log_level(logging::Level::WARNING);
-	CerrCapture capture;
+	ParamGuard const guard;
+	LogLevelGuard const log_level(logging::Level::WARNING);
+	CerrCapture const capture;
 
 	params::setRate(1.0e9);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 5.0);
 
-	json wf_json = {
+	json const wf_json = {
 		{"id", 456},
 		{"name", "HugeFmcw"},
 		{"power", 500.0},
@@ -126,22 +126,22 @@ TEST_CASE("JSON: FMCW waveform emits large-buffer warning", "[serial][json]")
 
 TEST_CASE("JSON: FMCW linear chirp direction round trips", "[serial][json][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(2.0e6);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 1.0);
 
 	for (const auto direction : {"up", "down"})
 	{
-		json wf_json = {{"id", 457},
-						{"name", std::string("Fmcw") + direction},
-						{"power", 500.0},
-						{"carrier_frequency", 2.4e9},
-						{"fmcw_linear_chirp",
-						 {{"direction", direction},
-						  {"chirp_bandwidth", 1.0e6},
-						  {"chirp_duration", 1.0e-3},
-						  {"chirp_period", 1.0e-3}}}};
+		json const wf_json = {{"id", 457},
+							  {"name", std::string("Fmcw") + direction},
+							  {"power", 500.0},
+							  {"carrier_frequency", 2.4e9},
+							  {"fmcw_linear_chirp",
+							   {{"direction", direction},
+								{"chirp_bandwidth", 1.0e6},
+								{"chirp_duration", 1.0e-3},
+								{"chirp_period", 1.0e-3}}}};
 
 		auto wf = serial::parse_waveform_from_json(wf_json);
 		REQUIRE(wf != nullptr);
@@ -163,20 +163,20 @@ TEST_CASE("JSON: FMCW linear chirp direction round trips", "[serial][json][fmcw]
 
 TEST_CASE("JSON: FMCW triangle round trips", "[serial][json][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(2.0e6);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 1.0);
 
-	json wf_json = {{"id", 458},
-					{"name", "Tri"},
-					{"power", 500.0},
-					{"carrier_frequency", 2.4e9},
-					{"fmcw_triangle",
-					 {{"chirp_bandwidth", 1.0e6},
-					  {"chirp_duration", 1.0e-3},
-					  {"start_frequency_offset", 1.0e3},
-					  {"triangle_count", 3}}}};
+	json const wf_json = {{"id", 458},
+						  {"name", "Tri"},
+						  {"power", 500.0},
+						  {"carrier_frequency", 2.4e9},
+						  {"fmcw_triangle",
+						   {{"chirp_bandwidth", 1.0e6},
+							{"chirp_duration", 1.0e-3},
+							{"start_frequency_offset", 1.0e3},
+							{"triangle_count", 3}}}};
 
 	auto wf = serial::parse_waveform_from_json(wf_json);
 	REQUIRE(wf != nullptr);
@@ -199,12 +199,12 @@ TEST_CASE("JSON: FMCW triangle round trips", "[serial][json][fmcw]")
 
 TEST_CASE("JSON: FMCW triangle rejects fractional triangle count", "[serial][json][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(2.0e6);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 1.0);
 
-	json wf_json = {
+	json const wf_json = {
 		{"id", 459},
 		{"name", "TriFractional"},
 		{"power", 500.0},
@@ -216,7 +216,7 @@ TEST_CASE("JSON: FMCW triangle rejects fractional triangle count", "[serial][jso
 
 TEST_CASE("JSON: Serialization of Math and Timing Structures", "[serial][json]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	core::World w;
 
 	// 1. Setup Platform with Math Paths
@@ -228,8 +228,8 @@ TEST_CASE("JSON: Serialization of Math and Timing Structures", "[serial][json]")
 	p->getMotionPath()->addCoord({math::Vec3(4.1, 5.2, 6.3), 7.5});
 	p->getMotionPath()->finalize();
 
-	math::RotationCoord start(0.0, 0.0, 0.0);
-	math::RotationCoord rate(-PI / 2.0, PI / 4.0, 0.0);
+	math::RotationCoord const start(0.0, 0.0, 0.0);
+	math::RotationCoord const rate(-PI / 2.0, PI / 4.0, 0.0);
 	p->getRotationPath()->setInterp(math::RotationPath::InterpType::INTERP_CONSTANT);
 	p->getRotationPath()->setConstantRate(start, rate);
 	p->getRotationPath()->finalize();
@@ -279,7 +279,7 @@ TEST_CASE("JSON: Serialization of Math and Timing Structures", "[serial][json]")
 
 TEST_CASE("JSON: Serialization of Assets and Radar Components", "[serial][json]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 
 	// MUST initialize global simulation parameters to avoid division-by-zero
 	// Without this, params::rate() is 0.0, causing the PRF math to evaluate to NaN.
@@ -377,12 +377,12 @@ TEST_CASE("JSON: Serialization of Assets and Radar Components", "[serial][json]"
 
 TEST_CASE("JSON: Full World Scenario Deserialization", "[serial][json]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	core::World world;
 	std::mt19937 seeder(42);
 
 	// Safely construct JSON using initializer lists
-	json scenario = {
+	json const scenario = {
 		{"simulation",
 		 {{"parameters",
 		   {{"starttime", 0.0},
@@ -440,11 +440,11 @@ TEST_CASE("JSON: Full World Scenario Deserialization", "[serial][json]")
 
 TEST_CASE("JSON: Full world skips incomplete numeric-placeholder radar components", "[serial][json]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	core::World world;
 	std::mt19937 seeder(42);
 
-	json scenario = {
+	json const scenario = {
 		{"simulation",
 		 {{"parameters",
 		   {{"starttime", 0.0},
@@ -490,40 +490,40 @@ TEST_CASE("JSON: Full world skips incomplete numeric-placeholder radar component
 
 TEST_CASE("JSON: Full world rejects duplicate scenario object names", "[serial][json]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	core::World world;
 	std::mt19937 seeder(42);
 
-	json scenario = {{"simulation",
-					  {{"parameters",
-						{{"starttime", 0.0},
-						 {"endtime", 1.0},
-						 {"rate", 1000.0},
-						 {"origin", {{"latitude", 0.0}, {"longitude", 0.0}, {"altitude", 0.0}}},
-						 {"coordinatesystem", {{"frame", "ENU"}}}}},
-					   {"platforms",
-						json::array({{{"id", 100},
-									  {"name", "MonoRadar"},
-									  {"components",
-									   json::array({{{"monostatic",
-													  {{"name", "MonoRadar Monostatic"},
-													   {"tx_id", 101},
-													   {"rx_id", 102},
-													   {"waveform", 10},
-													   {"antenna", 20},
-													   {"timing", 30},
-													   {"cw_mode", json::object()}}}}})}},
-									 {{"id", 103},
-									  {"name", "MonoRadar Copy"},
-									  {"components",
-									   json::array({{{"monostatic",
-													  {{"name", "MonoRadar Monostatic"},
-													   {"tx_id", 104},
-													   {"rx_id", 105},
-													   {"waveform", 11},
-													   {"antenna", 21},
-													   {"timing", 31},
-													   {"cw_mode", json::object()}}}}})}}})}}}};
+	json const scenario = {{"simulation",
+							{{"parameters",
+							  {{"starttime", 0.0},
+							   {"endtime", 1.0},
+							   {"rate", 1000.0},
+							   {"origin", {{"latitude", 0.0}, {"longitude", 0.0}, {"altitude", 0.0}}},
+							   {"coordinatesystem", {{"frame", "ENU"}}}}},
+							 {"platforms",
+							  json::array({{{"id", 100},
+											{"name", "MonoRadar"},
+											{"components",
+											 json::array({{{"monostatic",
+															{{"name", "MonoRadar Monostatic"},
+															 {"tx_id", 101},
+															 {"rx_id", 102},
+															 {"waveform", 10},
+															 {"antenna", 20},
+															 {"timing", 30},
+															 {"cw_mode", json::object()}}}}})}},
+										   {{"id", 103},
+											{"name", "MonoRadar Copy"},
+											{"components",
+											 json::array({{{"monostatic",
+															{{"name", "MonoRadar Monostatic"},
+															 {"tx_id", 104},
+															 {"rx_id", 105},
+															 {"waveform", 11},
+															 {"antenna", 21},
+															 {"timing", 31},
+															 {"cw_mode", json::object()}}}}})}}})}}}};
 
 	REQUIRE_THROWS_WITH(
 		serial::json_to_world(scenario, world, seeder),
@@ -533,13 +533,13 @@ TEST_CASE("JSON: Full world rejects duplicate scenario object names", "[serial][
 
 TEST_CASE("JSON: Rotation parsing warns when values look like the opposite unit", "[serial][json]")
 {
-	ParamGuard guard;
-	LogLevelGuard log_guard(logging::Level::WARNING);
-	CerrCapture capture;
+	ParamGuard const guard;
+	LogLevelGuard const log_guard(logging::Level::WARNING);
+	CerrCapture const capture;
 	core::World world;
 	std::mt19937 seeder(42);
 
-	json scenario = {
+	json const scenario = {
 		{"simulation",
 		 {{"name", "Warning Scenario"},
 		  {"parameters",
@@ -565,13 +565,13 @@ TEST_CASE("JSON: Rotation parsing warns when values look like the opposite unit"
 
 TEST_CASE("JSON: Deserialization Error Paths", "[serial][json]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	core::World world;
 	std::mt19937 seeder(42);
 
 	auto run_bad_scenario = [&](const json& test_comps)
 	{
-		json scenario = {
+		json const scenario = {
 			{"simulation",
 			 {{"parameters",
 			   {{"starttime", 0.0},
@@ -590,7 +590,7 @@ TEST_CASE("JSON: Deserialization Error Paths", "[serial][json]")
 
 	SECTION("Missing mode throws")
 	{
-		json test_comps = json::array(
+		json const test_comps = json::array(
 			{{{"transmitter", {{"id", 1}, {"name", "tx1"}, {"waveform", 10}, {"antenna", 20}, {"timing", 30}}}}});
 		REQUIRE_THROWS_WITH(run_bad_scenario(test_comps),
 							ContainsSubstring("must have a 'pulsed_mode', 'cw_mode', or 'fmcw_mode' block"));
@@ -598,25 +598,25 @@ TEST_CASE("JSON: Deserialization Error Paths", "[serial][json]")
 
 	SECTION("Unsupported RCS type throws")
 	{
-		json test_comps =
+		json const test_comps =
 			json::array({{{"target", {{"id", 1}, {"name", "bad-target"}, {"rcs", {{"type", "magic"}}}}}}});
 		REQUIRE_THROWS_WITH(run_bad_scenario(test_comps), ContainsSubstring("Unsupported target RCS type: magic"));
 	}
 
 	SECTION("Unsupported Fluctuation model type throws")
 	{
-		json test_comps = json::array({{{"target",
-										 {{"id", 1},
-										  {"name", "bad-target"},
-										  {"rcs", {{"type", "isotropic"}, {"value", 1.0}}},
-										  {"model", {{"type", "magic"}}}}}}});
+		json const test_comps = json::array({{{"target",
+											   {{"id", 1},
+												{"name", "bad-target"},
+												{"rcs", {{"type", "isotropic"}, {"value", 1.0}}},
+												{"model", {{"type", "magic"}}}}}}});
 		REQUIRE_THROWS_WITH(run_bad_scenario(test_comps),
 							ContainsSubstring("Unsupported fluctuation model type: magic"));
 	}
 
 	SECTION("Negative ID throws")
 	{
-		json test_comps = json::array(
+		json const test_comps = json::array(
 			{{{"target", {{"id", -5}, {"name", "bad-target"}, {"rcs", {{"type", "isotropic"}, {"value", 1.0}}}}}}});
 		REQUIRE_THROWS_WITH(run_bad_scenario(test_comps), ContainsSubstring("negative id"));
 	}
@@ -624,7 +624,7 @@ TEST_CASE("JSON: Deserialization Error Paths", "[serial][json]")
 
 TEST_CASE("JSON: FMCW schedule validation matches chirp timing", "[serial][json][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	std::mt19937 seeder(42);
 
 	const auto make_scenario = [](const json& schedule)
@@ -671,8 +671,8 @@ TEST_CASE("JSON: FMCW schedule validation matches chirp timing", "[serial][json]
 	SECTION("period shorter than T_rep but at least T_c only warns")
 	{
 		core::World world;
-		LogLevelGuard log_level(logging::Level::WARNING);
-		CerrCapture capture;
+		LogLevelGuard const log_level(logging::Level::WARNING);
+		CerrCapture const capture;
 		const auto scenario = make_scenario(json::array({{{"start", 0.1}, {"end", 0.1015}}}));
 		REQUIRE_NOTHROW(serial::json_to_world(scenario, world, seeder));
 		REQUIRE(world.getTransmitters().size() == 1);
@@ -682,7 +682,7 @@ TEST_CASE("JSON: FMCW schedule validation matches chirp timing", "[serial][json]
 
 TEST_CASE("JSON: FMCW dechirp configuration validates and round-trips", "[serial][json][fmcw][dechirp]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	std::mt19937 seeder(42);
 
 	const auto make_scenario = [](json fmcw_mode)
@@ -819,7 +819,7 @@ TEST_CASE("JSON: FMCW dechirp configuration validates and round-trips", "[serial
 
 TEST_CASE("JSON: Vec3 Serialization and Deserialization", "[serial][json]")
 {
-	math::Vec3 v_orig(1.2, 3.4, 5.6);
+	math::Vec3 const v_orig(1.2, 3.4, 5.6);
 	json j = v_orig;
 
 	REQUIRE_THAT(j["x"].get<double>(), WithinAbs(1.2, 1e-9));
@@ -834,7 +834,7 @@ TEST_CASE("JSON: Vec3 Serialization and Deserialization", "[serial][json]")
 
 TEST_CASE("JSON: Focused PrototypeTiming Serialization", "[serial][json]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	core::World w;
 
 	auto pt = std::make_unique<timing::PrototypeTiming>("FocusTiming", 99);
@@ -850,7 +850,7 @@ TEST_CASE("JSON: Focused PrototypeTiming Serialization", "[serial][json]")
 
 TEST_CASE("JSON: Monostatic Radar Serialization", "[serial][json]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(10000.0); // 10 kHz -> 1e-4s sample period
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 10.0);
@@ -921,7 +921,7 @@ TEST_CASE("JSON: Monostatic Radar Serialization", "[serial][json]")
 
 TEST_CASE("JSON: Granular updates of Radar Components and Timing", "[serial][json]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(10000.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 10.0);
@@ -964,11 +964,11 @@ TEST_CASE("JSON: Granular updates of Radar Components and Timing", "[serial][jso
 
 	SECTION("Update Parameters")
 	{
-		json j = {{"starttime", 1.0},
-				  {"endtime", 20.0},
-				  {"rate", 2000.0},
-				  {"origin", {{"latitude", 10.0}, {"longitude", 20.0}, {"altitude", 30.0}}},
-				  {"coordinatesystem", {{"frame", "ECEF"}}}};
+		json const j = {{"starttime", 1.0},
+						{"endtime", 20.0},
+						{"rate", 2000.0},
+						{"origin", {{"latitude", 10.0}, {"longitude", 20.0}, {"altitude", 30.0}}},
+						{"coordinatesystem", {{"frame", "ECEF"}}}};
 		serial::update_parameters_from_json(j, seeder);
 
 		REQUIRE_THAT(params::startTime(), WithinAbs(1.0, 1e-9));
@@ -979,12 +979,12 @@ TEST_CASE("JSON: Granular updates of Radar Components and Timing", "[serial][jso
 
 	SECTION("Update Parameters rejects unsupported oversample ratios")
 	{
-		json j = {{"starttime", 1.0},
-				  {"endtime", 20.0},
-				  {"rate", 2000.0},
-				  {"oversample", 9},
-				  {"origin", {{"latitude", 10.0}, {"longitude", 20.0}, {"altitude", 30.0}}},
-				  {"coordinatesystem", {{"frame", "ECEF"}}}};
+		json const j = {{"starttime", 1.0},
+						{"endtime", 20.0},
+						{"rate", 2000.0},
+						{"oversample", 9},
+						{"origin", {{"latitude", 10.0}, {"longitude", 20.0}, {"altitude", 30.0}}},
+						{"coordinatesystem", {{"frame", "ECEF"}}}};
 
 		REQUIRE_THROWS_WITH(serial::update_parameters_from_json(j, seeder),
 							ContainsSubstring("Oversampling ratios > 8 are not supported"));
@@ -993,7 +993,7 @@ TEST_CASE("JSON: Granular updates of Radar Components and Timing", "[serial][jso
 	SECTION("Update Antenna In-Place")
 	{
 		auto* ant_ptr = w.findAntenna(20);
-		json j = {{"id", 20}, {"name", "ant_updated"}, {"pattern", "isotropic"}, {"efficiency", 0.5}};
+		json const j = {{"id", 20}, {"name", "ant_updated"}, {"pattern", "isotropic"}, {"efficiency", 0.5}};
 		serial::update_antenna_from_json(j, ant_ptr, w);
 
 		REQUIRE(ant_ptr->getName() == "ant_updated");
@@ -1003,8 +1003,8 @@ TEST_CASE("JSON: Granular updates of Radar Components and Timing", "[serial][jso
 	SECTION("Update Antenna Replacement")
 	{
 		auto* ant_ptr = w.findAntenna(20);
-		json j = {{"id", 20},	 {"name", "ant_replaced"}, {"pattern", "sinc"}, {"alpha", 1.0}, {"beta", 2.0},
-				  {"gamma", 3.0}};
+		json const j = {{"id", 20},	   {"name", "ant_replaced"}, {"pattern", "sinc"}, {"alpha", 1.0}, {"beta", 2.0},
+						{"gamma", 3.0}};
 		serial::update_antenna_from_json(j, ant_ptr, w);
 
 		auto* new_ant = w.findAntenna(20);
@@ -1017,7 +1017,7 @@ TEST_CASE("JSON: Granular updates of Radar Components and Timing", "[serial][jso
 	SECTION("Update Antenna Rejects Empty File Replacement")
 	{
 		auto* ant_ptr = w.findAntenna(20);
-		json j = {{"id", 20}, {"name", "draft_h5"}, {"pattern", "file"}, {"filename", ""}};
+		json const j = {{"id", 20}, {"name", "draft_h5"}, {"pattern", "file"}, {"filename", ""}};
 
 		REQUIRE_THROWS_WITH(serial::update_antenna_from_json(j, ant_ptr, w), ContainsSubstring("without a filename"));
 		REQUIRE(w.findAntenna(20) == ant_ptr);
@@ -1027,9 +1027,9 @@ TEST_CASE("JSON: Granular updates of Radar Components and Timing", "[serial][jso
 
 	SECTION("Update Transmitter")
 	{
-		json j = {{"name", "tx_updated"}, {"cw_mode", json::object()},
-				  {"waveform", 10},		  {"antenna", 20},
-				  {"timing", 30},		  {"schedule", json::array({{{"start", 0.1}, {"end", 0.5}}})}};
+		json const j = {{"name", "tx_updated"}, {"cw_mode", json::object()},
+						{"waveform", 10},		{"antenna", 20},
+						{"timing", 30},			{"schedule", json::array({{{"start", 0.1}, {"end", 0.5}}})}};
 		serial::update_transmitter_from_json(j, tx_ptr, w, seeder);
 
 		REQUIRE(tx_ptr->getName() == "tx_updated");
@@ -1043,7 +1043,7 @@ TEST_CASE("JSON: Granular updates of Radar Components and Timing", "[serial][jso
 
 	SECTION("Update Transmitter PRF")
 	{
-		json j = {{"pulsed_mode", {{"prf", 1250.0}}}};
+		json const j = {{"pulsed_mode", {{"prf", 1250.0}}}};
 		serial::update_transmitter_from_json(j, tx_ptr, w, seeder);
 
 		REQUIRE(tx_ptr->getMode() == radar::OperationMode::PULSED_MODE);
@@ -1052,13 +1052,13 @@ TEST_CASE("JSON: Granular updates of Radar Components and Timing", "[serial][jso
 
 	SECTION("Update Receiver")
 	{
-		json j = {{"name", "rx_updated"},
-				  {"pulsed_mode", {{"prf", 1250.0}, {"window_length", 1e-4}, {"window_skip", 1e-5}}},
-				  {"noise_temp", 400.0},
-				  {"nodirect", true},
-				  {"nopropagationloss", true},
-				  {"antenna", 20},
-				  {"timing", 30}};
+		json const j = {{"name", "rx_updated"},
+						{"pulsed_mode", {{"prf", 1250.0}, {"window_length", 1e-4}, {"window_skip", 1e-5}}},
+						{"noise_temp", 400.0},
+						{"nodirect", true},
+						{"nopropagationloss", true},
+						{"antenna", 20},
+						{"timing", 30}};
 		serial::update_receiver_from_json(j, rx_ptr, w, seeder);
 
 		REQUIRE(rx_ptr->getName() == "rx_updated");
@@ -1072,9 +1072,9 @@ TEST_CASE("JSON: Granular updates of Radar Components and Timing", "[serial][jso
 
 	SECTION("Update Target")
 	{
-		json j = {{"name", "tgt_updated"},
-				  {"rcs", {{"type", "isotropic"}, {"value", 50.0}}},
-				  {"model", {{"type", "chisquare"}, {"k", 3.0}}}};
+		json const j = {{"name", "tgt_updated"},
+						{"rcs", {{"type", "isotropic"}, {"value", 50.0}}},
+						{"model", {{"type", "chisquare"}, {"k", 3.0}}}};
 		serial::update_target_from_json(j, tgt_ptr, w, seeder);
 
 		// Note: update_target_from_json replaces the target in the world.
@@ -1092,14 +1092,14 @@ TEST_CASE("JSON: Granular updates of Radar Components and Timing", "[serial][jso
 	SECTION("Update Timing")
 	{
 		auto* pt_ptr = w.findTiming(30);
-		json j = {{"name", "tim_updated"},
-				  {"frequency", 2e6},
-				  {"synconpulse", true},
-				  {"freq_offset", 10.0},
-				  {"random_freq_offset_stdev", 2.0},
-				  {"phase_offset", 0.5},
-				  {"random_phase_offset_stdev", 0.1},
-				  {"noise_entries", json::array({{{"alpha", 1.0}, {"weight", 0.5}}})}};
+		json const j = {{"name", "tim_updated"},
+						{"frequency", 2e6},
+						{"synconpulse", true},
+						{"freq_offset", 10.0},
+						{"random_freq_offset_stdev", 2.0},
+						{"phase_offset", 0.5},
+						{"random_phase_offset_stdev", 0.1},
+						{"noise_entries", json::array({{{"alpha", 1.0}, {"weight", 0.5}}})}};
 		serial::update_timing_from_json(j, w, 30);
 
 		auto* updated_timing = w.findTiming(30);
@@ -1135,7 +1135,7 @@ TEST_CASE("JSON: Granular updates of Radar Components and Timing", "[serial][jso
 
 TEST_CASE("JSON: Granular updates of Monostatic Radar", "[serial][json]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 10.0);
@@ -1177,8 +1177,9 @@ TEST_CASE("JSON: Granular updates of Monostatic Radar", "[serial][json]")
 	w.add(std::move(rx));
 	w.add(std::move(p));
 
-	json j = {{"name", "mono_updated"},	   {"tx_id", 101},		  {"rx_id", 102},	  {"waveform", 10}, {"antenna", 20},
-			  {"cw_mode", json::object()}, {"noise_temp", 300.0}, {"nodirect", true}, {"timing", 30}};
+	json const j = {{"name", "mono_updated"}, {"tx_id", 101},	  {"rx_id", 102},
+					{"waveform", 10},		  {"antenna", 20},	  {"cw_mode", json::object()},
+					{"noise_temp", 300.0},	  {"nodirect", true}, {"timing", 30}};
 
 	serial::update_monostatic_from_json(j, tx_ptr, rx_ptr, w, seeder);
 
@@ -1193,18 +1194,18 @@ TEST_CASE("JSON: Granular updates of Monostatic Radar", "[serial][json]")
 	REQUIRE(rx_ptr->getTiming()->getSeed() == 12345);
 	REQUIRE(tx_ptr->getTiming().get() == rx_ptr->getTiming().get());
 
-	json fmcw_update = {{"name", "mono_fmcw"},
-						{"tx_id", 101},
-						{"rx_id", 102},
-						{"waveform", 11},
-						{"antenna", 20},
-						{"fmcw_mode",
-						 {{"dechirp_mode", "physical"},
-						  {"dechirp_reference", {{"source", "attached"}}},
-						  {"if_sample_rate", 100.0},
-						  {"if_filter_bandwidth", 40.0},
-						  {"if_filter_transition_width", 10.0}}},
-						{"timing", 30}};
+	json const fmcw_update = {{"name", "mono_fmcw"},
+							  {"tx_id", 101},
+							  {"rx_id", 102},
+							  {"waveform", 11},
+							  {"antenna", 20},
+							  {"fmcw_mode",
+							   {{"dechirp_mode", "physical"},
+								{"dechirp_reference", {{"source", "attached"}}},
+								{"if_sample_rate", 100.0},
+								{"if_filter_bandwidth", 40.0},
+								{"if_filter_transition_width", 10.0}}},
+							  {"timing", 30}};
 
 	REQUIRE_NOTHROW(serial::update_monostatic_from_json(fmcw_update, tx_ptr, rx_ptr, w, seeder));
 	REQUIRE(tx_ptr->getMode() == radar::OperationMode::FMCW_MODE);

--- a/packages/libfers/tests/serial/test_json_serializer.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer.cpp
@@ -195,7 +195,9 @@ TEST_CASE("JSON: FMCW triangle round trips", "[serial][json][fmcw]")
 	REQUIRE(wf->isFmcwFamily());
 	REQUIRE(wf->isFmcwTriangle());
 	REQUIRE(wf->getFmcwTriangleSignal() != nullptr);
-	REQUIRE(wf->getFmcwTriangleSignal()->getTriangleCount().value() == 3);
+	const auto triangle_count = wf->getFmcwTriangleSignal()->getTriangleCount();
+	REQUIRE(triangle_count.has_value());
+	REQUIRE(triangle_count.value_or(0u) == 3u);
 
 	json serialized;
 	fers_signal::to_json(serialized, *wf);
@@ -206,7 +208,9 @@ TEST_CASE("JSON: FMCW triangle round trips", "[serial][json][fmcw]")
 	auto reparsed = serial::parse_waveform_from_json(serialized);
 	REQUIRE(reparsed != nullptr);
 	REQUIRE(reparsed->getFmcwTriangleSignal() != nullptr);
-	REQUIRE(reparsed->getFmcwTriangleSignal()->getTriangleCount().value() == 3);
+	const auto reparsed_triangle_count = reparsed->getFmcwTriangleSignal()->getTriangleCount();
+	REQUIRE(reparsed_triangle_count.has_value());
+	REQUIRE(reparsed_triangle_count.value_or(0u) == 3u);
 }
 
 TEST_CASE("JSON: FMCW triangle rejects fractional triangle count", "[serial][json][fmcw]")
@@ -765,9 +769,9 @@ TEST_CASE("JSON: FMCW dechirp configuration validates and round-trips", "[serial
 		REQUIRE(if_chain.sample_rate_hz.has_value());
 		REQUIRE(if_chain.filter_bandwidth_hz.has_value());
 		REQUIRE(if_chain.filter_transition_width_hz.has_value());
-		REQUIRE_THAT(*if_chain.sample_rate_hz, WithinAbs(1.0e6, 1.0e-9));
-		REQUIRE_THAT(*if_chain.filter_bandwidth_hz, WithinAbs(4.0e5, 1.0e-9));
-		REQUIRE_THAT(*if_chain.filter_transition_width_hz, WithinAbs(1.0e5, 1.0e-9));
+		REQUIRE_THAT(if_chain.sample_rate_hz.value_or(0.0), WithinAbs(1.0e6, 1.0e-9));
+		REQUIRE_THAT(if_chain.filter_bandwidth_hz.value_or(0.0), WithinAbs(4.0e5, 1.0e-9));
+		REQUIRE_THAT(if_chain.filter_transition_width_hz.value_or(0.0), WithinAbs(1.0e5, 1.0e-9));
 
 		const json serialized = serial::world_to_json(world);
 		const auto& mode_json =
@@ -1121,10 +1125,10 @@ TEST_CASE("JSON: Granular updates of Radar Components and Timing", "[serial][jso
 		REQUIRE(updated_timing->getName() == "tim_updated");
 		REQUIRE_THAT(updated_timing->getFrequency(), WithinAbs(2e6, 1e-9));
 		REQUIRE(updated_timing->getSyncOnPulse() == true);
-		REQUIRE_THAT(updated_timing->getFreqOffset().value(), WithinAbs(10.0, 1e-9));
-		REQUIRE_THAT(updated_timing->getRandomFreqOffsetStdev().value(), WithinAbs(2.0, 1e-9));
-		REQUIRE_THAT(updated_timing->getPhaseOffset().value(), WithinAbs(0.5, 1e-9));
-		REQUIRE_THAT(updated_timing->getRandomPhaseOffsetStdev().value(), WithinAbs(0.1, 1e-9));
+		REQUIRE_THAT(updated_timing->getFreqOffset().value_or(0.0), WithinAbs(10.0, 1e-9));
+		REQUIRE_THAT(updated_timing->getRandomFreqOffsetStdev().value_or(0.0), WithinAbs(2.0, 1e-9));
+		REQUIRE_THAT(updated_timing->getPhaseOffset().value_or(0.0), WithinAbs(0.5, 1e-9));
+		REQUIRE_THAT(updated_timing->getRandomPhaseOffsetStdev().value_or(0.0), WithinAbs(0.1, 1e-9));
 
 		std::vector<RealType> alphas, weights;
 		updated_timing->copyAlphas(alphas, weights);
@@ -1223,7 +1227,7 @@ TEST_CASE("JSON: Granular updates of Monostatic Radar", "[serial][json]")
 	REQUIRE(tx_ptr->getMode() == radar::OperationMode::FMCW_MODE);
 	REQUIRE(rx_ptr->getMode() == radar::OperationMode::FMCW_MODE);
 	REQUIRE(rx_ptr->getDechirpMode() == radar::Receiver::DechirpMode::Physical);
-	REQUIRE_THAT(*rx_ptr->getIfSampleRate(), WithinAbs(100.0, 1e-12));
-	REQUIRE_THAT(*rx_ptr->getIfFilterBandwidth(), WithinAbs(40.0, 1e-12));
-	REQUIRE_THAT(*rx_ptr->getIfFilterTransitionWidth(), WithinAbs(10.0, 1e-12));
+	REQUIRE_THAT(rx_ptr->getIfSampleRate().value_or(0.0), WithinAbs(100.0, 1e-12));
+	REQUIRE_THAT(rx_ptr->getIfFilterBandwidth().value_or(0.0), WithinAbs(40.0, 1e-12));
+	REQUIRE_THAT(rx_ptr->getIfFilterTransitionWidth().value_or(0.0), WithinAbs(10.0, 1e-12));
 }

--- a/packages/libfers/tests/serial/test_json_serializer.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer.cpp
@@ -61,7 +61,7 @@ namespace
 	{
 		std::ostringstream buffer;
 		std::streambuf* old{nullptr};
-		CerrCapture() { old = std::cerr.rdbuf(buffer.rdbuf()); }
+		CerrCapture() : old(std::cerr.rdbuf(buffer.rdbuf())) {}
 		CerrCapture(const CerrCapture&) = delete;
 		CerrCapture& operator=(const CerrCapture&) = delete;
 		CerrCapture(CerrCapture&&) = delete;

--- a/packages/libfers/tests/serial/test_json_serializer.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer.cpp
@@ -50,6 +50,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 
@@ -58,6 +62,10 @@ namespace
 		std::ostringstream buffer;
 		std::streambuf* old{nullptr};
 		CerrCapture() { old = std::cerr.rdbuf(buffer.rdbuf()); }
+		CerrCapture(const CerrCapture&) = delete;
+		CerrCapture& operator=(const CerrCapture&) = delete;
+		CerrCapture(CerrCapture&&) = delete;
+		CerrCapture& operator=(CerrCapture&&) = delete;
 		~CerrCapture() { std::cerr.rdbuf(old); }
 		[[nodiscard]] std::string str() const { return buffer.str(); }
 	};
@@ -65,6 +73,10 @@ namespace
 	struct LogLevelGuard
 	{
 		explicit LogLevelGuard(const logging::Level level) { logging::logger.setLevel(level); }
+		LogLevelGuard(const LogLevelGuard&) = delete;
+		LogLevelGuard& operator=(const LogLevelGuard&) = delete;
+		LogLevelGuard(LogLevelGuard&&) = delete;
+		LogLevelGuard& operator=(LogLevelGuard&&) = delete;
 		~LogLevelGuard() { logging::logger.setLevel(logging::Level::INFO); }
 	};
 }

--- a/packages/libfers/tests/serial/test_json_serializer.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer.cpp
@@ -143,7 +143,7 @@ TEST_CASE("JSON: FMCW linear chirp direction round trips", "[serial][json][fmcw]
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 1.0);
 
-	for (const auto direction : {"up", "down"})
+	for (const auto* const direction : {"up", "down"})
 	{
 		json const wf_json = {{"id", 457},
 							  {"name", std::string("Fmcw") + direction},
@@ -378,7 +378,7 @@ TEST_CASE("JSON: Serialization of Assets and Radar Components", "[serial][json]"
 			if (c.contains("receiver"))
 			{
 				found_rx = true;
-				auto& rx_json = c["receiver"];
+				const auto& rx_json = c["receiver"];
 				REQUIRE_THAT(rx_json["noise_temp"].get<double>(), WithinAbs(300.0, 1e-9));
 				REQUIRE(rx_json["nodirect"] == true);
 				REQUIRE(rx_json["nopropagationloss"] == true);
@@ -444,8 +444,8 @@ TEST_CASE("JSON: Full World Scenario Deserialization", "[serial][json]")
 	REQUIRE(params::params.random_seed == 777);
 	REQUIRE(params::params.rotation_angle_unit == params::RotationAngleUnit::Radians);
 
-	auto tx = world.getTransmitters()[0].get();
-	auto rx = world.getReceivers()[0].get();
+	auto* tx = world.getTransmitters()[0].get();
+	auto* rx = world.getReceivers()[0].get();
 	REQUIRE(tx->getAttached() == rx);
 	REQUIRE(rx->getAttached() == tx);
 	REQUIRE(tx->getTiming().get() == rx->getTiming().get());

--- a/packages/libfers/tests/serial/test_json_serializer.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer.cpp
@@ -79,6 +79,233 @@ namespace
 		LogLevelGuard& operator=(LogLevelGuard&&) = delete;
 		~LogLevelGuard() { logging::logger.setLevel(logging::Level::INFO); }
 	};
+
+	void configureFmcwRoundTripParams()
+	{
+		params::setRate(2.0e6);
+		params::setOversampleRatio(1);
+		params::setTime(0.0, 1.0);
+	}
+
+	[[nodiscard]] json linearChirpJson(const std::string_view direction)
+	{
+		return {{"id", 457},
+				{"name", std::string("Fmcw") + std::string(direction)},
+				{"power", 500.0},
+				{"carrier_frequency", 2.4e9},
+				{"fmcw_linear_chirp",
+				 {{"direction", direction},
+				  {"chirp_bandwidth", 1.0e6},
+				  {"chirp_duration", 1.0e-3},
+				  {"chirp_period", 1.0e-3}}}};
+	}
+
+	void requireLinearChirpDirectionRoundTrip(const std::string_view direction)
+	{
+		auto wf = serial::parse_waveform_from_json(linearChirpJson(direction));
+		REQUIRE(wf != nullptr);
+		REQUIRE(wf->getFmcwChirpSignal() != nullptr);
+		REQUIRE(wf->getFmcwChirpSignal()->isDownChirp() == (direction == "down"));
+
+		json serialized;
+		fers_signal::to_json(serialized, *wf);
+		REQUIRE(serialized.contains("fmcw_linear_chirp"));
+		REQUIRE_FALSE(serialized.contains("fmcw_up_chirp"));
+		REQUIRE(serialized.at("fmcw_linear_chirp").at("direction") == direction);
+
+		auto reparsed = serial::parse_waveform_from_json(serialized);
+		REQUIRE(reparsed != nullptr);
+		REQUIRE(reparsed->getFmcwChirpSignal() != nullptr);
+		REQUIRE(reparsed->getFmcwChirpSignal()->isDownChirp() == (direction == "down"));
+	}
+
+	void configureSerializableWorldParams()
+	{
+		params::setRate(1000.0);
+		params::setOversampleRatio(1);
+		params::setTime(0.0, 10.0);
+	}
+
+	void populateSerializableAssetsWorld(core::World& world)
+	{
+		auto cw = std::make_unique<fers_signal::CwSignal>();
+		world.add(std::make_unique<fers_signal::RadarSignal>("CwWave", 10.0, 1e9, 1.0, std::move(cw), 10));
+		world.add(std::make_unique<antenna::Gaussian>("gauss", 1.5, 2.5, 20));
+
+		auto proto_tim = std::make_unique<timing::PrototypeTiming>("dummy_proto", 104);
+		proto_tim->setFrequency(10e6);
+		auto tim = std::make_shared<timing::Timing>("dummy_time", 42, 103);
+		tim->initializeModel(proto_tim.get());
+		world.add(std::move(proto_tim));
+
+		auto platform = std::make_unique<radar::Platform>("p1", 100);
+		auto transmitter =
+			std::make_unique<radar::Transmitter>(platform.get(), "tx", radar::OperationMode::PULSED_MODE, 101);
+		transmitter->setTiming(tim);
+		transmitter->setPrf(1000.0);
+		transmitter->setSchedule({{0.1, 0.5}});
+
+		auto target = radar::createIsoTarget(platform.get(), "tgt", 10.0, 42, 102);
+		target->setFluctuationModel(std::make_unique<radar::RcsChiSquare>(target->getRngEngine(), 2.5));
+
+		auto receiver =
+			std::make_unique<radar::Receiver>(platform.get(), "rx", 88, radar::OperationMode::PULSED_MODE, 105);
+		receiver->setTiming(tim);
+		receiver->setWindowProperties(1e-4, 1000.0, 1e-5);
+		receiver->setNoiseTemperature(300.0);
+		receiver->setFlag(radar::Receiver::RecvFlag::FLAG_NODIRECT);
+		receiver->setFlag(radar::Receiver::RecvFlag::FLAG_NOPROPLOSS);
+
+		world.add(std::move(transmitter));
+		world.add(std::move(target));
+		world.add(std::move(receiver));
+		world.add(std::move(platform));
+	}
+
+	void requireSerializedAssets(const json& simulation_json)
+	{
+		REQUIRE(simulation_json["waveforms"][0]["name"] == "CwWave");
+		REQUIRE_THAT(simulation_json["waveforms"][0]["power"].get<double>(), WithinAbs(10.0, 1e-9));
+		REQUIRE(simulation_json["waveforms"][0].contains("cw"));
+
+		REQUIRE(simulation_json["antennas"][0]["pattern"] == "gaussian");
+		REQUIRE_THAT(simulation_json["antennas"][0]["azscale"].get<double>(), WithinAbs(1.5, 1e-9));
+	}
+
+	[[nodiscard]] const json* findComponent(const json& components, const std::string_view key)
+	{
+		const std::string key_string(key);
+		for (const auto& component : components)
+		{
+			if (component.contains(key_string))
+			{
+				return &component.at(key_string);
+			}
+		}
+		return nullptr;
+	}
+
+	[[nodiscard]] const json& requireComponent(const json& components, const std::string_view key)
+	{
+		const auto* component = findComponent(components, key);
+		REQUIRE(component != nullptr);
+		return *component;
+	}
+
+	void requireSerializedTransmitter(const json& transmitter_json)
+	{
+		REQUIRE_THAT(transmitter_json["pulsed_mode"]["prf"].get<double>(), WithinAbs(1000.0, 1e-9));
+		REQUIRE_THAT(transmitter_json["schedule"][0]["start"].get<double>(), WithinAbs(0.1, 1e-9));
+	}
+
+	void requireSerializedTarget(const json& target_json)
+	{
+		REQUIRE(target_json["rcs"]["type"] == "isotropic");
+		REQUIRE_THAT(target_json["rcs"]["value"].get<double>(), WithinAbs(10.0, 1e-9));
+		REQUIRE(target_json["model"]["type"] == "chisquare");
+		REQUIRE_THAT(target_json["model"]["k"].get<double>(), WithinAbs(2.5, 1e-9));
+	}
+
+	void requireSerializedReceiver(const json& receiver_json)
+	{
+		REQUIRE_THAT(receiver_json["noise_temp"].get<double>(), WithinAbs(300.0, 1e-9));
+		REQUIRE(receiver_json["nodirect"] == true);
+		REQUIRE(receiver_json["nopropagationloss"] == true);
+		REQUIRE_THAT(receiver_json["pulsed_mode"]["window_length"].get<double>(), WithinAbs(1e-4, 1e-9));
+	}
+
+	void requireSerializedRadarComponents(const json& components)
+	{
+		REQUIRE(components.size() == 3);
+		requireSerializedTransmitter(requireComponent(components, "transmitter"));
+		requireSerializedTarget(requireComponent(components, "target"));
+		requireSerializedReceiver(requireComponent(components, "receiver"));
+	}
+
+	[[nodiscard]] json badComponentScenario(const json& test_components)
+	{
+		return {
+			{"simulation",
+			 {{"parameters",
+			   {{"starttime", 0.0},
+				{"endtime", 1.0},
+				{"rate", 1000.0},
+				{"origin", {{"latitude", 0.0}, {"longitude", 0.0}, {"altitude", 0.0}}},
+				{"coordinatesystem", {{"frame", "ENU"}}}}},
+			  {"waveforms",
+			   json::array(
+				   {{{"id", 10}, {"name", "w1"}, {"power", 1.0}, {"carrier_frequency", 1.0}, {"cw", json::object()}}})},
+			  {"antennas", json::array({{{"id", 20}, {"name", "a1"}, {"pattern", "isotropic"}}})},
+			  {"timings", json::array({{{"id", 30}, {"name", "t1"}, {"frequency", 1e6}}})},
+			  {"platforms", json::array({{{"id", 100}, {"name", "p1"}, {"components", test_components}}})}}}};
+	}
+
+	[[nodiscard]] json fmcwDechirpScenario(json fmcw_mode)
+	{
+		json scenario;
+		scenario["simulation"]["parameters"] = {{"starttime", 0.0},
+												{"endtime", 1.0e-3},
+												{"rate", 4.0e6},
+												{"origin", {{"latitude", 0.0}, {"longitude", 0.0}, {"altitude", 0.0}}},
+												{"coordinatesystem", {{"frame", "ENU"}}}};
+		scenario["simulation"]["waveforms"] = json::array({{{"id", 10},
+															{"name", "fmcw_wave"},
+															{"power", 1.0},
+															{"carrier_frequency", 1.0e9},
+															{"fmcw_linear_chirp",
+															 {{"direction", "up"},
+															  {"chirp_bandwidth", 1.0e6},
+															  {"chirp_duration", 1.0e-4},
+															  {"chirp_period", 1.0e-4}}}}});
+		scenario["simulation"]["antennas"] = json::array({{{"id", 20}, {"name", "a1"}, {"pattern", "isotropic"}}});
+		scenario["simulation"]["timings"] = json::array({{{"id", 30}, {"name", "t1"}, {"frequency", 1.0e6}}});
+		scenario["simulation"]["platforms"] = json::array({{{"id", 100},
+															{"name", "p1"},
+															{"components",
+															 json::array({{{"monostatic",
+																			{{"name", "mono1"},
+																			 {"tx_id", 101},
+																			 {"rx_id", 102},
+																			 {"waveform", 10},
+																			 {"antenna", 20},
+																			 {"timing", 30},
+																			 {"fmcw_mode", fmcw_mode}}}}})}}});
+		return scenario;
+	}
+
+	void requireAttachedDechirpRoundTrip(core::World& world)
+	{
+		REQUIRE(world.getReceivers().size() == 1);
+		const auto* rx = world.getReceivers().front().get();
+		REQUIRE(rx->getDechirpMode() == radar::Receiver::DechirpMode::Physical);
+		REQUIRE(rx->getDechirpReference().source == radar::Receiver::DechirpReferenceSource::Attached);
+		REQUIRE_FALSE(rx->getDechirpSources().empty());
+
+		const json serialized = serial::world_to_json(world);
+		const auto& mode_json =
+			serialized.at("simulation").at("platforms").at(0).at("components").at(0).at("monostatic").at("fmcw_mode");
+		REQUIRE(mode_json.at("dechirp_mode") == "physical");
+		REQUIRE(mode_json.at("dechirp_reference").at("source") == "attached");
+	}
+
+	void requireIfChainRoundTrip(core::World& world)
+	{
+		const auto* rx = world.getReceivers().front().get();
+		const auto& if_chain = rx->getFmcwIfChainRequest();
+		REQUIRE(if_chain.sample_rate_hz.has_value());
+		REQUIRE(if_chain.filter_bandwidth_hz.has_value());
+		REQUIRE(if_chain.filter_transition_width_hz.has_value());
+		REQUIRE_THAT(if_chain.sample_rate_hz.value_or(0.0), WithinAbs(1.0e6, 1.0e-9));
+		REQUIRE_THAT(if_chain.filter_bandwidth_hz.value_or(0.0), WithinAbs(4.0e5, 1.0e-9));
+		REQUIRE_THAT(if_chain.filter_transition_width_hz.value_or(0.0), WithinAbs(1.0e5, 1.0e-9));
+
+		const json serialized = serial::world_to_json(world);
+		const auto& mode_json =
+			serialized.at("simulation").at("platforms").at(0).at("components").at(0).at("monostatic").at("fmcw_mode");
+		REQUIRE(mode_json.at("if_sample_rate") == 1.0e6);
+		REQUIRE(mode_json.at("if_filter_bandwidth") == 4.0e5);
+		REQUIRE(mode_json.at("if_filter_transition_width") == 1.0e5);
+	}
 }
 
 TEST_CASE("JSON: Granular parsing of Antenna and Waveform", "[serial][json]")
@@ -139,37 +366,11 @@ TEST_CASE("JSON: FMCW waveform emits large-buffer warning", "[serial][json]")
 TEST_CASE("JSON: FMCW linear chirp direction round trips", "[serial][json][fmcw]")
 {
 	ParamGuard const guard;
-	params::setRate(2.0e6);
-	params::setOversampleRatio(1);
-	params::setTime(0.0, 1.0);
+	configureFmcwRoundTripParams();
 
 	for (const auto* const direction : {"up", "down"})
 	{
-		json const wf_json = {{"id", 457},
-							  {"name", std::string("Fmcw") + direction},
-							  {"power", 500.0},
-							  {"carrier_frequency", 2.4e9},
-							  {"fmcw_linear_chirp",
-							   {{"direction", direction},
-								{"chirp_bandwidth", 1.0e6},
-								{"chirp_duration", 1.0e-3},
-								{"chirp_period", 1.0e-3}}}};
-
-		auto wf = serial::parse_waveform_from_json(wf_json);
-		REQUIRE(wf != nullptr);
-		REQUIRE(wf->getFmcwChirpSignal() != nullptr);
-		REQUIRE(wf->getFmcwChirpSignal()->isDownChirp() == (std::string_view(direction) == "down"));
-
-		json serialized;
-		fers_signal::to_json(serialized, *wf);
-		REQUIRE(serialized.contains("fmcw_linear_chirp"));
-		REQUIRE_FALSE(serialized.contains("fmcw_up_chirp"));
-		REQUIRE(serialized.at("fmcw_linear_chirp").at("direction") == direction);
-
-		auto reparsed = serial::parse_waveform_from_json(serialized);
-		REQUIRE(reparsed != nullptr);
-		REQUIRE(reparsed->getFmcwChirpSignal() != nullptr);
-		REQUIRE(reparsed->getFmcwChirpSignal()->isDownChirp() == (std::string_view(direction) == "down"));
+		requireLinearChirpDirectionRoundTrip(direction);
 	}
 }
 
@@ -296,98 +497,18 @@ TEST_CASE("JSON: Serialization of Math and Timing Structures", "[serial][json]")
 TEST_CASE("JSON: Serialization of Assets and Radar Components", "[serial][json]")
 {
 	ParamGuard const guard;
-
-	// MUST initialize global simulation parameters to avoid division-by-zero
-	// Without this, params::rate() is 0.0, causing the PRF math to evaluate to NaN.
-	params::setRate(1000.0);
-	params::setOversampleRatio(1);
-	params::setTime(0.0, 10.0);
+	configureSerializableWorldParams();
 
 	core::World w;
-
-	// Assets
-	auto cw = std::make_unique<fers_signal::CwSignal>();
-	w.add(std::make_unique<fers_signal::RadarSignal>("CwWave", 10.0, 1e9, 1.0, std::move(cw), 10));
-	w.add(std::make_unique<antenna::Gaussian>("gauss", 1.5, 2.5, 20));
-
-	// PrototypeTiming AND Timing must both be properly initialized
-	auto proto_tim = std::make_unique<timing::PrototypeTiming>("dummy_proto", 104);
-	proto_tim->setFrequency(10e6);
-	auto tim = std::make_shared<timing::Timing>("dummy_time", 42, 103);
-	tim->initializeModel(proto_tim.get());
-	w.add(std::move(proto_tim));
-
-	// Platform & Components
-	auto p = std::make_unique<radar::Platform>("p1", 100);
-	auto tx = std::make_unique<radar::Transmitter>(p.get(), "tx", radar::OperationMode::PULSED_MODE, 101);
-
-	// Set timing FIRST, then PRF, then Schedule, to guarantee internal math has all variables
-	tx->setTiming(tim);
-	tx->setPrf(1000.0);
-	tx->setSchedule({{0.1, 0.5}});
-
-	auto tgt = radar::createIsoTarget(p.get(), "tgt", 10.0, 42, 102);
-	tgt->setFluctuationModel(std::make_unique<radar::RcsChiSquare>(tgt->getRngEngine(), 2.5));
-
-	auto rx = std::make_unique<radar::Receiver>(p.get(), "rx", 88, radar::OperationMode::PULSED_MODE, 105);
-	rx->setTiming(tim);
-	rx->setWindowProperties(1e-4, 1000.0, 1e-5);
-	rx->setNoiseTemperature(300.0);
-	rx->setFlag(radar::Receiver::RecvFlag::FLAG_NODIRECT);
-	rx->setFlag(radar::Receiver::RecvFlag::FLAG_NOPROPLOSS);
-
-	w.add(std::move(tx));
-	w.add(std::move(tgt));
-	w.add(std::move(rx));
-	w.add(std::move(p));
+	populateSerializableAssetsWorld(w);
 
 	json j = serial::world_to_json(w);
 
-	SECTION("Assets Serialize Correctly")
-	{
-		REQUIRE(j["simulation"]["waveforms"][0]["name"] == "CwWave");
-		REQUIRE_THAT(j["simulation"]["waveforms"][0]["power"].get<double>(), WithinAbs(10.0, 1e-9));
-		REQUIRE(j["simulation"]["waveforms"][0].contains("cw"));
-
-		REQUIRE(j["simulation"]["antennas"][0]["pattern"] == "gaussian");
-		REQUIRE_THAT(j["simulation"]["antennas"][0]["azscale"].get<double>(), WithinAbs(1.5, 1e-9));
-	}
+	SECTION("Assets Serialize Correctly") { requireSerializedAssets(j["simulation"]); }
 
 	SECTION("Radar Components Serialize Correctly")
 	{
-		auto& comps = j["simulation"]["platforms"][0]["components"];
-		REQUIRE(comps.size() == 3);
-
-		bool found_tx = false, found_tgt = false, found_rx = false;
-		for (const auto& c : comps)
-		{
-			if (c.contains("transmitter"))
-			{
-				found_tx = true;
-				REQUIRE_THAT(c["transmitter"]["pulsed_mode"]["prf"].get<double>(), WithinAbs(1000.0, 1e-9));
-				REQUIRE_THAT(c["transmitter"]["schedule"][0]["start"].get<double>(), WithinAbs(0.1, 1e-9));
-			}
-			if (c.contains("target"))
-			{
-				found_tgt = true;
-				REQUIRE(c["target"]["rcs"]["type"] == "isotropic");
-				REQUIRE_THAT(c["target"]["rcs"]["value"].get<double>(), WithinAbs(10.0, 1e-9));
-				REQUIRE(c["target"]["model"]["type"] == "chisquare");
-				REQUIRE_THAT(c["target"]["model"]["k"].get<double>(), WithinAbs(2.5, 1e-9));
-			}
-			if (c.contains("receiver"))
-			{
-				found_rx = true;
-				const auto& rx_json = c["receiver"];
-				REQUIRE_THAT(rx_json["noise_temp"].get<double>(), WithinAbs(300.0, 1e-9));
-				REQUIRE(rx_json["nodirect"] == true);
-				REQUIRE(rx_json["nopropagationloss"] == true);
-				REQUIRE_THAT(rx_json["pulsed_mode"]["window_length"].get<double>(), WithinAbs(1e-4, 1e-9));
-			}
-		}
-		REQUIRE(found_tx);
-		REQUIRE(found_tgt);
-		REQUIRE(found_rx);
+		requireSerializedRadarComponents(j["simulation"]["platforms"][0]["components"]);
 	}
 }
 
@@ -579,63 +700,55 @@ TEST_CASE("JSON: Rotation parsing warns when values look like the opposite unit"
 	REQUIRE_THAT(capture.str(), ContainsSubstring("declared"));
 }
 
-TEST_CASE("JSON: Deserialization Error Paths", "[serial][json]")
+TEST_CASE("JSON: Deserialization Error Paths rejects missing transmitter mode", "[serial][json]")
 {
 	ParamGuard const guard;
 	core::World world;
 	std::mt19937 seeder(42);
+	json const test_comps = json::array(
+		{{{"transmitter", {{"id", 1}, {"name", "tx1"}, {"waveform", 10}, {"antenna", 20}, {"timing", 30}}}}});
 
-	auto run_bad_scenario = [&](const json& test_comps)
-	{
-		json const scenario = {
-			{"simulation",
-			 {{"parameters",
-			   {{"starttime", 0.0},
-				{"endtime", 1.0},
-				{"rate", 1000.0},
-				{"origin", {{"latitude", 0.0}, {"longitude", 0.0}, {"altitude", 0.0}}},
-				{"coordinatesystem", {{"frame", "ENU"}}}}},
-			  {"waveforms",
-			   json::array(
-				   {{{"id", 10}, {"name", "w1"}, {"power", 1.0}, {"carrier_frequency", 1.0}, {"cw", json::object()}}})},
-			  {"antennas", json::array({{{"id", 20}, {"name", "a1"}, {"pattern", "isotropic"}}})},
-			  {"timings", json::array({{{"id", 30}, {"name", "t1"}, {"frequency", 1e6}}})},
-			  {"platforms", json::array({{{"id", 100}, {"name", "p1"}, {"components", test_comps}}})}}}};
-		serial::json_to_world(scenario, world, seeder);
-	};
+	REQUIRE_THROWS_WITH(serial::json_to_world(badComponentScenario(test_comps), world, seeder),
+						ContainsSubstring("must have a 'pulsed_mode', 'cw_mode', or 'fmcw_mode' block"));
+}
 
-	SECTION("Missing mode throws")
-	{
-		json const test_comps = json::array(
-			{{{"transmitter", {{"id", 1}, {"name", "tx1"}, {"waveform", 10}, {"antenna", 20}, {"timing", 30}}}}});
-		REQUIRE_THROWS_WITH(run_bad_scenario(test_comps),
-							ContainsSubstring("must have a 'pulsed_mode', 'cw_mode', or 'fmcw_mode' block"));
-	}
+TEST_CASE("JSON: Deserialization Error Paths rejects unsupported RCS type", "[serial][json]")
+{
+	ParamGuard const guard;
+	core::World world;
+	std::mt19937 seeder(42);
+	json const test_comps =
+		json::array({{{"target", {{"id", 1}, {"name", "bad-target"}, {"rcs", {{"type", "magic"}}}}}}});
 
-	SECTION("Unsupported RCS type throws")
-	{
-		json const test_comps =
-			json::array({{{"target", {{"id", 1}, {"name", "bad-target"}, {"rcs", {{"type", "magic"}}}}}}});
-		REQUIRE_THROWS_WITH(run_bad_scenario(test_comps), ContainsSubstring("Unsupported target RCS type: magic"));
-	}
+	REQUIRE_THROWS_WITH(serial::json_to_world(badComponentScenario(test_comps), world, seeder),
+						ContainsSubstring("Unsupported target RCS type: magic"));
+}
 
-	SECTION("Unsupported Fluctuation model type throws")
-	{
-		json const test_comps = json::array({{{"target",
-											   {{"id", 1},
-												{"name", "bad-target"},
-												{"rcs", {{"type", "isotropic"}, {"value", 1.0}}},
-												{"model", {{"type", "magic"}}}}}}});
-		REQUIRE_THROWS_WITH(run_bad_scenario(test_comps),
-							ContainsSubstring("Unsupported fluctuation model type: magic"));
-	}
+TEST_CASE("JSON: Deserialization Error Paths rejects unsupported fluctuation model type", "[serial][json]")
+{
+	ParamGuard const guard;
+	core::World world;
+	std::mt19937 seeder(42);
+	json const test_comps = json::array({{{"target",
+										   {{"id", 1},
+											{"name", "bad-target"},
+											{"rcs", {{"type", "isotropic"}, {"value", 1.0}}},
+											{"model", {{"type", "magic"}}}}}}});
 
-	SECTION("Negative ID throws")
-	{
-		json const test_comps = json::array(
-			{{{"target", {{"id", -5}, {"name", "bad-target"}, {"rcs", {{"type", "isotropic"}, {"value", 1.0}}}}}}});
-		REQUIRE_THROWS_WITH(run_bad_scenario(test_comps), ContainsSubstring("negative id"));
-	}
+	REQUIRE_THROWS_WITH(serial::json_to_world(badComponentScenario(test_comps), world, seeder),
+						ContainsSubstring("Unsupported fluctuation model type: magic"));
+}
+
+TEST_CASE("JSON: Deserialization Error Paths rejects negative IDs", "[serial][json]")
+{
+	ParamGuard const guard;
+	core::World world;
+	std::mt19937 seeder(42);
+	json const test_comps = json::array(
+		{{{"target", {{"id", -5}, {"name", "bad-target"}, {"rcs", {{"type", "isotropic"}, {"value", 1.0}}}}}}});
+
+	REQUIRE_THROWS_WITH(serial::json_to_world(badComponentScenario(test_comps), world, seeder),
+						ContainsSubstring("negative id"));
 }
 
 TEST_CASE("JSON: FMCW schedule validation matches chirp timing", "[serial][json][fmcw]")
@@ -696,141 +809,100 @@ TEST_CASE("JSON: FMCW schedule validation matches chirp timing", "[serial][json]
 	}
 }
 
-TEST_CASE("JSON: FMCW dechirp configuration validates and round-trips", "[serial][json][fmcw][dechirp]")
+TEST_CASE("JSON: FMCW dechirp attached reference round-trips", "[serial][json][fmcw][dechirp]")
 {
 	ParamGuard const guard;
 	std::mt19937 seeder(42);
+	core::World world;
+	const auto scenario =
+		fmcwDechirpScenario({{"dechirp_mode", "physical"}, {"dechirp_reference", {{"source", "attached"}}}});
 
-	const auto make_scenario = [](json fmcw_mode)
-	{
-		json scenario;
-		scenario["simulation"]["parameters"] = {{"starttime", 0.0},
-												{"endtime", 1.0e-3},
-												{"rate", 4.0e6},
-												{"origin", {{"latitude", 0.0}, {"longitude", 0.0}, {"altitude", 0.0}}},
-												{"coordinatesystem", {{"frame", "ENU"}}}};
-		scenario["simulation"]["waveforms"] = json::array({{{"id", 10},
-															{"name", "fmcw_wave"},
-															{"power", 1.0},
-															{"carrier_frequency", 1.0e9},
-															{"fmcw_linear_chirp",
-															 {{"direction", "up"},
-															  {"chirp_bandwidth", 1.0e6},
-															  {"chirp_duration", 1.0e-4},
-															  {"chirp_period", 1.0e-4}}}}});
-		scenario["simulation"]["antennas"] = json::array({{{"id", 20}, {"name", "a1"}, {"pattern", "isotropic"}}});
-		scenario["simulation"]["timings"] = json::array({{{"id", 30}, {"name", "t1"}, {"frequency", 1.0e6}}});
-		scenario["simulation"]["platforms"] = json::array({{{"id", 100},
-															{"name", "p1"},
-															{"components",
-															 json::array({{{"monostatic",
-																			{{"name", "mono1"},
-																			 {"tx_id", 101},
-																			 {"rx_id", 102},
-																			 {"waveform", 10},
-																			 {"antenna", 20},
-																			 {"timing", 30},
-																			 {"fmcw_mode", fmcw_mode}}}}})}}});
-		return scenario;
-	};
+	REQUIRE_NOTHROW(serial::json_to_world(scenario, world, seeder));
+	requireAttachedDechirpRoundTrip(world);
+}
 
-	SECTION("attached reference is resolved and serialized")
-	{
-		core::World world;
-		const auto scenario =
-			make_scenario({{"dechirp_mode", "physical"}, {"dechirp_reference", {{"source", "attached"}}}});
+TEST_CASE("JSON: FMCW dechirp IF-chain fields round-trip", "[serial][json][fmcw][dechirp]")
+{
+	ParamGuard const guard;
+	std::mt19937 seeder(42);
+	core::World world;
+	const auto scenario = fmcwDechirpScenario({{"dechirp_mode", "physical"},
+											   {"dechirp_reference", {{"source", "attached"}}},
+											   {"if_sample_rate", 1.0e6},
+											   {"if_filter_bandwidth", 4.0e5},
+											   {"if_filter_transition_width", 1.0e5}});
 
-		REQUIRE_NOTHROW(serial::json_to_world(scenario, world, seeder));
-		REQUIRE(world.getReceivers().size() == 1);
-		const auto* rx = world.getReceivers().front().get();
-		REQUIRE(rx->getDechirpMode() == radar::Receiver::DechirpMode::Physical);
-		REQUIRE(rx->getDechirpReference().source == radar::Receiver::DechirpReferenceSource::Attached);
-		REQUIRE_FALSE(rx->getDechirpSources().empty());
+	REQUIRE_NOTHROW(serial::json_to_world(scenario, world, seeder));
+	requireIfChainRoundTrip(world);
+}
 
-		const json serialized = serial::world_to_json(world);
-		const auto& mode_json =
-			serialized.at("simulation").at("platforms").at(0).at("components").at(0).at("monostatic").at("fmcw_mode");
-		REQUIRE(mode_json.at("dechirp_mode") == "physical");
-		REQUIRE(mode_json.at("dechirp_reference").at("source") == "attached");
-	}
+TEST_CASE("JSON: FMCW dechirp rejects orphan dechirp_reference", "[serial][json][fmcw][dechirp]")
+{
+	ParamGuard const guard;
+	std::mt19937 seeder(42);
+	core::World world;
+	const auto scenario = fmcwDechirpScenario({{"dechirp_reference", {{"source", "attached"}}}});
 
-	SECTION("IF-chain fields are parsed and serialized")
-	{
-		core::World world;
-		const auto scenario = make_scenario({{"dechirp_mode", "physical"},
-											 {"dechirp_reference", {{"source", "attached"}}},
-											 {"if_sample_rate", 1.0e6},
-											 {"if_filter_bandwidth", 4.0e5},
-											 {"if_filter_transition_width", 1.0e5}});
+	REQUIRE_THROWS_WITH(serial::json_to_world(scenario, world, seeder), ContainsSubstring("dechirp_reference"));
+}
 
-		REQUIRE_NOTHROW(serial::json_to_world(scenario, world, seeder));
-		const auto* rx = world.getReceivers().front().get();
-		const auto& if_chain = rx->getFmcwIfChainRequest();
-		REQUIRE(if_chain.sample_rate_hz.has_value());
-		REQUIRE(if_chain.filter_bandwidth_hz.has_value());
-		REQUIRE(if_chain.filter_transition_width_hz.has_value());
-		REQUIRE_THAT(if_chain.sample_rate_hz.value_or(0.0), WithinAbs(1.0e6, 1.0e-9));
-		REQUIRE_THAT(if_chain.filter_bandwidth_hz.value_or(0.0), WithinAbs(4.0e5, 1.0e-9));
-		REQUIRE_THAT(if_chain.filter_transition_width_hz.value_or(0.0), WithinAbs(1.0e5, 1.0e-9));
+TEST_CASE("JSON: FMCW dechirp requires dechirp for IF sample rate", "[serial][json][fmcw][dechirp]")
+{
+	ParamGuard const guard;
+	std::mt19937 seeder(42);
+	core::World world;
+	const auto scenario = fmcwDechirpScenario({{"if_sample_rate", 1.0e6}});
 
-		const json serialized = serial::world_to_json(world);
-		const auto& mode_json =
-			serialized.at("simulation").at("platforms").at(0).at("components").at(0).at("monostatic").at("fmcw_mode");
-		REQUIRE(mode_json.at("if_sample_rate") == 1.0e6);
-		REQUIRE(mode_json.at("if_filter_bandwidth") == 4.0e5);
-		REQUIRE(mode_json.at("if_filter_transition_width") == 1.0e5);
-	}
+	REQUIRE_THROWS_WITH(serial::json_to_world(scenario, world, seeder), ContainsSubstring("IF-chain fields"));
+}
 
-	SECTION("orphan dechirp_reference is rejected")
-	{
-		core::World world;
-		const auto scenario = make_scenario({{"dechirp_reference", {{"source", "attached"}}}});
-		REQUIRE_THROWS_WITH(serial::json_to_world(scenario, world, seeder), ContainsSubstring("dechirp_reference"));
-	}
+TEST_CASE("JSON: FMCW dechirp rejects non-positive IF-chain values", "[serial][json][fmcw][dechirp]")
+{
+	ParamGuard const guard;
+	std::mt19937 seeder(42);
+	core::World world;
+	const auto scenario = fmcwDechirpScenario(
+		{{"dechirp_mode", "physical"}, {"dechirp_reference", {{"source", "attached"}}}, {"if_sample_rate", -1.0}});
 
-	SECTION("IF sample rate requires dechirp")
-	{
-		core::World world;
-		const auto scenario = make_scenario({{"if_sample_rate", 1.0e6}});
-		REQUIRE_THROWS_WITH(serial::json_to_world(scenario, world, seeder), ContainsSubstring("IF-chain fields"));
-	}
+	REQUIRE_THROWS_WITH(serial::json_to_world(scenario, world, seeder), ContainsSubstring("finite positive"));
+}
 
-	SECTION("IF-chain values must be positive")
-	{
-		core::World world;
-		const auto scenario = make_scenario(
-			{{"dechirp_mode", "physical"}, {"dechirp_reference", {{"source", "attached"}}}, {"if_sample_rate", -1.0}});
-		REQUIRE_THROWS_WITH(serial::json_to_world(scenario, world, seeder), ContainsSubstring("finite positive"));
-	}
+TEST_CASE("JSON: FMCW dechirp rejects IF filter bandwidth at Nyquist", "[serial][json][fmcw][dechirp]")
+{
+	ParamGuard const guard;
+	std::mt19937 seeder(42);
+	core::World world;
+	const auto scenario = fmcwDechirpScenario({{"dechirp_mode", "physical"},
+											   {"dechirp_reference", {{"source", "attached"}}},
+											   {"if_sample_rate", 1.0e6},
+											   {"if_filter_bandwidth", 5.0e5}});
 
-	SECTION("IF filter bandwidth must be below IF Nyquist")
-	{
-		core::World world;
-		const auto scenario = make_scenario({{"dechirp_mode", "physical"},
-											 {"dechirp_reference", {{"source", "attached"}}},
-											 {"if_sample_rate", 1.0e6},
-											 {"if_filter_bandwidth", 5.0e5}});
-		REQUIRE_THROWS_WITH(serial::json_to_world(scenario, world, seeder),
-							ContainsSubstring("less than half if_sample_rate"));
-	}
+	REQUIRE_THROWS_WITH(serial::json_to_world(scenario, world, seeder),
+						ContainsSubstring("less than half if_sample_rate"));
+}
 
-	SECTION("conflicting mode blocks cannot hide dechirp configuration")
-	{
-		core::World world;
-		auto scenario = make_scenario({{"dechirp_mode", "physical"}, {"dechirp_reference", {{"source", "attached"}}}});
-		auto& monostatic = scenario["simulation"]["platforms"][0]["components"][0]["monostatic"];
-		monostatic["cw_mode"] = json::object();
+TEST_CASE("JSON: FMCW dechirp rejects conflicting mode blocks", "[serial][json][fmcw][dechirp]")
+{
+	ParamGuard const guard;
+	std::mt19937 seeder(42);
+	core::World world;
+	auto scenario =
+		fmcwDechirpScenario({{"dechirp_mode", "physical"}, {"dechirp_reference", {{"source", "attached"}}}});
+	auto& monostatic = scenario["simulation"]["platforms"][0]["components"][0]["monostatic"];
+	monostatic["cw_mode"] = json::object();
 
-		REQUIRE_THROWS_WITH(serial::json_to_world(scenario, world, seeder), ContainsSubstring("at most one"));
-	}
+	REQUIRE_THROWS_WITH(serial::json_to_world(scenario, world, seeder), ContainsSubstring("at most one"));
+}
 
-	SECTION("unknown dechirp reference keys are rejected")
-	{
-		core::World world;
-		const auto scenario = make_scenario(
-			{{"dechirp_mode", "physical"}, {"dechirp_reference", {{"source", "attached"}, {"bogus", true}}}});
-		REQUIRE_THROWS_WITH(serial::json_to_world(scenario, world, seeder), ContainsSubstring("unsupported key"));
-	}
+TEST_CASE("JSON: FMCW dechirp rejects unknown reference keys", "[serial][json][fmcw][dechirp]")
+{
+	ParamGuard const guard;
+	std::mt19937 seeder(42);
+	core::World world;
+	const auto scenario = fmcwDechirpScenario(
+		{{"dechirp_mode", "physical"}, {"dechirp_reference", {{"source", "attached"}, {"bogus", true}}}});
+
+	REQUIRE_THROWS_WITH(serial::json_to_world(scenario, world, seeder), ContainsSubstring("unsupported key"));
 }
 
 TEST_CASE("JSON: Vec3 Serialization and Deserialization", "[serial][json]")

--- a/packages/libfers/tests/serial/test_json_serializer_stress.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer_stress.cpp
@@ -128,8 +128,8 @@ namespace
 		}
 		if (a.is_number_float())
 		{
-			double va = a.get<double>();
-			double vb = b.get<double>();
+			const double va = a.get<double>();
+			const double vb = b.get<double>();
 			// Allow a small epsilon for float serialization round-tripping
 			if (std::abs(va - vb) > 1e-5 && std::abs(va - vb) / std::max(std::abs(va), std::abs(vb)) > 1e-5)
 			{

--- a/packages/libfers/tests/serial/test_json_serializer_stress.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer_stress.cpp
@@ -147,16 +147,11 @@ namespace
 		return true;
 	}
 
-	// Generates a massive, highly complex world to stress the serializer
-	void buildStressWorld(core::World& world, size_t num_platforms, std::mt19937& rng)
+	void addStressAssets(core::World& world, std::mt19937& rng, std::vector<SimId>& wave_ids,
+						 std::vector<SimId>& ant_ids, std::vector<SimId>& time_ids)
 	{
 		std::uniform_real_distribution<RealType> dist_real(0.1, 1000.0);
-		std::uniform_int_distribution<int> const dist_mode(0, 1);
-		std::uniform_int_distribution<unsigned> seed_dist;
 
-		std::vector<SimId> wave_ids, ant_ids, time_ids;
-
-		// 1. Generate Assets (Waveforms, Antennas, Timings)
 		for (size_t i = 0; i < 20; ++i)
 		{
 			SimId const w_id = SimIdGenerator::instance().generateId(ObjectType::Waveform);
@@ -200,118 +195,124 @@ namespace
 			tim->setAlpha(1.0, 0.5);
 			tim->setAlpha(2.0, 0.25);
 			if (i % 2 == 0)
+			{
 				tim->setSyncOnPulse();
+			}
 			world.add(std::move(tim));
 			time_ids.push_back(t_id);
 		}
+	}
 
-		// 2. Generate Platforms and Components
-		for (size_t i = 0; i < num_platforms; ++i)
+	void addStressPlatform(core::World& world, const size_t i, std::mt19937& rng,
+						   std::uniform_real_distribution<RealType>& dist_real,
+						   std::uniform_int_distribution<unsigned>& seed_dist, const std::vector<SimId>& wave_ids,
+						   const std::vector<SimId>& ant_ids, const std::vector<SimId>& time_ids)
+	{
+		SimId const p_id = SimIdGenerator::instance().generateId(ObjectType::Platform);
+		auto plat = std::make_unique<radar::Platform>("platform_" + std::to_string(i), p_id);
+
+		plat->getMotionPath()->setInterp(math::Path::InterpType::INTERP_CUBIC);
+		for (size_t wp = 0; wp < 10; ++wp)
 		{
-			SimId const p_id = SimIdGenerator::instance().generateId(ObjectType::Platform);
-			auto plat = std::make_unique<radar::Platform>("platform_" + std::to_string(i), p_id);
+			plat->getMotionPath()->addCoord(
+				{math::Vec3(dist_real(rng), dist_real(rng), dist_real(rng)), static_cast<RealType>(wp) * 0.01});
+		}
+		plat->getMotionPath()->finalize();
 
-			// Motion Path (Cubic)
-			plat->getMotionPath()->setInterp(math::Path::InterpType::INTERP_CUBIC);
+		if (i % 2 == 0)
+		{
+			plat->getRotationPath()->setInterp(math::RotationPath::InterpType::INTERP_LINEAR);
 			for (size_t wp = 0; wp < 10; ++wp)
 			{
-				plat->getMotionPath()->addCoord({
-					math::Vec3(dist_real(rng), dist_real(rng), dist_real(rng)),
-					static_cast<RealType>(wp) * 0.01 // Scaled to fit in 0.1s
-				});
+				plat->getRotationPath()->addCoord(
+					{dist_real(rng) * (PI / 180.0), dist_real(rng) * (PI / 180.0), static_cast<RealType>(wp) * 0.01});
 			}
-			plat->getMotionPath()->finalize();
+		}
+		else
+		{
+			plat->getRotationPath()->setInterp(math::RotationPath::InterpType::INTERP_CONSTANT);
+			math::RotationCoord const start{dist_real(rng) * (PI / 180.0), dist_real(rng) * (PI / 180.0), 0.0};
+			math::RotationCoord const rate{dist_real(rng) * (PI / 180.0), dist_real(rng) * (PI / 180.0), 0.0};
+			plat->getRotationPath()->setConstantRate(start, rate);
+		}
+		plat->getRotationPath()->finalize();
 
-			// Rotation Path (Alternate between Linear Waypoints and Fixed Constant Rotation)
-			if (i % 2 == 0)
-			{
-				plat->getRotationPath()->setInterp(math::RotationPath::InterpType::INTERP_LINEAR);
-				for (size_t wp = 0; wp < 10; ++wp)
-				{
-					plat->getRotationPath()->addCoord({
-						dist_real(rng) * (PI / 180.0), dist_real(rng) * (PI / 180.0),
-						static_cast<RealType>(wp) * 0.01 // Scaled to fit in 0.1s
-					});
-				}
-			}
-			else
-			{
-				plat->getRotationPath()->setInterp(math::RotationPath::InterpType::INTERP_CONSTANT);
-				math::RotationCoord const start{dist_real(rng) * (PI / 180.0), dist_real(rng) * (PI / 180.0), 0.0};
-				math::RotationCoord const rate{dist_real(rng) * (PI / 180.0), dist_real(rng) * (PI / 180.0), 0.0};
-				plat->getRotationPath()->setConstantRate(start, rate);
-			}
-			plat->getRotationPath()->finalize();
+		auto* proto_tim = world.findTiming(time_ids[i % time_ids.size()]);
 
-			auto* proto_tim = world.findTiming(time_ids[i % time_ids.size()]);
+		auto tx =
+			std::make_unique<radar::Transmitter>(plat.get(), "tx_" + std::to_string(i), radar::OperationMode::CW_MODE);
+		tx->setWave(world.findWaveform(wave_ids[i % wave_ids.size()]));
+		tx->setAntenna(world.findAntenna(ant_ids[i % ant_ids.size()]));
+		auto tx_tim = std::make_shared<timing::Timing>(proto_tim->getName(), seed_dist(rng), proto_tim->getId());
+		tx_tim->initializeModel(proto_tim);
+		tx->setTiming(tx_tim);
+		tx->setSchedule({{0.01, 0.04}, {0.06, 0.09}});
+		world.add(std::move(tx));
 
-			// Standalone Transmitter
-			auto tx_mode = radar::OperationMode::CW_MODE;
-			auto tx = std::make_unique<radar::Transmitter>(plat.get(), "tx_" + std::to_string(i), tx_mode);
-			tx->setWave(world.findWaveform(wave_ids[i % wave_ids.size()]));
-			tx->setAntenna(world.findAntenna(ant_ids[i % ant_ids.size()]));
-			auto tx_tim = std::make_shared<timing::Timing>(proto_tim->getName(), seed_dist(rng), proto_tim->getId());
-			tx_tim->initializeModel(proto_tim);
-			tx->setTiming(tx_tim);
-			tx->setSchedule({{0.01, 0.04}, {0.06, 0.09}}); // Scaled schedules to fit inside [0.0, 0.1]
-			world.add(std::move(tx));
+		auto rx = std::make_unique<radar::Receiver>(plat.get(), "rx_" + std::to_string(i), seed_dist(rng),
+													radar::OperationMode::CW_MODE);
+		rx->setAntenna(world.findAntenna(ant_ids[(i + 1) % ant_ids.size()]));
+		auto rx_tim = std::make_shared<timing::Timing>(proto_tim->getName(), seed_dist(rng), proto_tim->getId());
+		rx_tim->initializeModel(proto_tim);
+		rx->setTiming(rx_tim);
+		rx->setNoiseTemperature(290.0);
+		if (i % 2 == 0)
+		{
+			rx->setFlag(radar::Receiver::RecvFlag::FLAG_NODIRECT);
+		}
+		if (i % 3 == 0)
+		{
+			rx->setFlag(radar::Receiver::RecvFlag::FLAG_NOPROPLOSS);
+		}
+		rx->setSchedule({{0.02, 0.08}});
+		world.add(std::move(rx));
 
-			// Standalone Receiver
-			auto rx_mode = radar::OperationMode::CW_MODE;
-			auto rx = std::make_unique<radar::Receiver>(plat.get(), "rx_" + std::to_string(i), seed_dist(rng), rx_mode);
-			rx->setAntenna(world.findAntenna(ant_ids[(i + 1) % ant_ids.size()]));
-			auto rx_tim = std::make_shared<timing::Timing>(proto_tim->getName(), seed_dist(rng), proto_tim->getId());
-			rx_tim->initializeModel(proto_tim);
-			rx->setTiming(rx_tim);
-			rx->setNoiseTemperature(290.0);
-			if (i % 2 == 0)
-				rx->setFlag(radar::Receiver::RecvFlag::FLAG_NODIRECT);
-			if (i % 3 == 0)
-				rx->setFlag(radar::Receiver::RecvFlag::FLAG_NOPROPLOSS);
-			rx->setSchedule({{0.02, 0.08}});
-			world.add(std::move(rx));
+		auto mono_tx = std::make_unique<radar::Transmitter>(plat.get(), "mono_tx_" + std::to_string(i),
+															radar::OperationMode::CW_MODE);
+		mono_tx->setWave(world.findWaveform(wave_ids[(i + 2) % wave_ids.size()]));
+		mono_tx->setAntenna(world.findAntenna(ant_ids[(i + 2) % ant_ids.size()]));
+		auto mono_tx_tim = std::make_shared<timing::Timing>(proto_tim->getName(), seed_dist(rng), proto_tim->getId());
+		mono_tx_tim->initializeModel(proto_tim);
+		mono_tx->setTiming(mono_tx_tim);
+		mono_tx->setSchedule({{0.01, 0.09}});
 
-			// Monostatic Radar Pair (Linked Tx/Rx)
-			auto mono_mode = radar::OperationMode::CW_MODE;
-			auto mono_tx = std::make_unique<radar::Transmitter>(plat.get(), "mono_tx_" + std::to_string(i), mono_mode);
-			mono_tx->setWave(world.findWaveform(wave_ids[(i + 2) % wave_ids.size()]));
-			mono_tx->setAntenna(world.findAntenna(ant_ids[(i + 2) % ant_ids.size()]));
-			auto mono_tx_tim =
-				std::make_shared<timing::Timing>(proto_tim->getName(), seed_dist(rng), proto_tim->getId());
-			mono_tx_tim->initializeModel(proto_tim);
-			mono_tx->setTiming(mono_tx_tim);
-			mono_tx->setSchedule({{0.01, 0.09}});
+		auto mono_rx = std::make_unique<radar::Receiver>(plat.get(), "mono_rx_" + std::to_string(i), seed_dist(rng),
+														 radar::OperationMode::CW_MODE);
+		mono_rx->setAntenna(world.findAntenna(ant_ids[(i + 2) % ant_ids.size()]));
+		auto mono_rx_tim = std::make_shared<timing::Timing>(proto_tim->getName(), seed_dist(rng), proto_tim->getId());
+		mono_rx_tim->initializeModel(proto_tim);
+		mono_rx->setTiming(mono_rx_tim);
+		mono_rx->setNoiseTemperature(300.0);
+		mono_rx->setSchedule({{0.01, 0.09}});
 
-			auto mono_rx = std::make_unique<radar::Receiver>(plat.get(), "mono_rx_" + std::to_string(i), seed_dist(rng),
-															 mono_mode);
-			mono_rx->setAntenna(
-				world.findAntenna(ant_ids[(i + 2) % ant_ids.size()])); // Monostatic usually shares antenna
-			auto mono_rx_tim =
-				std::make_shared<timing::Timing>(proto_tim->getName(), seed_dist(rng), proto_tim->getId());
-			mono_rx_tim->initializeModel(proto_tim);
-			mono_rx->setTiming(mono_rx_tim);
-			mono_rx->setNoiseTemperature(300.0);
-			mono_rx->setSchedule({{0.01, 0.09}});
+		mono_tx->setAttached(mono_rx.get());
+		mono_rx->setAttached(mono_tx.get());
+		world.add(std::move(mono_tx));
+		world.add(std::move(mono_rx));
 
-			// Link them to form a monostatic radar
-			mono_tx->setAttached(mono_rx.get());
-			mono_rx->setAttached(mono_tx.get());
-			world.add(std::move(mono_tx));
-			world.add(std::move(mono_rx));
+		auto tgt = radar::createIsoTarget(plat.get(), "tgt_" + std::to_string(i), dist_real(rng), seed_dist(rng));
+		if (i % 2 == 0)
+		{
+			tgt->setFluctuationModel(std::make_unique<radar::RcsChiSquare>(tgt->getRngEngine(), 2.0));
+		}
+		else
+		{
+			tgt->setFluctuationModel(std::make_unique<radar::RcsConst>());
+		}
+		world.add(std::move(tgt));
+		world.add(std::move(plat));
+	}
 
-			// Target
-			auto tgt = radar::createIsoTarget(plat.get(), "tgt_" + std::to_string(i), dist_real(rng), seed_dist(rng));
-			if (i % 2 == 0)
-			{
-				tgt->setFluctuationModel(std::make_unique<radar::RcsChiSquare>(tgt->getRngEngine(), 2.0));
-			}
-			else
-			{
-				tgt->setFluctuationModel(std::make_unique<radar::RcsConst>());
-			}
-			world.add(std::move(tgt));
+	void buildStressWorld(core::World& world, size_t num_platforms, std::mt19937& rng)
+	{
+		std::uniform_real_distribution<RealType> dist_real(0.1, 1000.0);
+		std::uniform_int_distribution<unsigned> seed_dist;
+		std::vector<SimId> wave_ids, ant_ids, time_ids;
 
-			world.add(std::move(plat));
+		addStressAssets(world, rng, wave_ids, ant_ids, time_ids);
+		for (size_t i = 0; i < num_platforms; ++i)
+		{
+			addStressPlatform(world, i, rng, dist_real, seed_dist, wave_ids, ant_ids, time_ids);
 		}
 	}
 }

--- a/packages/libfers/tests/serial/test_json_serializer_stress.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer_stress.cpp
@@ -55,6 +55,7 @@ namespace
 		{
 			if (!j.empty() && j[0].is_object() && j[0].contains("id"))
 			{
+				// NOLINTNEXTLINE(modernize-use-ranges): nlohmann::json iterators fail ranges::sort concepts here.
 				std::sort(j.begin(), j.end(),
 						  [](const json& a, const json& b)
 						  {

--- a/packages/libfers/tests/serial/test_json_serializer_stress.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer_stress.cpp
@@ -33,6 +33,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/serial/test_json_serializer_stress.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer_stress.cpp
@@ -77,66 +77,95 @@ namespace
 
 	// Smart recursive JSON comparator that handles floating point drift
 	// and prints the exact path of the failure.
-	bool compareJson(const json& a, const json& b, const std::string& path = "")
+	bool compareJson(const json& a, const json& b, const std::string& path = "");
+
+	void reportMissingObjectKeys(const json& a, const json& b, const std::string& path)
+	{
+		for (const auto& [k, v] : a.items())
+		{
+			if (!b.contains(k))
+			{
+				UNSCOPED_INFO("Key missing in B: " << path << "/" << k);
+			}
+		}
+		for (const auto& [k, v] : b.items())
+		{
+			if (!a.contains(k))
+			{
+				UNSCOPED_INFO("Key missing in A: " << path << "/" << k);
+			}
+		}
+	}
+
+	bool compareJsonObject(const json& a, const json& b, const std::string& path)
+	{
+		if (a.size() != b.size())
+		{
+			UNSCOPED_INFO("Object size mismatch at " << path << ": " << a.size() << " vs " << b.size());
+			reportMissingObjectKeys(a, b, path);
+			return false;
+		}
+		for (const auto& [key, val] : a.items())
+		{
+			std::string child_path = path;
+			child_path += '/';
+			child_path += key;
+			if (!compareJson(val, b[key], child_path))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	bool compareJsonArray(const json& a, const json& b, const std::string& path)
+	{
+		if (a.size() != b.size())
+		{
+			UNSCOPED_INFO("Array size mismatch at " << path << ": " << a.size() << " vs " << b.size());
+			return false;
+		}
+		for (size_t i = 0; i < a.size(); ++i)
+		{
+			if (!compareJson(a[i], b[i], path + "[" + std::to_string(i) + "]"))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	bool compareJsonFloat(const json& a, const json& b, const std::string& path)
+	{
+		const double va = a.get<double>();
+		const double vb = b.get<double>();
+		// Allow a small epsilon for float serialization round-tripping
+		if (std::abs(va - vb) > 1e-5 && std::abs(va - vb) / std::max(std::abs(va), std::abs(vb)) > 1e-5)
+		{
+			UNSCOPED_INFO("Float mismatch at " << path << ": " << va << " vs " << vb);
+			return false;
+		}
+		return true;
+	}
+
+	bool compareJson(const json& a, const json& b, const std::string& path)
 	{
 		if (a.type() != b.type())
 		{
 			UNSCOPED_INFO("Type mismatch at " << path << ": " << a.type_name() << " vs " << b.type_name());
 			return false;
 		}
-
 		if (a.is_object())
 		{
-			if (a.size() != b.size())
-			{
-				UNSCOPED_INFO("Object size mismatch at " << path << ": " << a.size() << " vs " << b.size());
-				for (const auto& [k, v] : a.items())
-				{
-					if (!b.contains(k))
-						UNSCOPED_INFO("Key missing in B: " << path << "/" << k);
-				}
-				for (const auto& [k, v] : b.items())
-				{
-					if (!a.contains(k))
-						UNSCOPED_INFO("Key missing in A: " << path << "/" << k);
-				}
-				return false;
-			}
-			for (const auto& [key, val] : a.items())
-			{
-				std::string child_path = path;
-				child_path += '/';
-				child_path += key;
-				if (!compareJson(val, b[key], child_path))
-					return false;
-			}
-			return true;
+			return compareJsonObject(a, b, path);
 		}
 		if (a.is_array())
 		{
-			if (a.size() != b.size())
-			{
-				UNSCOPED_INFO("Array size mismatch at " << path << ": " << a.size() << " vs " << b.size());
-				return false;
-			}
-			for (size_t i = 0; i < a.size(); ++i)
-			{
-				if (!compareJson(a[i], b[i], path + "[" + std::to_string(i) + "]"))
-					return false;
-			}
-			return true;
+			return compareJsonArray(a, b, path);
 		}
 		if (a.is_number_float())
 		{
-			const double va = a.get<double>();
-			const double vb = b.get<double>();
-			// Allow a small epsilon for float serialization round-tripping
-			if (std::abs(va - vb) > 1e-5 && std::abs(va - vb) / std::max(std::abs(va), std::abs(vb)) > 1e-5)
-			{
-				UNSCOPED_INFO("Float mismatch at " << path << ": " << va << " vs " << vb);
-				return false;
-			}
-			return true;
+			return compareJsonFloat(a, b, path);
 		}
 
 		if (a != b)

--- a/packages/libfers/tests/serial/test_json_serializer_stress.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer_stress.cpp
@@ -103,12 +103,15 @@ namespace
 			}
 			for (auto& [key, val] : a.items())
 			{
-				if (!compareJson(val, b[key], path + "/" + key))
+				std::string child_path = path;
+				child_path += '/';
+				child_path += key;
+				if (!compareJson(val, b[key], child_path))
 					return false;
 			}
 			return true;
 		}
-		else if (a.is_array())
+		if (a.is_array())
 		{
 			if (a.size() != b.size())
 			{
@@ -122,7 +125,7 @@ namespace
 			}
 			return true;
 		}
-		else if (a.is_number_float())
+		if (a.is_number_float())
 		{
 			double va = a.get<double>();
 			double vb = b.get<double>();
@@ -134,15 +137,13 @@ namespace
 			}
 			return true;
 		}
-		else
+
+		if (a != b)
 		{
-			if (a != b)
-			{
-				UNSCOPED_INFO("Value mismatch at " << path << ": " << a << " vs " << b);
-				return false;
-			}
-			return true;
+			UNSCOPED_INFO("Value mismatch at " << path << ": " << a << " vs " << b);
+			return false;
 		}
+		return true;
 	}
 
 	// Generates a massive, highly complex world to stress the serializer

--- a/packages/libfers/tests/serial/test_json_serializer_stress.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer_stress.cpp
@@ -145,7 +145,7 @@ namespace
 	void buildStressWorld(core::World& world, size_t num_platforms, std::mt19937& rng)
 	{
 		std::uniform_real_distribution<RealType> dist_real(0.1, 1000.0);
-		std::uniform_int_distribution<int> dist_mode(0, 1);
+		std::uniform_int_distribution<int> const dist_mode(0, 1);
 		std::uniform_int_distribution<unsigned> seed_dist;
 
 		std::vector<SimId> wave_ids, ant_ids, time_ids;
@@ -153,14 +153,14 @@ namespace
 		// 1. Generate Assets (Waveforms, Antennas, Timings)
 		for (size_t i = 0; i < 20; ++i)
 		{
-			SimId w_id = SimIdGenerator::instance().generateId(ObjectType::Waveform);
+			SimId const w_id = SimIdGenerator::instance().generateId(ObjectType::Waveform);
 			auto sig = std::make_unique<fers_signal::CwSignal>();
 			auto wave = std::make_unique<fers_signal::RadarSignal>("wave_" + std::to_string(i), dist_real(rng),
 																   1e9 + dist_real(rng), 1.0, std::move(sig), w_id);
 			world.add(std::move(wave));
 			wave_ids.push_back(w_id);
 
-			SimId a_id = SimIdGenerator::instance().generateId(ObjectType::Antenna);
+			SimId const a_id = SimIdGenerator::instance().generateId(ObjectType::Antenna);
 			std::unique_ptr<antenna::Antenna> ant;
 			switch (i % 5)
 			{
@@ -184,7 +184,7 @@ namespace
 			world.add(std::move(ant));
 			ant_ids.push_back(a_id);
 
-			SimId t_id = SimIdGenerator::instance().generateId(ObjectType::Timing);
+			SimId const t_id = SimIdGenerator::instance().generateId(ObjectType::Timing);
 			auto tim = std::make_unique<timing::PrototypeTiming>("time_" + std::to_string(i), t_id);
 			tim->setFrequency(10e6);
 			tim->setFreqOffset(dist_real(rng));
@@ -202,7 +202,7 @@ namespace
 		// 2. Generate Platforms and Components
 		for (size_t i = 0; i < num_platforms; ++i)
 		{
-			SimId p_id = SimIdGenerator::instance().generateId(ObjectType::Platform);
+			SimId const p_id = SimIdGenerator::instance().generateId(ObjectType::Platform);
 			auto plat = std::make_unique<radar::Platform>("platform_" + std::to_string(i), p_id);
 
 			// Motion Path (Cubic)
@@ -231,8 +231,8 @@ namespace
 			else
 			{
 				plat->getRotationPath()->setInterp(math::RotationPath::InterpType::INTERP_CONSTANT);
-				math::RotationCoord start{dist_real(rng) * (PI / 180.0), dist_real(rng) * (PI / 180.0), 0.0};
-				math::RotationCoord rate{dist_real(rng) * (PI / 180.0), dist_real(rng) * (PI / 180.0), 0.0};
+				math::RotationCoord const start{dist_real(rng) * (PI / 180.0), dist_real(rng) * (PI / 180.0), 0.0};
+				math::RotationCoord const rate{dist_real(rng) * (PI / 180.0), dist_real(rng) * (PI / 180.0), 0.0};
 				plat->getRotationPath()->setConstantRate(start, rate);
 			}
 			plat->getRotationPath()->finalize();
@@ -312,7 +312,7 @@ namespace
 
 TEST_CASE("JSON Serializer Stress Test and Round-Trip Validation", "[serial][json][stress]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	// Keep time and rate low to prevent massive CW buffer allocations during json_to_world
@@ -365,7 +365,7 @@ TEST_CASE("JSON Serializer Stress Test and Round-Trip Validation", "[serial][jso
 
 		// Use the smart comparator instead of == to handle float drift
 		// and to print exact JSON paths on failure.
-		bool is_match = compareJson(j_original, j_roundtrip, "/root");
+		bool const is_match = compareJson(j_original, j_roundtrip, "/root");
 		REQUIRE(is_match);
 	}
 

--- a/packages/libfers/tests/serial/test_json_serializer_stress.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer_stress.cpp
@@ -46,7 +46,7 @@ namespace
 	{
 		if (j.is_object())
 		{
-			for (auto& [key, val] : j.items())
+			for (const auto& [key, val] : j.items())
 			{
 				sortJsonArrays(val);
 			}
@@ -89,19 +89,19 @@ namespace
 			if (a.size() != b.size())
 			{
 				UNSCOPED_INFO("Object size mismatch at " << path << ": " << a.size() << " vs " << b.size());
-				for (auto& [k, v] : a.items())
+				for (const auto& [k, v] : a.items())
 				{
 					if (!b.contains(k))
 						UNSCOPED_INFO("Key missing in B: " << path << "/" << k);
 				}
-				for (auto& [k, v] : b.items())
+				for (const auto& [k, v] : b.items())
 				{
 					if (!a.contains(k))
 						UNSCOPED_INFO("Key missing in A: " << path << "/" << k);
 				}
 				return false;
 			}
-			for (auto& [key, val] : a.items())
+			for (const auto& [key, val] : a.items())
 			{
 				std::string child_path = path;
 				child_path += '/';
@@ -242,7 +242,7 @@ namespace
 			}
 			plat->getRotationPath()->finalize();
 
-			auto proto_tim = world.findTiming(time_ids[i % time_ids.size()]);
+			auto* proto_tim = world.findTiming(time_ids[i % time_ids.size()]);
 
 			// Standalone Transmitter
 			auto tx_mode = radar::OperationMode::CW_MODE;

--- a/packages/libfers/tests/serial/test_kml_generator.cpp
+++ b/packages/libfers/tests/serial/test_kml_generator.cpp
@@ -23,6 +23,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/serial/test_kml_generator.cpp
+++ b/packages/libfers/tests/serial/test_kml_generator.cpp
@@ -58,7 +58,7 @@ namespace
 
 TEST_CASE("KmlGenerator: Generates valid KML file in ENU frame", "[serial][kml][facade]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setCoordinateSystem(params::CoordinateFrame::ENU, 0, true);
 	params::setOrigin(-33.957652, 18.4611991, 111.01); // UCT
@@ -67,7 +67,7 @@ TEST_CASE("KmlGenerator: Generates valid KML file in ENU frame", "[serial][kml][
 	// ENU coordinates are local offsets in meters
 	populateMinimalWorld(world, {100.0, 200.0, 300.0});
 
-	std::string out_path = getTempKmlPath("test_enu.kml");
+	std::string const out_path = getTempKmlPath("test_enu.kml");
 	std::filesystem::remove(out_path);
 
 	REQUIRE(serial::KmlGenerator::generateKml(world, out_path));
@@ -81,7 +81,7 @@ TEST_CASE("KmlGenerator: Generates valid KML file in ENU frame", "[serial][kml][
 
 TEST_CASE("KmlGenerator: Generates valid KML file in UTM frame", "[serial][kml][facade]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	// Zone 34S (South Africa)
 	params::setCoordinateSystem(params::CoordinateFrame::UTM, 34, false);
@@ -90,7 +90,7 @@ TEST_CASE("KmlGenerator: Generates valid KML file in UTM frame", "[serial][kml][
 	// Valid UTM coordinates: Easting = 500000 (center), Northing = 6234000 (~34 deg South)
 	populateMinimalWorld(world, {500000.0, 6234000.0, 300.0});
 
-	std::string out_path = getTempKmlPath("test_utm.kml");
+	std::string const out_path = getTempKmlPath("test_utm.kml");
 	std::filesystem::remove(out_path);
 
 	REQUIRE(serial::KmlGenerator::generateKml(world, out_path));
@@ -104,7 +104,7 @@ TEST_CASE("KmlGenerator: Generates valid KML file in UTM frame", "[serial][kml][
 
 TEST_CASE("KmlGenerator: Generates valid KML file in ECEF frame", "[serial][kml][facade]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setCoordinateSystem(params::CoordinateFrame::ECEF, 0, true);
 
@@ -112,7 +112,7 @@ TEST_CASE("KmlGenerator: Generates valid KML file in ECEF frame", "[serial][kml]
 	// Valid ECEF coordinates: Surface of the Earth at the equator/prime meridian
 	populateMinimalWorld(world, {6378137.0, 0.0, 0.0});
 
-	std::string out_path = getTempKmlPath("test_ecef.kml");
+	std::string const out_path = getTempKmlPath("test_ecef.kml");
 	std::filesystem::remove(out_path);
 
 	REQUIRE(serial::KmlGenerator::generateKml(world, out_path));
@@ -126,8 +126,8 @@ TEST_CASE("KmlGenerator: Generates valid KML file in ECEF frame", "[serial][kml]
 
 TEST_CASE("KmlGenerator: Fails gracefully on invalid file path", "[serial][kml][facade]")
 {
-	ParamGuard guard;
-	core::World world;
+	ParamGuard const guard;
+	core::World const world;
 
 	const std::filesystem::path missing_parent =
 		std::filesystem::temp_directory_path() / "fers_missing_kml_generator_dir_12345";
@@ -142,7 +142,7 @@ TEST_CASE("KmlGenerator: Fails gracefully on invalid file path", "[serial][kml][
 
 TEST_CASE("KmlGenerator: Catches exceptions from invalid UTM zones", "[serial][kml][facade]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	// Zone 99 is invalid and will cause GeographicLib to throw an exception
 	params::setCoordinateSystem(params::CoordinateFrame::UTM, 99, true);
@@ -150,7 +150,7 @@ TEST_CASE("KmlGenerator: Catches exceptions from invalid UTM zones", "[serial][k
 	core::World world;
 	populateMinimalWorld(world, {500000.0, 6234000.0, 300.0});
 
-	std::string out_path = getTempKmlPath("test_utm_fail.kml");
+	std::string const out_path = getTempKmlPath("test_utm_fail.kml");
 
 	// The KmlGenerator should catch the GeographicLib exception and return an error.
 	const auto result = serial::KmlGenerator::generateKml(world, out_path);

--- a/packages/libfers/tests/serial/test_kml_generator_utils.cpp
+++ b/packages/libfers/tests/serial/test_kml_generator_utils.cpp
@@ -66,22 +66,22 @@ TEST_CASE("KML Math: 3dB Drop Angles", "[serial][kml][math]")
 
 	SECTION("Gaussian Antenna")
 	{
-		antenna::Gaussian valid_gaussian("gauss", 1.0, 1.0);
+		antenna::Gaussian const valid_gaussian("gauss", 1.0, 1.0);
 		// theta = sqrt(ln(2) / scale) * 180 / PI
-		double expected_deg = std::sqrt(std::log(2.0) / 1.0) * 180.0 / PI;
+		double const expected_deg = std::sqrt(std::log(2.0) / 1.0) * 180.0 / PI;
 		REQUIRE_THAT(serial::kml_generator_utils::findGaussian3DbDropAngle(&valid_gaussian),
 					 WithinAbs(expected_deg, 1e-4));
 
-		antenna::Gaussian invalid_gaussian("gauss_bad", -1.0, 1.0);
+		antenna::Gaussian const invalid_gaussian("gauss_bad", -1.0, 1.0);
 		REQUIRE_THAT(serial::kml_generator_utils::findGaussian3DbDropAngle(&invalid_gaussian), WithinAbs(0.0, 1e-6));
 	}
 
 	SECTION("Parabolic Antenna")
 	{
-		antenna::Parabolic valid_parabolic("dish", 1.0);
+		antenna::Parabolic const valid_parabolic("dish", 1.0);
 		// arg = 1.6 * lambda / (PI * D). For lambda=0.1, D=1.0 -> arg = 0.16 / PI
-		double arg = 0.16 / PI;
-		double expected_deg = std::asin(arg) * 180.0 / PI;
+		double const arg = 0.16 / PI;
+		double const expected_deg = std::asin(arg) * 180.0 / PI;
 		REQUIRE_THAT(serial::kml_generator_utils::findParabolic3DbDropAngle(&valid_parabolic, 0.1),
 					 WithinAbs(expected_deg, 1e-4));
 
@@ -90,17 +90,17 @@ TEST_CASE("KML Math: 3dB Drop Angles", "[serial][kml][math]")
 					 WithinAbs(90.0, 1e-6));
 
 		// Invalid diameter
-		antenna::Parabolic invalid_parabolic("dish_bad", 0.0);
+		antenna::Parabolic const invalid_parabolic("dish_bad", 0.0);
 		REQUIRE_THAT(serial::kml_generator_utils::findParabolic3DbDropAngle(&invalid_parabolic, 0.1),
 					 WithinAbs(0.0, 1e-6));
 	}
 
 	SECTION("SquareHorn Antenna")
 	{
-		antenna::SquareHorn valid_horn("horn", 1.0);
+		antenna::SquareHorn const valid_horn("horn", 1.0);
 		// arg = 1.39155 * lambda / (PI * D). For lambda=0.1, D=1.0 -> arg = 0.139155 / PI
-		double arg = 0.139155 / PI;
-		double expected_deg = std::asin(arg) * 180.0 / PI;
+		double const arg = 0.139155 / PI;
+		double const expected_deg = std::asin(arg) * 180.0 / PI;
 		REQUIRE_THAT(serial::kml_generator_utils::findSquareHorn3DbDropAngle(&valid_horn, 0.1),
 					 WithinAbs(expected_deg, 1e-4));
 
@@ -108,7 +108,7 @@ TEST_CASE("KML Math: 3dB Drop Angles", "[serial][kml][math]")
 		REQUIRE_THAT(serial::kml_generator_utils::findSquareHorn3DbDropAngle(&valid_horn, 10.0), WithinAbs(90.0, 1e-6));
 
 		// Invalid dimension
-		antenna::SquareHorn invalid_horn("horn_bad", -0.5);
+		antenna::SquareHorn const invalid_horn("horn_bad", -0.5);
 		REQUIRE_THAT(serial::kml_generator_utils::findSquareHorn3DbDropAngle(&invalid_horn, 0.1), WithinAbs(0.0, 1e-6));
 	}
 }
@@ -230,7 +230,7 @@ TEST_CASE("KML Generation: Antenna Visualization", "[serial][kml][generation]")
 TEST_CASE("KML Generation: Path Visualization", "[serial][kml][generation]")
 {
 	auto ctx = createTestContext();
-	radar::Platform plat("plat");
+	radar::Platform const plat("plat");
 
 	SECTION("Static Path")
 	{
@@ -386,7 +386,7 @@ TEST_CASE("KML Generation: Antenna Wavelength and Dispatch", "[serial][kml][gene
 	SECTION("XmlAntenna (Symbolic)")
 	{
 		// Create a minimal valid XML file to satisfy the XmlAntenna constructor
-		std::string temp_xml = (std::filesystem::temp_directory_path() / "dummy_ant.xml").string();
+		std::string const temp_xml = (std::filesystem::temp_directory_path() / "dummy_ant.xml").string();
 		std::ofstream out(temp_xml);
 		out << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
 			<< "<antenna>\n"
@@ -420,7 +420,7 @@ TEST_CASE("KML Generation: Antenna Wavelength and Dispatch", "[serial][kml][gene
 TEST_CASE("KML Generation: Dynamic Path Edge Cases", "[serial][kml][generation]")
 {
 	auto ctx = createTestContext();
-	radar::Platform plat("plat");
+	radar::Platform const plat("plat");
 	plat.getMotionPath()->setInterp(math::Path::InterpType::INTERP_LINEAR);
 
 	SECTION("Single coordinate (zero duration)")
@@ -462,8 +462,8 @@ TEST_CASE("KML Generation: Dynamic Path Edge Cases", "[serial][kml][generation]"
 TEST_CASE("KML Generation: processPlatform Early Return", "[serial][kml][generation]")
 {
 	auto ctx = createTestContext();
-	radar::Platform plat("plat");
-	std::vector<const radar::Object*> objects;
+	radar::Platform const plat("plat");
+	std::vector<const radar::Object*> const objects;
 
 	std::ostringstream oss;
 	// Platform has an empty motion path, so it should return immediately

--- a/packages/libfers/tests/serial/test_kml_generator_utils.cpp
+++ b/packages/libfers/tests/serial/test_kml_generator_utils.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <sstream>
 
 #include "antenna/antenna_factory.h"
@@ -117,7 +118,8 @@ TEST_CASE("KML Geodesic: Coordinate Calculations", "[serial][kml][geodesic]")
 {
 	SECTION("Destination Coordinate")
 	{
-		double dest_lat, dest_lon;
+		double dest_lat = std::numeric_limits<double>::quiet_NaN();
+		double dest_lon = std::numeric_limits<double>::quiet_NaN();
 		// Start at equator/prime meridian, move East (90 deg) by ~1 degree of longitude (111319.49 meters)
 		serial::kml_generator_utils::calculateDestinationCoordinate(0.0, 0.0, 90.0, 111319.49, dest_lat, dest_lon);
 		REQUIRE_THAT(dest_lat, WithinAbs(0.0, 1e-4));

--- a/packages/libfers/tests/serial/test_libxml_wrapper.cpp
+++ b/packages/libfers/tests/serial/test_libxml_wrapper.cpp
@@ -132,6 +132,7 @@ TEST_CASE("XmlDocument throws when setting root on moved-from doc", "[serial][xm
 	XmlDocument const moved_doc(std::move(doc));
 	const XmlElement root = XmlElement::create("root");
 	moved_doc.setRootElement(root);
+	// NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move): Verifies moved-from document guard.
 	REQUIRE_THROWS_AS(doc.setRootElement(root), std::runtime_error);
 }
 
@@ -141,6 +142,7 @@ TEST_CASE("XmlDocument throws when getting root on moved-from doc", "[serial][xm
 	XmlDocument const moved_doc(std::move(doc));
 	const XmlElement root = XmlElement::create("root");
 	moved_doc.setRootElement(root);
+	// NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move): Verifies moved-from document guard.
 	REQUIRE_THROWS_AS(doc.getRootElement(), std::runtime_error);
 }
 

--- a/packages/libfers/tests/serial/test_libxml_wrapper.cpp
+++ b/packages/libfers/tests/serial/test_libxml_wrapper.cpp
@@ -26,7 +26,7 @@ namespace
 
 TEST_CASE("XmlElement handles invalid nodes", "[serial][xml]")
 {
-	XmlElement element(nullptr);
+	XmlElement const element(nullptr);
 	REQUIRE_FALSE(element.isValid());
 	REQUIRE(element.getText().empty());
 	REQUIRE_FALSE(element.childElement("child").isValid());
@@ -34,7 +34,7 @@ TEST_CASE("XmlElement handles invalid nodes", "[serial][xml]")
 
 TEST_CASE("XmlElement reads and writes text", "[serial][xml]")
 {
-	XmlDocument doc;
+	XmlDocument const doc;
 	const XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 	root.setText("alpha");
@@ -49,7 +49,7 @@ TEST_CASE("XmlElement reads and writes text", "[serial][xml]")
 
 TEST_CASE("XmlElement manages attributes", "[serial][xml]")
 {
-	XmlDocument doc;
+	XmlDocument const doc;
 	const XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 	root.setAttribute("mode", "cw");
@@ -60,7 +60,7 @@ TEST_CASE("XmlElement manages attributes", "[serial][xml]")
 
 TEST_CASE("XmlElement handles child indexing and filtering", "[serial][xml]")
 {
-	XmlDocument doc;
+	XmlDocument const doc;
 	const XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 
@@ -105,7 +105,7 @@ TEST_CASE("XmlDocument loads files and persists output", "[serial][xml]")
 	REQUIRE(doc.saveFile(output_path));
 
 	std::ifstream in(output_path, std::ios::binary);
-	std::string saved((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+	std::string const saved((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
 	REQUIRE(saved.find("<value>17</value>") != std::string::npos);
 
 	std::remove(input_path.c_str());
@@ -114,7 +114,7 @@ TEST_CASE("XmlDocument loads files and persists output", "[serial][xml]")
 
 TEST_CASE("XmlDocument requires root element", "[serial][xml]")
 {
-	XmlDocument doc;
+	XmlDocument const doc;
 	const XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 	REQUIRE(doc.getRootElement().name() == "root");
@@ -122,14 +122,14 @@ TEST_CASE("XmlDocument requires root element", "[serial][xml]")
 
 TEST_CASE("XmlDocument throws when root is missing", "[serial][xml]")
 {
-	XmlDocument doc;
+	XmlDocument const doc;
 	REQUIRE_THROWS_AS(doc.getRootElement(), std::runtime_error);
 }
 
 TEST_CASE("XmlDocument throws when setting root on moved-from doc", "[serial][xml]")
 {
 	XmlDocument doc;
-	XmlDocument moved_doc(std::move(doc));
+	XmlDocument const moved_doc(std::move(doc));
 	const XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	moved_doc.setRootElement(root);
 	REQUIRE_THROWS_AS(doc.setRootElement(root), std::runtime_error);
@@ -138,7 +138,7 @@ TEST_CASE("XmlDocument throws when setting root on moved-from doc", "[serial][xm
 TEST_CASE("XmlDocument throws when getting root on moved-from doc", "[serial][xml]")
 {
 	XmlDocument doc;
-	XmlDocument moved_doc(std::move(doc));
+	XmlDocument const moved_doc(std::move(doc));
 	const XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	moved_doc.setRootElement(root);
 	REQUIRE_THROWS_AS(doc.getRootElement(), std::runtime_error);
@@ -245,8 +245,8 @@ TEST_CASE("XmlDocument loadFile fails for missing file", "[serial][xml]")
 
 TEST_CASE("mergeXmlDocuments merges element children", "[serial][xml]")
 {
-	XmlDocument main_doc;
-	XmlDocument included_doc;
+	XmlDocument const main_doc;
+	XmlDocument const included_doc;
 
 	const XmlElement main_root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	main_root.addChild("main").setText("1");
@@ -267,7 +267,7 @@ TEST_CASE("mergeXmlDocuments merges element children", "[serial][xml]")
 
 TEST_CASE("removeIncludeElements removes all include nodes", "[serial][xml]")
 {
-	XmlDocument doc;
+	XmlDocument const doc;
 	const XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	root.addChild("include").setText("first");
 	root.addChild("keep").setText("value");

--- a/packages/libfers/tests/serial/test_libxml_wrapper.cpp
+++ b/packages/libfers/tests/serial/test_libxml_wrapper.cpp
@@ -35,7 +35,7 @@ TEST_CASE("XmlElement handles invalid nodes", "[serial][xml]")
 TEST_CASE("XmlElement reads and writes text", "[serial][xml]")
 {
 	XmlDocument const doc;
-	const XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	const XmlElement root = XmlElement::create("root");
 	doc.setRootElement(root);
 	root.setText("alpha");
 	root.setText("beta");
@@ -50,7 +50,7 @@ TEST_CASE("XmlElement reads and writes text", "[serial][xml]")
 TEST_CASE("XmlElement manages attributes", "[serial][xml]")
 {
 	XmlDocument const doc;
-	const XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	const XmlElement root = XmlElement::create("root");
 	doc.setRootElement(root);
 	root.setAttribute("mode", "cw");
 
@@ -61,7 +61,7 @@ TEST_CASE("XmlElement manages attributes", "[serial][xml]")
 TEST_CASE("XmlElement handles child indexing and filtering", "[serial][xml]")
 {
 	XmlDocument const doc;
-	const XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	const XmlElement root = XmlElement::create("root");
 	doc.setRootElement(root);
 
 	const XmlElement alpha0 = root.addChild("alpha");
@@ -115,7 +115,7 @@ TEST_CASE("XmlDocument loads files and persists output", "[serial][xml]")
 TEST_CASE("XmlDocument requires root element", "[serial][xml]")
 {
 	XmlDocument const doc;
-	const XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	const XmlElement root = XmlElement::create("root");
 	doc.setRootElement(root);
 	REQUIRE(doc.getRootElement().name() == "root");
 }
@@ -130,7 +130,7 @@ TEST_CASE("XmlDocument throws when setting root on moved-from doc", "[serial][xm
 {
 	XmlDocument doc;
 	XmlDocument const moved_doc(std::move(doc));
-	const XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	const XmlElement root = XmlElement::create("root");
 	moved_doc.setRootElement(root);
 	REQUIRE_THROWS_AS(doc.setRootElement(root), std::runtime_error);
 }
@@ -139,7 +139,7 @@ TEST_CASE("XmlDocument throws when getting root on moved-from doc", "[serial][xm
 {
 	XmlDocument doc;
 	XmlDocument const moved_doc(std::move(doc));
-	const XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	const XmlElement root = XmlElement::create("root");
 	moved_doc.setRootElement(root);
 	REQUIRE_THROWS_AS(doc.getRootElement(), std::runtime_error);
 }
@@ -248,11 +248,11 @@ TEST_CASE("mergeXmlDocuments merges element children", "[serial][xml]")
 	XmlDocument const main_doc;
 	XmlDocument const included_doc;
 
-	const XmlElement main_root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	const XmlElement main_root = XmlElement::create("root");
 	main_root.addChild("main").setText("1");
 	main_doc.setRootElement(main_root);
 
-	const XmlElement included_root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	const XmlElement included_root = XmlElement::create("root");
 	included_root.addChild("a").setText("2");
 	included_root.addChild("b").setText("3");
 	included_doc.setRootElement(included_root);
@@ -268,7 +268,7 @@ TEST_CASE("mergeXmlDocuments merges element children", "[serial][xml]")
 TEST_CASE("removeIncludeElements removes all include nodes", "[serial][xml]")
 {
 	XmlDocument const doc;
-	const XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	const XmlElement root = XmlElement::create("root");
 	root.addChild("include").setText("first");
 	root.addChild("keep").setText("value");
 	root.addChild("include").setText("second");

--- a/packages/libfers/tests/serial/test_response.cpp
+++ b/packages/libfers/tests/serial/test_response.cpp
@@ -34,12 +34,12 @@ namespace
 TEST_CASE("Response start/end time default to zero", "[serial][response]")
 {
 	radar::Platform platform("TxPlatform");
-	radar::Transmitter transmitter(&platform, "TxA", radar::OperationMode::PULSED_MODE, 7);
+	radar::Transmitter const transmitter(&platform, "TxA", radar::OperationMode::PULSED_MODE, 7);
 
 	auto signal = std::make_unique<CaptureSignal>();
-	fers_signal::RadarSignal wave("wave", 1.0, 1.0, 1.0, std::move(signal), 100);
+	fers_signal::RadarSignal const wave("wave", 1.0, 1.0, 1.0, std::move(signal), 100);
 
-	serial::Response response(&wave, &transmitter);
+	serial::Response const response(&wave, &transmitter);
 
 	REQUIRE_THAT(response.startTime(), WithinAbs(0.0, 0.0));
 	REQUIRE_THAT(response.endTime(), WithinAbs(0.0, 0.0));
@@ -49,10 +49,10 @@ TEST_CASE("Response start/end time default to zero", "[serial][response]")
 TEST_CASE("Response records interpolation points", "[serial][response]")
 {
 	radar::Platform platform("TxPlatform");
-	radar::Transmitter transmitter(&platform, "TxA", radar::OperationMode::PULSED_MODE, 7);
+	radar::Transmitter const transmitter(&platform, "TxA", radar::OperationMode::PULSED_MODE, 7);
 
 	auto signal = std::make_unique<CaptureSignal>();
-	fers_signal::RadarSignal wave("wave", 1.0, 1.0, 1.0, std::move(signal), 100);
+	fers_signal::RadarSignal const wave("wave", 1.0, 1.0, 1.0, std::move(signal), 100);
 
 	serial::Response response(&wave, &transmitter);
 	response.addInterpPoint({1.0, 0.25, 0.0, 0.0});
@@ -66,26 +66,26 @@ TEST_CASE("Response records interpolation points", "[serial][response]")
 TEST_CASE("Response exposes transmitter id", "[serial][response]")
 {
 	radar::Platform platform("TxPlatform");
-	radar::Transmitter transmitter(&platform, "TxA", radar::OperationMode::CW_MODE, 1234);
+	radar::Transmitter const transmitter(&platform, "TxA", radar::OperationMode::CW_MODE, 1234);
 
 	auto signal = std::make_unique<CaptureSignal>();
-	fers_signal::RadarSignal wave("wave", 1.0, 1.0, 1.0, std::move(signal), 100);
+	fers_signal::RadarSignal const wave("wave", 1.0, 1.0, 1.0, std::move(signal), 100);
 
-	serial::Response response(&wave, &transmitter);
+	serial::Response const response(&wave, &transmitter);
 	REQUIRE(response.getTransmitterId() == 1234);
 }
 
 TEST_CASE("Response renderBinary delegates to signal", "[serial][response]")
 {
 	radar::Platform platform("TxPlatform");
-	radar::Transmitter transmitter(&platform, "TxA", radar::OperationMode::PULSED_MODE, 7);
+	radar::Transmitter const transmitter(&platform, "TxA", radar::OperationMode::PULSED_MODE, 7);
 
 	auto signal = std::make_unique<CaptureSignal>();
 	signal->data = {ComplexType{1.0, -1.0}, ComplexType{0.5, 0.25}};
 	std::vector<ComplexType> dummy = {ComplexType{0.0, 0.0}};
 	signal->load(dummy, static_cast<unsigned>(dummy.size()), 1250.0);
 
-	fers_signal::RadarSignal wave("wave", 1.0, 1.0, 1.0, std::move(signal), 100);
+	fers_signal::RadarSignal const wave("wave", 1.0, 1.0, 1.0, std::move(signal), 100);
 
 	serial::Response response(&wave, &transmitter);
 	response.addInterpPoint({1.0, 0.0, 0.0, 0.0});

--- a/packages/libfers/tests/serial/test_vita49.cpp
+++ b/packages/libfers/tests/serial/test_vita49.cpp
@@ -121,7 +121,7 @@ namespace
 		void releaseFirstSend()
 		{
 			{
-				std::lock_guard lock(mutex);
+				std::lock_guard const lock(mutex);
 				release_first_send = true;
 			}
 			cv.notify_all();
@@ -471,7 +471,7 @@ TEST_CASE("VITA packetizer uses first sample timestamp, packet cap, and big-endi
 {
 	using namespace serial::vita49;
 
-	Vita49Packetizer packetizer(1'700'000'000'123'456'789ull, 1.0, 1400);
+	Vita49Packetizer const packetizer(1'700'000'000'123'456'789ull, 1.0, 1400);
 	REQUIRE(packetizer.maxComplexSamplesPerPacket() == 342u);
 
 	std::vector<ComplexType> samples(1000, ComplexType(0.5, -0.5));
@@ -601,7 +601,7 @@ TEST_CASE("VITA paced sender blocks at queue depth instead of dropping", "[seria
 TEST_CASE("VITA packetizer encodes explicit sample loss flags", "[serial][vita49]")
 {
 	using namespace serial::vita49;
-	Vita49Packetizer packetizer(1'700'000'000'000'000'000ull, 1.0, 1400);
+	Vita49Packetizer const packetizer(1'700'000'000'000'000'000ull, 1.0, 1400);
 	std::vector<ComplexType> samples{ComplexType(0.0, 0.0)};
 	const core::ReceiverStreamDescriptor stream{.receiver_id = 9,
 												.receiver_name = "rx",
@@ -1083,7 +1083,7 @@ TEST_CASE("VITA output sink starts pacing at simulation start time", "[serial][v
 {
 	using namespace serial::vita49;
 
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(2.0, 3.0);
 
 	auto recording = std::make_unique<RecordingSender>();
@@ -1123,7 +1123,7 @@ TEST_CASE("VITA output sink drains future packets before final stats", "[serial]
 {
 	using namespace serial::vita49;
 
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 1.0);
 
 	auto recording = std::make_unique<RecordingSender>();

--- a/packages/libfers/tests/serial/test_vita49.cpp
+++ b/packages/libfers/tests/serial/test_vita49.cpp
@@ -971,12 +971,14 @@ TEST_CASE("VITA output sink emits live telemetry snapshots and packet traces", "
 	REQUIRE(stream_stats.end_sample_time.has_value());
 	REQUIRE(stream_stats.first_timestamp.has_value());
 	REQUIRE(stream_stats.end_timestamp.has_value());
-	CHECK(*stream_stats.first_sample_time == 0.0);
-	CHECK(*stream_stats.end_sample_time == 0.5);
-	CHECK(stream_stats.first_timestamp->integer_seconds == 1700000000u);
-	CHECK(stream_stats.first_timestamp->fractional_picoseconds == 0u);
-	CHECK(stream_stats.end_timestamp->integer_seconds == 1700000000u);
-	CHECK(stream_stats.end_timestamp->fractional_picoseconds == 500000000000u);
+	const auto first_timestamp = stream_stats.first_timestamp.value_or(core::Vita49Timestamp{});
+	const auto end_timestamp = stream_stats.end_timestamp.value_or(core::Vita49Timestamp{});
+	CHECK(stream_stats.first_sample_time.value_or(0.0) == 0.0);
+	CHECK(stream_stats.end_sample_time.value_or(0.0) == 0.5);
+	CHECK(first_timestamp.integer_seconds == 1700000000u);
+	CHECK(first_timestamp.fractional_picoseconds == 0u);
+	CHECK(end_timestamp.integer_seconds == 1700000000u);
+	CHECK(end_timestamp.fractional_picoseconds == 500000000000u);
 	CHECK(stats_snapshots.back().streams.size() == 1u);
 	CHECK(stats_snapshots.back().streams.front().receiver_id == 7u);
 	CHECK(std::ranges::any_of(packet_traces, [](const auto& trace) { return trace.event == "context"; }));
@@ -986,8 +988,9 @@ TEST_CASE("VITA output sink emits live telemetry snapshots and packet traces", "
 		std::ranges::find_if(packet_traces, [](const auto& trace) { return trace.event == "data"; });
 	REQUIRE(data_trace != packet_traces.end());
 	REQUIRE(data_trace->timestamp.has_value());
-	CHECK(data_trace->timestamp->integer_seconds == 1700000000u);
-	CHECK(data_trace->timestamp->fractional_picoseconds == 0u);
+	const auto data_timestamp = data_trace->timestamp.value_or(core::Vita49Timestamp{});
+	CHECK(data_timestamp.integer_seconds == 1700000000u);
+	CHECK(data_timestamp.fractional_picoseconds == 0u);
 }
 
 TEST_CASE("VITA output sink batches packet trace telemetry", "[serial][vita49][telemetry]")

--- a/packages/libfers/tests/serial/test_vita49.cpp
+++ b/packages/libfers/tests/serial/test_vita49.cpp
@@ -92,6 +92,249 @@ namespace
 		return value;
 	}
 
+	[[nodiscard]] core::ReceiverStreamDescriptor fmcwContextStreamDescriptor()
+	{
+		return core::ReceiverStreamDescriptor{.receiver_id = 0x1122334455667788ull,
+											  .receiver_name = "rx1",
+											  .mode = "fmcw",
+											  .sample_rate = 2.5e6,
+											  .reference_frequency = 9.6e9,
+											  .if_offset = -1.25e6,
+											  .bandwidth = 5.0e6,
+											  .dechirped = true,
+											  .if_resampled = false,
+											  .adc_bits = 14,
+											  .coordinate = {.frame = "UTM",
+															 .origin_latitude = -33.9,
+															 .origin_longitude = 18.4,
+															 .origin_altitude = 111.0,
+															 .utm_zone = 34,
+															 .utm_north_hemisphere = false},
+											  .initial_platform_state = {.platform_id = 0x99,
+																		 .platform_name = "rx-platform",
+																		 .position_x = 1.0,
+																		 .position_y = 2.0,
+																		 .position_z = 3.0,
+																		 .velocity_x = 4.0,
+																		 .velocity_y = 5.0,
+																		 .velocity_z = 6.0,
+																		 .azimuth = 0.25,
+																		 .elevation = -0.5},
+											  .fmcw = {.present = true,
+													   .waveform_shape = "linear",
+													   .chirp_bandwidth = 20.0e6,
+													   .chirp_duration = 1.0e-3,
+													   .chirp_period = 2.0e-3,
+													   .chirp_rate = 20.0e9,
+													   .chirp_rate_signed = -20.0e9,
+													   .sweep_direction = "down",
+													   .start_frequency_offset = 1.5e6,
+													   .chirp_count = 64,
+													   .dechirp_mode = "physical",
+													   .dechirp_reference_source = "transmitter",
+													   .dechirp_reference_transmitter_id = 0x1234,
+													   .dechirp_reference_transmitter_name = "tx-lo",
+													   .dechirp_reference_waveform_id = 0,
+													   .dechirp_reference_waveform_name = ""}};
+	}
+
+	[[nodiscard]] std::vector<std::uint8_t> serializedFmcwContextPacket()
+	{
+		using namespace serial::vita49;
+		const auto context = Vita49ContextBuilder::build(ContextBuildRequest{.stream = fmcwContextStreamDescriptor(),
+																			 .stream_id = 0x55667788u,
+																			 .simulation_name = "sim",
+																			 .adc_fullscale = 2.0,
+																			 .timestamp = Timestamp{100u, 250u},
+																			 .packet_count = 3,
+																			 .sample_loss = true,
+																			 .stream_open = true});
+		return Vita49Serializer::serializeContext(context);
+	}
+
+	void requireContextPacketHeader(const std::vector<std::uint8_t>& bytes)
+	{
+		using namespace serial::vita49;
+		REQUIRE(bytes.size() % 4u == 0u);
+		REQUIRE((readU32(bytes, 0) & 0xFFFF0000u) == 0x4A630000u);
+		REQUIRE((readU32(bytes, 0) & 0x0000FFFFu) == bytes.size() / 4u);
+		REQUIRE(readU32(bytes, 4) == 0x55667788u);
+		REQUIRE(readU64(bytes, 8) == kFersVrtIqClassId);
+		REQUIRE(readU32(bytes, 16) == 100u);
+		REQUIRE(readU64(bytes, 20) == 250u);
+		REQUIRE(readU32(bytes, 28) == kFersContextCif0);
+	}
+
+	void requireContextPacketFields(const std::vector<std::uint8_t>& bytes)
+	{
+		using namespace serial::vita49;
+		REQUIRE((readU32(bytes, 32) & TrailerSampleLoss) == TrailerSampleLoss);
+		REQUIRE(readU64(bytes, 36) == makeComplexInt16PayloadFormat());
+		REQUIRE(readF64(bytes, 44) == 2.5e6);
+		REQUIRE(readF64(bytes, 52) == 9.6e9);
+		REQUIRE(readF64(bytes, 60) == -1.25e6);
+		REQUIRE(readF64(bytes, 68) == 5.0e6);
+		REQUIRE(readF64(bytes, 76) == 2.0);
+		REQUIRE(readU64(bytes, 84) == 0x1122334455667788ull);
+	}
+
+	void requireAsciiMetadataPadding(const std::vector<std::uint8_t>& bytes, const std::size_t ascii_offset)
+	{
+		const auto null_pos = std::find(bytes.begin() + static_cast<std::ptrdiff_t>(ascii_offset), bytes.end(), 0);
+		REQUIRE(null_pos != bytes.end());
+		for (auto it = bytes.begin() + static_cast<std::ptrdiff_t>(ascii_offset); it != null_pos; ++it)
+		{
+			REQUIRE(*it <= 0x7Fu);
+		}
+		for (auto it = std::next(null_pos); it != bytes.end(); ++it)
+		{
+			REQUIRE(*it == 0u);
+		}
+	}
+
+	void requireContextReceiverMetadata(const nlohmann::json& metadata)
+	{
+		using namespace serial::vita49;
+		REQUIRE(metadata.at("schema") == "fers-vita49-context-v1");
+		REQUIRE(metadata.at("simulation_name") == "sim");
+		REQUIRE(metadata.at("receiver").at("id").get<std::uint64_t>() == 0x1122334455667788ull);
+		REQUIRE(metadata.at("receiver").at("name") == "rx1");
+		REQUIRE(metadata.at("receiver").at("mode") == "fmcw");
+		REQUIRE(metadata.at("receiver").at("adc_bits") == 14u);
+		const auto context_flags = metadata.at("receiver").at("context_flags").get<std::uint32_t>();
+		REQUIRE(
+			(context_flags &
+			 (ContextFlagDechirped | ContextFlagSampleLoss | ContextFlagStreamOpen | ContextFlagFmcwMetadataPresent)) ==
+			(ContextFlagDechirped | ContextFlagSampleLoss | ContextFlagStreamOpen | ContextFlagFmcwMetadataPresent));
+	}
+
+	void requireContextCoordinateMetadata(const nlohmann::json& metadata)
+	{
+		REQUIRE(metadata.at("coordinate_frame").at("frame") == "UTM");
+		REQUIRE(metadata.at("coordinate_frame").at("origin").at("latitude") == -33.9);
+		REQUIRE(metadata.at("coordinate_frame").at("origin").at("longitude") == 18.4);
+		REQUIRE(metadata.at("coordinate_frame").at("origin").at("altitude") == 111.0);
+		REQUIRE(metadata.at("coordinate_frame").at("utm_zone") == 34);
+		REQUIRE_FALSE(metadata.at("coordinate_frame").at("utm_north_hemisphere").get<bool>());
+	}
+
+	void requireContextPlatformMetadata(const nlohmann::json& metadata)
+	{
+		REQUIRE(metadata.at("initial_platform_state").at("platform_id") == 0x99u);
+		REQUIRE(metadata.at("initial_platform_state").at("platform_name") == "rx-platform");
+		REQUIRE(metadata.at("initial_platform_state").at("position_m").at("x") == 1.0);
+		REQUIRE(metadata.at("initial_platform_state").at("position_m").at("y") == 2.0);
+		REQUIRE(metadata.at("initial_platform_state").at("position_m").at("z") == 3.0);
+		REQUIRE(metadata.at("initial_platform_state").at("velocity_mps").at("x") == 4.0);
+		REQUIRE(metadata.at("initial_platform_state").at("velocity_mps").at("y") == 5.0);
+		REQUIRE(metadata.at("initial_platform_state").at("velocity_mps").at("z") == 6.0);
+		REQUIRE(metadata.at("initial_platform_state").at("rotation_rad").at("azimuth") == 0.25);
+		REQUIRE(metadata.at("initial_platform_state").at("rotation_rad").at("elevation") == -0.5);
+	}
+
+	void requireContextFmcwMetadata(const nlohmann::json& metadata)
+	{
+		REQUIRE(metadata.at("fmcw").at("present").get<bool>());
+		REQUIRE(metadata.at("fmcw").at("waveform_shape") == "linear");
+		REQUIRE(metadata.at("fmcw").at("sweep_direction") == "down");
+		REQUIRE(metadata.at("fmcw").at("chirp_bandwidth_hz") == 20.0e6);
+		REQUIRE(metadata.at("fmcw").at("chirp_duration_s") == 1.0e-3);
+		REQUIRE(metadata.at("fmcw").at("chirp_period_s") == 2.0e-3);
+		REQUIRE(metadata.at("fmcw").at("chirp_rate_hz_per_s") == 20.0e9);
+		REQUIRE(metadata.at("fmcw").at("chirp_rate_signed_hz_per_s") == -20.0e9);
+		REQUIRE(metadata.at("fmcw").at("start_frequency_offset_hz") == 1.5e6);
+		REQUIRE(metadata.at("fmcw").at("chirp_count") == 64u);
+		REQUIRE(metadata.at("fmcw").at("dechirp_mode") == "physical");
+		REQUIRE(metadata.at("fmcw").at("dechirp_reference_source") == "transmitter");
+		REQUIRE(metadata.at("fmcw").at("dechirp_reference_transmitter_id") == 0x1234u);
+		REQUIRE(metadata.at("fmcw").at("dechirp_reference_transmitter_name") == "tx-lo");
+		REQUIRE(metadata.at("waveform").at("kind") == "fmcw");
+		REQUIRE(metadata.at("waveform").at("metadata_ref") == "fmcw");
+	}
+
+	[[nodiscard]] core::ReceiverStreamDescriptor basicCwStreamDescriptor()
+	{
+		return core::ReceiverStreamDescriptor{.receiver_id = 77,
+											  .receiver_name = "rx",
+											  .mode = "cw",
+											  .sample_rate = 1.0,
+											  .reference_frequency = 1.0e9,
+											  .coordinate = {},
+											  .initial_platform_state = {},
+											  .fmcw = {}};
+	}
+
+	void requirePacketsFitPayload(const std::vector<serial::vita49::SerializedPacket>& packets,
+								  const std::size_t max_bytes)
+	{
+		for (const auto& packet : packets)
+		{
+			REQUIRE(packet.bytes.size() <= max_bytes);
+			REQUIRE((readU32(packet.bytes, 0) & 0x0000FFFFu) == packet.bytes.size() / 4u);
+		}
+	}
+
+	[[nodiscard]] serial::vita49::SerializedPacket testSerializedPacket(const std::uint8_t payload_byte,
+																		const std::uint64_t sample_count)
+	{
+		return serial::vita49::SerializedPacket{.bytes = {0, 0, 0, payload_byte},
+												.stream_id = 9,
+												.sample_count = sample_count,
+												.first_sample_time = 0.0,
+												.data_packet = true,
+												.timestamp = serial::vita49::Timestamp{}};
+	}
+
+	[[nodiscard]] std::future<serial::vita49::EnqueueResult>
+	enqueueAsync(serial::vita49::PacedSender& sender, const serial::vita49::SerializedPacket& packet,
+				 std::atomic_bool& enqueue_finished)
+	{
+		return std::async(std::launch::async,
+						  [&sender, packet, &enqueue_finished]
+						  {
+							  auto result = sender.enqueue(packet);
+							  enqueue_finished.store(true);
+							  return result;
+						  });
+	}
+
+	void requireLiveTelemetryStats(const core::OutputStats& final_stats,
+								   const std::vector<core::OutputStats>& stats_snapshots)
+	{
+		REQUIRE_FALSE(stats_snapshots.empty());
+		REQUIRE(final_stats.streams.size() == 1u);
+		const auto& stream_stats = final_stats.streams.front();
+		REQUIRE(stream_stats.first_sample_time.has_value());
+		REQUIRE(stream_stats.end_sample_time.has_value());
+		REQUIRE(stream_stats.first_timestamp.has_value());
+		REQUIRE(stream_stats.end_timestamp.has_value());
+
+		const auto first_timestamp = stream_stats.first_timestamp.value_or(core::Vita49Timestamp{});
+		const auto end_timestamp = stream_stats.end_timestamp.value_or(core::Vita49Timestamp{});
+		CHECK(stream_stats.first_sample_time.value_or(0.0) == 0.0);
+		CHECK(stream_stats.end_sample_time.value_or(0.0) == 0.5);
+		CHECK(first_timestamp.integer_seconds == 1700000000u);
+		CHECK(first_timestamp.fractional_picoseconds == 0u);
+		CHECK(end_timestamp.integer_seconds == 1700000000u);
+		CHECK(end_timestamp.fractional_picoseconds == 500000000000u);
+		CHECK(stats_snapshots.back().streams.size() == 1u);
+		CHECK(stats_snapshots.back().streams.front().receiver_id == 7u);
+	}
+
+	void requireLivePacketTraces(const std::vector<core::ReceiverOutputPacketTrace>& packet_traces)
+	{
+		CHECK(std::ranges::any_of(packet_traces, [](const auto& trace) { return trace.event == "context"; }));
+		CHECK(std::ranges::any_of(packet_traces, [](const auto& trace) { return trace.event == "data"; }));
+		CHECK(std::ranges::all_of(packet_traces, [](const auto& trace) { return trace.sequence > 0u; }));
+		const auto data_trace =
+			std::ranges::find_if(packet_traces, [](const auto& trace) { return trace.event == "data"; });
+		REQUIRE(data_trace != packet_traces.end());
+		REQUIRE(data_trace->timestamp.has_value());
+		const auto data_timestamp = data_trace->timestamp.value_or(core::Vita49Timestamp{});
+		CHECK(data_timestamp.integer_seconds == 1700000000u);
+		CHECK(data_timestamp.fractional_picoseconds == 0u);
+	}
+
 	class RecordingSender final : public serial::vita49::DatagramSender
 	{
 	public:
@@ -230,130 +473,18 @@ TEST_CASE("VITA context packet serializes CIF and fields in profile order", "[se
 {
 	using namespace serial::vita49;
 
-	const core::ReceiverStreamDescriptor stream{.receiver_id = 0x1122334455667788ull,
-												.receiver_name = "rx1",
-												.mode = "fmcw",
-												.sample_rate = 2.5e6,
-												.reference_frequency = 9.6e9,
-												.if_offset = -1.25e6,
-												.bandwidth = 5.0e6,
-												.dechirped = true,
-												.if_resampled = false,
-												.adc_bits = 14,
-												.coordinate = {.frame = "UTM",
-															   .origin_latitude = -33.9,
-															   .origin_longitude = 18.4,
-															   .origin_altitude = 111.0,
-															   .utm_zone = 34,
-															   .utm_north_hemisphere = false},
-												.initial_platform_state = {.platform_id = 0x99,
-																		   .platform_name = "rx-platform",
-																		   .position_x = 1.0,
-																		   .position_y = 2.0,
-																		   .position_z = 3.0,
-																		   .velocity_x = 4.0,
-																		   .velocity_y = 5.0,
-																		   .velocity_z = 6.0,
-																		   .azimuth = 0.25,
-																		   .elevation = -0.5},
-												.fmcw = {.present = true,
-														 .waveform_shape = "linear",
-														 .chirp_bandwidth = 20.0e6,
-														 .chirp_duration = 1.0e-3,
-														 .chirp_period = 2.0e-3,
-														 .chirp_rate = 20.0e9,
-														 .chirp_rate_signed = -20.0e9,
-														 .sweep_direction = "down",
-														 .start_frequency_offset = 1.5e6,
-														 .chirp_count = 64,
-														 .dechirp_mode = "physical",
-														 .dechirp_reference_source = "transmitter",
-														 .dechirp_reference_transmitter_id = 0x1234,
-														 .dechirp_reference_transmitter_name = "tx-lo",
-														 .dechirp_reference_waveform_id = 0,
-														 .dechirp_reference_waveform_name = ""}};
-	const auto context = Vita49ContextBuilder::build(ContextBuildRequest{.stream = stream,
-																		 .stream_id = 0x55667788u,
-																		 .simulation_name = "sim",
-																		 .adc_fullscale = 2.0,
-																		 .timestamp = Timestamp{100u, 250u},
-																		 .packet_count = 3,
-																		 .sample_loss = true,
-																		 .stream_open = true});
+	const auto bytes = serializedFmcwContextPacket();
 
-	const auto bytes = Vita49Serializer::serializeContext(context);
-
-	REQUIRE(bytes.size() % 4u == 0u);
-	REQUIRE((readU32(bytes, 0) & 0xFFFF0000u) == 0x4A630000u);
-	REQUIRE((readU32(bytes, 0) & 0x0000FFFFu) == bytes.size() / 4u);
-	REQUIRE(readU32(bytes, 4) == 0x55667788u);
-	REQUIRE(readU64(bytes, 8) == kFersVrtIqClassId);
-	REQUIRE(readU32(bytes, 16) == 100u);
-	REQUIRE(readU64(bytes, 20) == 250u);
-	REQUIRE(readU32(bytes, 28) == kFersContextCif0);
-	REQUIRE((readU32(bytes, 32) & TrailerSampleLoss) == TrailerSampleLoss);
-	REQUIRE(readU64(bytes, 36) == makeComplexInt16PayloadFormat());
-	REQUIRE(readF64(bytes, 44) == 2.5e6);
-	REQUIRE(readF64(bytes, 52) == 9.6e9);
-	REQUIRE(readF64(bytes, 60) == -1.25e6);
-	REQUIRE(readF64(bytes, 68) == 5.0e6);
-	REQUIRE(readF64(bytes, 76) == 2.0);
-	REQUIRE(readU64(bytes, 84) == 0x1122334455667788ull);
+	requireContextPacketHeader(bytes);
+	requireContextPacketFields(bytes);
 	constexpr std::size_t ascii_offset = 92u;
-	const auto null_pos = std::find(bytes.begin() + static_cast<std::ptrdiff_t>(ascii_offset), bytes.end(), 0);
-	REQUIRE(null_pos != bytes.end());
-	for (auto it = bytes.begin() + static_cast<std::ptrdiff_t>(ascii_offset); it != null_pos; ++it)
-	{
-		REQUIRE(*it <= 0x7Fu);
-	}
-	for (auto it = std::next(null_pos); it != bytes.end(); ++it)
-	{
-		REQUIRE(*it == 0u);
-	}
+	requireAsciiMetadataPadding(bytes, ascii_offset);
 
 	const auto metadata = nlohmann::json::parse(readAsciiMetadata(bytes, ascii_offset));
-	REQUIRE(metadata.at("schema") == "fers-vita49-context-v1");
-	REQUIRE(metadata.at("simulation_name") == "sim");
-	REQUIRE(metadata.at("receiver").at("id").get<std::uint64_t>() == 0x1122334455667788ull);
-	REQUIRE(metadata.at("receiver").at("name") == "rx1");
-	REQUIRE(metadata.at("receiver").at("mode") == "fmcw");
-	REQUIRE(metadata.at("receiver").at("adc_bits") == 14u);
-	const auto context_flags = metadata.at("receiver").at("context_flags").get<std::uint32_t>();
-	REQUIRE((context_flags &
-			 (ContextFlagDechirped | ContextFlagSampleLoss | ContextFlagStreamOpen | ContextFlagFmcwMetadataPresent)) ==
-			(ContextFlagDechirped | ContextFlagSampleLoss | ContextFlagStreamOpen | ContextFlagFmcwMetadataPresent));
-	REQUIRE(metadata.at("coordinate_frame").at("frame") == "UTM");
-	REQUIRE(metadata.at("coordinate_frame").at("origin").at("latitude") == -33.9);
-	REQUIRE(metadata.at("coordinate_frame").at("origin").at("longitude") == 18.4);
-	REQUIRE(metadata.at("coordinate_frame").at("origin").at("altitude") == 111.0);
-	REQUIRE(metadata.at("coordinate_frame").at("utm_zone") == 34);
-	REQUIRE_FALSE(metadata.at("coordinate_frame").at("utm_north_hemisphere").get<bool>());
-	REQUIRE(metadata.at("initial_platform_state").at("platform_id") == 0x99u);
-	REQUIRE(metadata.at("initial_platform_state").at("platform_name") == "rx-platform");
-	REQUIRE(metadata.at("initial_platform_state").at("position_m").at("x") == 1.0);
-	REQUIRE(metadata.at("initial_platform_state").at("position_m").at("y") == 2.0);
-	REQUIRE(metadata.at("initial_platform_state").at("position_m").at("z") == 3.0);
-	REQUIRE(metadata.at("initial_platform_state").at("velocity_mps").at("x") == 4.0);
-	REQUIRE(metadata.at("initial_platform_state").at("velocity_mps").at("y") == 5.0);
-	REQUIRE(metadata.at("initial_platform_state").at("velocity_mps").at("z") == 6.0);
-	REQUIRE(metadata.at("initial_platform_state").at("rotation_rad").at("azimuth") == 0.25);
-	REQUIRE(metadata.at("initial_platform_state").at("rotation_rad").at("elevation") == -0.5);
-	REQUIRE(metadata.at("fmcw").at("present").get<bool>());
-	REQUIRE(metadata.at("fmcw").at("waveform_shape") == "linear");
-	REQUIRE(metadata.at("fmcw").at("sweep_direction") == "down");
-	REQUIRE(metadata.at("fmcw").at("chirp_bandwidth_hz") == 20.0e6);
-	REQUIRE(metadata.at("fmcw").at("chirp_duration_s") == 1.0e-3);
-	REQUIRE(metadata.at("fmcw").at("chirp_period_s") == 2.0e-3);
-	REQUIRE(metadata.at("fmcw").at("chirp_rate_hz_per_s") == 20.0e9);
-	REQUIRE(metadata.at("fmcw").at("chirp_rate_signed_hz_per_s") == -20.0e9);
-	REQUIRE(metadata.at("fmcw").at("start_frequency_offset_hz") == 1.5e6);
-	REQUIRE(metadata.at("fmcw").at("chirp_count") == 64u);
-	REQUIRE(metadata.at("fmcw").at("dechirp_mode") == "physical");
-	REQUIRE(metadata.at("fmcw").at("dechirp_reference_source") == "transmitter");
-	REQUIRE(metadata.at("fmcw").at("dechirp_reference_transmitter_id") == 0x1234u);
-	REQUIRE(metadata.at("fmcw").at("dechirp_reference_transmitter_name") == "tx-lo");
-	REQUIRE(metadata.at("waveform").at("kind") == "fmcw");
-	REQUIRE(metadata.at("waveform").at("metadata_ref") == "fmcw");
+	requireContextReceiverMetadata(metadata);
+	requireContextCoordinateMetadata(metadata);
+	requireContextPlatformMetadata(metadata);
+	requireContextFmcwMetadata(metadata);
 }
 
 TEST_CASE("VITA context metadata follows receiver mode when stale mode blocks are present", "[serial][vita49]")
@@ -486,26 +617,17 @@ TEST_CASE("VITA packetizer uses first sample timestamp, packet cap, and big-endi
 	REQUIRE(packetizer.maxComplexSamplesPerPacket() == 342u);
 
 	std::vector<ComplexType> samples(1000, ComplexType(0.5, -0.5));
-	const core::ReceiverStreamDescriptor stream{.receiver_id = 77,
-												.receiver_name = "rx",
-												.mode = "cw",
-												.sample_rate = 1.0,
-												.reference_frequency = 1.0e9,
-												.coordinate = {},
-												.initial_platform_state = {},
-												.fmcw = {}};
-	const core::ReceiverSampleBlock block{
-		.stream = stream, .first_sample_time = 1.25, .sample_rate = 1.0, .samples = samples, .sample_start = 0};
+	const core::ReceiverSampleBlock block{.stream = basicCwStreamDescriptor(),
+										  .first_sample_time = 1.25,
+										  .sample_rate = 1.0,
+										  .samples = samples,
+										  .sample_start = 0};
 	PacketCountSequencer counts;
 	const auto result = packetizer.packetize(block, 0xABCDEF01u, counts, false);
 
 	REQUIRE(result.packets.size() == 3u);
 	REQUIRE(result.samples_emitted == 1000u);
-	for (const auto& packet : result.packets)
-	{
-		REQUIRE(packet.bytes.size() <= 1400u);
-		REQUIRE((readU32(packet.bytes, 0) & 0x0000FFFFu) == packet.bytes.size() / 4u);
-	}
+	requirePacketsFitPayload(result.packets, 1400u);
 	REQUIRE(readU32(result.packets.front().bytes, 16) == 1'700'000'001u);
 	REQUIRE(readU64(result.packets.front().bytes, 20) == 373'456'789'000ull);
 	REQUIRE(readU16(result.packets.front().bytes, 28) == 0x4000u);
@@ -567,31 +689,15 @@ TEST_CASE("VITA paced sender blocks at queue depth instead of dropping", "[seria
 	sender.open("127.0.0.1", 1);
 	sender.start(0.0);
 
-	const SerializedPacket first{.bytes = {0, 0, 0, 1},
-								 .stream_id = 9,
-								 .sample_count = 10,
-								 .first_sample_time = 0.0,
-								 .data_packet = true,
-								 .timestamp = Timestamp{}};
-	const SerializedPacket second{.bytes = {0, 0, 0, 2},
-								  .stream_id = 9,
-								  .sample_count = 12,
-								  .first_sample_time = 0.0,
-								  .data_packet = true,
-								  .timestamp = Timestamp{}};
+	const auto first = testSerializedPacket(1, 10);
+	const auto second = testSerializedPacket(2, 12);
 
 	const auto first_result = sender.enqueue(first);
 	REQUIRE(first_result.enqueued);
 	REQUIRE_FALSE(first_result.dropped);
 	REQUIRE(recording_raw->waitUntilFirstSendEntered());
 	std::atomic_bool second_enqueue_finished = false;
-	auto second_result_future = std::async(std::launch::async,
-										   [&]
-										   {
-											   auto result = sender.enqueue(second);
-											   second_enqueue_finished.store(true);
-											   return result;
-										   });
+	auto second_result_future = enqueueAsync(sender, second, second_enqueue_finished);
 	std::this_thread::sleep_for(20ms);
 	const auto second_finished_before_release = second_enqueue_finished.load();
 	recording_raw->releaseFirstSend();
@@ -964,33 +1070,8 @@ TEST_CASE("VITA output sink emits live telemetry snapshots and packet traces", "
 	sink.submitBlock(block);
 	const auto final_stats = sink.finalize();
 
-	REQUIRE_FALSE(stats_snapshots.empty());
-	REQUIRE(final_stats.streams.size() == 1u);
-	const auto& stream_stats = final_stats.streams.front();
-	REQUIRE(stream_stats.first_sample_time.has_value());
-	REQUIRE(stream_stats.end_sample_time.has_value());
-	REQUIRE(stream_stats.first_timestamp.has_value());
-	REQUIRE(stream_stats.end_timestamp.has_value());
-	const auto first_timestamp = stream_stats.first_timestamp.value_or(core::Vita49Timestamp{});
-	const auto end_timestamp = stream_stats.end_timestamp.value_or(core::Vita49Timestamp{});
-	CHECK(stream_stats.first_sample_time.value_or(0.0) == 0.0);
-	CHECK(stream_stats.end_sample_time.value_or(0.0) == 0.5);
-	CHECK(first_timestamp.integer_seconds == 1700000000u);
-	CHECK(first_timestamp.fractional_picoseconds == 0u);
-	CHECK(end_timestamp.integer_seconds == 1700000000u);
-	CHECK(end_timestamp.fractional_picoseconds == 500000000000u);
-	CHECK(stats_snapshots.back().streams.size() == 1u);
-	CHECK(stats_snapshots.back().streams.front().receiver_id == 7u);
-	CHECK(std::ranges::any_of(packet_traces, [](const auto& trace) { return trace.event == "context"; }));
-	CHECK(std::ranges::any_of(packet_traces, [](const auto& trace) { return trace.event == "data"; }));
-	CHECK(std::ranges::all_of(packet_traces, [](const auto& trace) { return trace.sequence > 0u; }));
-	const auto data_trace =
-		std::ranges::find_if(packet_traces, [](const auto& trace) { return trace.event == "data"; });
-	REQUIRE(data_trace != packet_traces.end());
-	REQUIRE(data_trace->timestamp.has_value());
-	const auto data_timestamp = data_trace->timestamp.value_or(core::Vita49Timestamp{});
-	CHECK(data_timestamp.integer_seconds == 1700000000u);
-	CHECK(data_timestamp.fractional_picoseconds == 0u);
+	requireLiveTelemetryStats(final_stats, stats_snapshots);
+	requireLivePacketTraces(packet_traces);
 }
 
 TEST_CASE("VITA output sink batches packet trace telemetry", "[serial][vita49][telemetry]")

--- a/packages/libfers/tests/serial/test_vita49.cpp
+++ b/packages/libfers/tests/serial/test_vita49.cpp
@@ -43,6 +43,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/serial/test_vita49.cpp
+++ b/packages/libfers/tests/serial/test_vita49.cpp
@@ -132,7 +132,7 @@ namespace
 		void releaseFirstSend()
 		{
 			{
-				std::lock_guard const lock(mutex);
+				std::scoped_lock const lock(mutex);
 				release_first_send = true;
 			}
 			cv.notify_all();

--- a/packages/libfers/tests/serial/test_vita49.cpp
+++ b/packages/libfers/tests/serial/test_vita49.cpp
@@ -70,6 +70,13 @@ namespace
 		return std::bit_cast<double>(readU64(bytes, offset));
 	}
 
+#ifndef _WIN32
+	[[nodiscard]] sockaddr* asSockaddr(sockaddr_in& address) noexcept
+	{
+		return static_cast<sockaddr*>(static_cast<void*>(&address));
+	}
+#endif
+
 	[[nodiscard]] std::string readAsciiMetadata(const std::vector<std::uint8_t>& bytes, std::size_t offset)
 	{
 		std::string value;
@@ -1180,14 +1187,14 @@ TEST_CASE("VITA UDP sender loopback carries stream ID and packet count", "[seria
 	bind_addr.sin_family = AF_INET;
 	bind_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 	bind_addr.sin_port = 0;
-	if (::bind(receiver, reinterpret_cast<sockaddr*>(&bind_addr), sizeof(bind_addr)) != 0)
+	if (::bind(receiver, asSockaddr(bind_addr), sizeof(bind_addr)) != 0)
 	{
 		::close(receiver);
 		SKIP("loopback bind unavailable");
 	}
 
 	socklen_t addr_len = sizeof(bind_addr);
-	REQUIRE(::getsockname(receiver, reinterpret_cast<sockaddr*>(&bind_addr), &addr_len) == 0);
+	REQUIRE(::getsockname(receiver, asSockaddr(bind_addr), &addr_len) == 0);
 
 	timeval timeout{};
 	timeout.tv_sec = 1;

--- a/packages/libfers/tests/serial/test_waveform_factory.cpp
+++ b/packages/libfers/tests/serial/test_waveform_factory.cpp
@@ -112,8 +112,9 @@ TEST_CASE("Waveform factory loads CSV waveform metadata", "[serial][waveform_fac
 	REQUIRE_THAT(waveform->getPower(), WithinAbs(power, 1e-12));
 	REQUIRE_THAT(waveform->getCarrier(), WithinAbs(carrier, 1e-3));
 	REQUIRE(waveform->getId() == explicitId);
-	REQUIRE(waveform->getFilename().has_value());
-	REQUIRE(*waveform->getFilename() == path.string());
+	const auto filename = waveform->getFilename();
+	REQUIRE(filename.has_value());
+	REQUIRE(filename.value_or("") == path.string());
 	REQUIRE_THAT(waveform->getRate(), WithinAbs(csvRate * params::oversampleRatio(), 1e-12));
 	REQUIRE_THAT(waveform->getLength(), WithinAbs(static_cast<RealType>(samples.size()) / csvRate, 1e-12));
 
@@ -147,8 +148,9 @@ TEST_CASE("Waveform factory loads HDF5 waveform metadata", "[serial][waveform_fa
 	REQUIRE_THAT(waveform->getPower(), WithinAbs(power, 1e-12));
 	REQUIRE_THAT(waveform->getCarrier(), WithinAbs(carrier, 1e-3));
 	REQUIRE(waveform->getId() == explicitId);
-	REQUIRE(waveform->getFilename().has_value());
-	REQUIRE(*waveform->getFilename() == path.string());
+	const auto filename = waveform->getFilename();
+	REQUIRE(filename.has_value());
+	REQUIRE(filename.value_or("") == path.string());
 	REQUIRE_THAT(waveform->getRate(), WithinAbs(params::rate(), 1e-12));
 	REQUIRE_THAT(waveform->getLength(), WithinAbs(static_cast<RealType>(samples.size()) / params::rate(), 1e-12));
 

--- a/packages/libfers/tests/serial/test_waveform_factory.cpp
+++ b/packages/libfers/tests/serial/test_waveform_factory.cpp
@@ -24,6 +24,10 @@ namespace
 		params::Parameters saved;
 
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 
 		~ParamGuard() { params::params = saved; }
 	};

--- a/packages/libfers/tests/serial/test_waveform_factory.cpp
+++ b/packages/libfers/tests/serial/test_waveform_factory.cpp
@@ -82,7 +82,7 @@ namespace
 
 TEST_CASE("Waveform factory loads CSV waveform metadata", "[serial][waveform_factory]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(9999.0);
 	params::setOversampleRatio(2);
@@ -118,7 +118,7 @@ TEST_CASE("Waveform factory loads CSV waveform metadata", "[serial][waveform_fac
 
 TEST_CASE("Waveform factory loads HDF5 waveform metadata", "[serial][waveform_factory]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(64.0);
 
@@ -153,7 +153,7 @@ TEST_CASE("Waveform factory loads HDF5 waveform metadata", "[serial][waveform_fa
 
 TEST_CASE("Waveform factory preserves explicit waveform id", "[serial][waveform_factory]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	const std::filesystem::path path = tempFilePath(uniqueFileName("waveform_factory_id", ".csv"));
@@ -184,7 +184,7 @@ TEST_CASE("Waveform factory throws for missing CSV file", "[serial][waveform_fac
 
 TEST_CASE("Waveform factory throws for missing HDF5 file", "[serial][waveform_factory]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(100.0);
 

--- a/packages/libfers/tests/serial/test_xml_parser.cpp
+++ b/packages/libfers/tests/serial/test_xml_parser.cpp
@@ -16,6 +16,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/serial/test_xml_parser.cpp
+++ b/packages/libfers/tests/serial/test_xml_parser.cpp
@@ -62,7 +62,7 @@ namespace
 
 TEST_CASE("parseSimulationFromString successfully parses a valid scenario", "[serial][xml_parser]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	core::World world;
 	std::mt19937 seeder(42);
 
@@ -78,11 +78,11 @@ TEST_CASE("parseSimulationFromString successfully parses a valid scenario", "[se
 
 TEST_CASE("parseSimulationFromString throws on malformed XML", "[serial][xml_parser]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	core::World world;
 	std::mt19937 seeder(42);
 
-	std::string bad_xml = "<simulation><parameters><starttime>0</starttime></parameters>"; // Missing closing tags
+	std::string const bad_xml = "<simulation><parameters><starttime>0</starttime></parameters>"; // Missing closing tags
 
 	REQUIRE_THROWS_WITH(serial::parseSimulationFromString(bad_xml, &world, false, seeder),
 						ContainsSubstring("Failed to parse XML from memory string"));
@@ -90,12 +90,12 @@ TEST_CASE("parseSimulationFromString throws on malformed XML", "[serial][xml_par
 
 TEST_CASE("parseSimulationFromString throws on schema validation failure", "[serial][xml_parser]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	core::World world;
 	std::mt19937 seeder(42);
 
 	// Missing required <parameters> block
-	std::string invalid_schema_xml = R"(<?xml version="1.0" encoding="UTF-8"?>
+	std::string const invalid_schema_xml = R"(<?xml version="1.0" encoding="UTF-8"?>
 		<simulation name="TestSim">
 		  <waveform name="w1"><power>1000</power><carrier_frequency>1e9</carrier_frequency><cw/></waveform>
 		</simulation>)";
@@ -106,16 +106,16 @@ TEST_CASE("parseSimulationFromString throws on schema validation failure", "[ser
 
 TEST_CASE("parseSimulation handles file loading and includes", "[serial][xml_parser]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	core::World world;
 	std::mt19937 seeder(42);
 
-	std::string include_xml = R"(<?xml version="1.0" encoding="UTF-8"?>
+	std::string const include_xml = R"(<?xml version="1.0" encoding="UTF-8"?>
 		<simulation name="IncludeSim">
 		  <antenna name="a1" pattern="isotropic"/>
 		</simulation>)";
 
-	std::string main_xml = R"(<?xml version="1.0" encoding="UTF-8"?>
+	std::string const main_xml = R"(<?xml version="1.0" encoding="UTF-8"?>
 		<simulation name="MainSim">
 		  <parameters>
 		    <starttime>0</starttime>
@@ -140,7 +140,7 @@ TEST_CASE("parseSimulation handles file loading and includes", "[serial][xml_par
 
 TEST_CASE("parseSimulation throws on missing file", "[serial][xml_parser]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	core::World world;
 	std::mt19937 seeder(42);
 

--- a/packages/libfers/tests/serial/test_xml_parser_utils.cpp
+++ b/packages/libfers/tests/serial/test_xml_parser_utils.cpp
@@ -41,7 +41,7 @@ namespace
 	{
 		std::ostringstream buffer;
 		std::streambuf* old{nullptr};
-		CerrCapture() { old = std::cerr.rdbuf(buffer.rdbuf()); }
+		CerrCapture() : old(std::cerr.rdbuf(buffer.rdbuf())) {}
 		CerrCapture(const CerrCapture&) = delete;
 		CerrCapture& operator=(const CerrCapture&) = delete;
 		CerrCapture(CerrCapture&&) = delete;

--- a/packages/libfers/tests/serial/test_xml_parser_utils.cpp
+++ b/packages/libfers/tests/serial/test_xml_parser_utils.cpp
@@ -89,8 +89,8 @@ TEST_CASE("get_child_real_type extracts floating point values", "[serial][xml_pa
 
 TEST_CASE("get_attribute_bool extracts boolean values safely", "[serial][xml_parser_utils]")
 {
-	LogLevelGuard log_level(logging::Level::WARNING);
-	CerrCapture capture;
+	LogLevelGuard const log_level(logging::Level::WARNING);
+	CerrCapture const capture;
 	auto doc = loadXml("<root flag_true=\"true\" flag_false=\"false\" flag_invalid=\"yes\"/>");
 	auto root = doc.getRootElement();
 
@@ -104,7 +104,7 @@ TEST_CASE("get_attribute_bool extracts boolean values safely", "[serial][xml_par
 TEST_CASE("resolve_reference_id maps string names to SimIds", "[serial][xml_parser_utils]")
 {
 	auto doc = loadXml("<root ref=\"target_a\"/>");
-	std::unordered_map<std::string, SimId> map = {{"target_a", 42}, {"target_b", 99}};
+	std::unordered_map<std::string, SimId> const map = {{"target_a", 42}, {"target_b", 99}};
 
 	REQUIRE(serial::xml_parser_utils::resolve_reference_id(doc.getRootElement(), "ref", "owner", map) == 42);
 	REQUIRE_THROWS_AS(serial::xml_parser_utils::resolve_reference_id(doc.getRootElement(), "missing", "owner", map),
@@ -117,7 +117,7 @@ TEST_CASE("resolve_reference_id maps string names to SimIds", "[serial][xml_pars
 
 TEST_CASE("parseSchedule handles valid and invalid periods", "[serial][xml_parser_utils]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setTime(0.0, 10.0);
 
 	auto doc = loadXml("<parent>"
@@ -136,7 +136,7 @@ TEST_CASE("parseSchedule handles valid and invalid periods", "[serial][xml_parse
 
 TEST_CASE("parseParameters extracts simulation parameters", "[serial][xml_parser_utils]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 
 	SECTION("Full parameters with UTM South")
 	{
@@ -208,8 +208,8 @@ TEST_CASE("parseParameters extracts simulation parameters", "[serial][xml_parser
 
 	SECTION("Missing optional parameters use defaults without warnings")
 	{
-		LogLevelGuard log_level(logging::Level::WARNING);
-		CerrCapture capture;
+		LogLevelGuard const log_level(logging::Level::WARNING);
+		CerrCapture const capture;
 		auto doc = loadXml("<parameters>"
 						   "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
 						   "</parameters>");
@@ -226,8 +226,8 @@ TEST_CASE("parseParameters extracts simulation parameters", "[serial][xml_parser
 
 	SECTION("Origin altitude defaults to zero when omitted")
 	{
-		LogLevelGuard log_level(logging::Level::WARNING);
-		CerrCapture capture;
+		LogLevelGuard const log_level(logging::Level::WARNING);
+		CerrCapture const capture;
 		auto doc = loadXml("<parameters>"
 						   "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
 						   "  <origin latitude=\"-33.0\" longitude=\"18.0\"/>"
@@ -312,7 +312,7 @@ TEST_CASE("parseParameters extracts simulation parameters", "[serial][xml_parser
 
 TEST_CASE("parseParameters throws on invalid UTM zones", "[serial][xml_parser_utils]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	auto doc = loadXml("<parameters>"
 					   "  <starttime>0</starttime>"
 					   "  <endtime>1</endtime>"
@@ -359,9 +359,9 @@ TEST_CASE("parseWaveform handles CW and delegates file loading", "[serial][xml_p
 
 TEST_CASE("parseWaveform warns for large FMCW streaming allocation", "[serial][xml_parser_utils]")
 {
-	ParamGuard guard;
-	LogLevelGuard log_level(logging::Level::WARNING);
-	CerrCapture capture;
+	ParamGuard const guard;
+	LogLevelGuard const log_level(logging::Level::WARNING);
+	CerrCapture const capture;
 
 	params::setRate(1.0e9);
 	params::setOversampleRatio(1);
@@ -393,7 +393,7 @@ TEST_CASE("parseWaveform warns for large FMCW streaming allocation", "[serial][x
 
 TEST_CASE("parseWaveform validates FMCW chirp schema constraints", "[serial][xml_parser_utils][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(2.0e6);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 1.0);
@@ -554,8 +554,8 @@ TEST_CASE("parseTiming extracts clock parameters and noise entries", "[serial][x
 
 TEST_CASE("parseTiming accepts omitted defaults without warnings", "[serial][xml_parser_utils]")
 {
-	LogLevelGuard log_level(logging::Level::WARNING);
-	CerrCapture capture;
+	LogLevelGuard const log_level(logging::Level::WARNING);
+	CerrCapture const capture;
 	core::World world;
 	serial::xml_parser_utils::ParserContext ctx;
 	ctx.world = &world;
@@ -651,8 +651,8 @@ TEST_CASE("parseAntenna instantiates correct antenna types", "[serial][xml_parse
 
 TEST_CASE("parseAntenna accepts omitted efficiency without warnings", "[serial][xml_parser_utils]")
 {
-	LogLevelGuard log_level(logging::Level::WARNING);
-	CerrCapture capture;
+	LogLevelGuard const log_level(logging::Level::WARNING);
+	CerrCapture const capture;
 	core::World world;
 	serial::xml_parser_utils::ParserContext ctx;
 	ctx.world = &world;
@@ -702,8 +702,8 @@ TEST_CASE("parseMotionPath handles all interpolation types", "[serial][xml_parse
 
 	SECTION("Missing interpolation defaults to static without warnings")
 	{
-		LogLevelGuard log_level(logging::Level::WARNING);
-		CerrCapture capture;
+		LogLevelGuard const log_level(logging::Level::WARNING);
+		CerrCapture const capture;
 		auto doc = loadXml("<motionpath>"
 						   "  <positionwaypoint><x>1</x><y>2</y><altitude>3</altitude><time>0</time></positionwaypoint>"
 						   "</motionpath>");
@@ -775,8 +775,8 @@ TEST_CASE("parseFixedRotation sets constant rate rotation", "[serial][xml_parser
 
 TEST_CASE("parseRotationPath warns when values look like the opposite unit", "[serial][xml_parser_utils]")
 {
-	LogLevelGuard log_guard(logging::Level::WARNING);
-	CerrCapture capture;
+	LogLevelGuard const log_guard(logging::Level::WARNING);
+	CerrCapture const capture;
 	radar::Platform platform("warning-platform", 77);
 	auto doc =
 		loadXml("<rotationpath interpolation=\"static\">"
@@ -792,7 +792,7 @@ TEST_CASE("parseRotationPath warns when values look like the opposite unit", "[s
 
 TEST_CASE("parseTransmitter resolves references and builds object with schedule", "[serial][xml_parser_utils]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(10000.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 10.0);
@@ -814,10 +814,10 @@ TEST_CASE("parseTransmitter resolves references and builds object with schedule"
 	world.add(std::move(ant));
 	world.add(std::move(tim));
 
-	std::unordered_map<std::string, SimId> w_refs = {{"w1", 10}};
-	std::unordered_map<std::string, SimId> a_refs = {{"a1", 20}};
-	std::unordered_map<std::string, SimId> t_refs = {{"t1", 30}};
-	serial::xml_parser_utils::ReferenceLookup refs{&w_refs, &a_refs, &t_refs};
+	std::unordered_map<std::string, SimId> const w_refs = {{"w1", 10}};
+	std::unordered_map<std::string, SimId> const a_refs = {{"a1", 20}};
+	std::unordered_map<std::string, SimId> const t_refs = {{"t1", 30}};
+	serial::xml_parser_utils::ReferenceLookup const refs{&w_refs, &a_refs, &t_refs};
 
 	radar::Platform platform("plat");
 
@@ -837,7 +837,7 @@ TEST_CASE("parseTransmitter resolves references and builds object with schedule"
 
 TEST_CASE("parseTransmitter rejects FMCW waveform and mode mismatches", "[serial][xml_parser_utils][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(2.0e6);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 10.0);
@@ -855,10 +855,10 @@ TEST_CASE("parseTransmitter rejects FMCW waveform and mode mismatches", "[serial
 	timing_proto->setFrequency(1e6);
 	world.add(std::move(timing_proto));
 
-	std::unordered_map<std::string, SimId> w_refs = {{"fmcw_wave", 10}};
-	std::unordered_map<std::string, SimId> a_refs = {{"a1", 20}};
-	std::unordered_map<std::string, SimId> t_refs = {{"t1", 30}};
-	serial::xml_parser_utils::ReferenceLookup refs{&w_refs, &a_refs, &t_refs};
+	std::unordered_map<std::string, SimId> const w_refs = {{"fmcw_wave", 10}};
+	std::unordered_map<std::string, SimId> const a_refs = {{"a1", 20}};
+	std::unordered_map<std::string, SimId> const t_refs = {{"t1", 30}};
+	serial::xml_parser_utils::ReferenceLookup const refs{&w_refs, &a_refs, &t_refs};
 
 	radar::Platform platform("plat");
 
@@ -886,7 +886,7 @@ TEST_CASE("parseTransmitter rejects FMCW waveform and mode mismatches", "[serial
 
 TEST_CASE("parseTransmitter validates FMCW schedule duration against chirp timing", "[serial][xml_parser_utils][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(2.0e6);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 10.0);
@@ -904,10 +904,10 @@ TEST_CASE("parseTransmitter validates FMCW schedule duration against chirp timin
 	timing_proto->setFrequency(1e6);
 	world.add(std::move(timing_proto));
 
-	std::unordered_map<std::string, SimId> w_refs = {{"fmcw_wave", 10}};
-	std::unordered_map<std::string, SimId> a_refs = {{"a1", 20}};
-	std::unordered_map<std::string, SimId> t_refs = {{"t1", 30}};
-	serial::xml_parser_utils::ReferenceLookup refs{&w_refs, &a_refs, &t_refs};
+	std::unordered_map<std::string, SimId> const w_refs = {{"fmcw_wave", 10}};
+	std::unordered_map<std::string, SimId> const a_refs = {{"a1", 20}};
+	std::unordered_map<std::string, SimId> const t_refs = {{"t1", 30}};
+	serial::xml_parser_utils::ReferenceLookup const refs{&w_refs, &a_refs, &t_refs};
 
 	radar::Platform platform("plat");
 
@@ -924,8 +924,8 @@ TEST_CASE("parseTransmitter validates FMCW schedule duration against chirp timin
 
 	SECTION("period shorter than T_rep but at least T_c only warns")
 	{
-		LogLevelGuard log_level(logging::Level::WARNING);
-		CerrCapture capture;
+		LogLevelGuard const log_level(logging::Level::WARNING);
+		CerrCapture const capture;
 		auto doc = loadXml("<transmitter name=\"tx_short_trep\" waveform=\"fmcw_wave\" antenna=\"a1\" timing=\"t1\">"
 						   "  <fmcw_mode/>"
 						   "  <schedule><period start=\"0.1\" end=\"0.1015\"/></schedule>"
@@ -939,7 +939,7 @@ TEST_CASE("parseTransmitter validates FMCW schedule duration against chirp timin
 
 TEST_CASE("parseReceiver resolves references and builds object with flags and schedule", "[serial][xml_parser_utils]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(10000.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 10.0);
@@ -956,10 +956,10 @@ TEST_CASE("parseReceiver resolves references and builds object with flags and sc
 	world.add(std::move(ant));
 	world.add(std::move(tim));
 
-	std::unordered_map<std::string, SimId> w_refs;
-	std::unordered_map<std::string, SimId> a_refs = {{"a1", 20}};
-	std::unordered_map<std::string, SimId> t_refs = {{"t1", 30}};
-	serial::xml_parser_utils::ReferenceLookup refs{&w_refs, &a_refs, &t_refs};
+	std::unordered_map<std::string, SimId> const w_refs;
+	std::unordered_map<std::string, SimId> const a_refs = {{"a1", 20}};
+	std::unordered_map<std::string, SimId> const t_refs = {{"t1", 30}};
+	serial::xml_parser_utils::ReferenceLookup const refs{&w_refs, &a_refs, &t_refs};
 
 	radar::Platform platform("plat");
 
@@ -989,8 +989,8 @@ TEST_CASE("parseReceiver resolves references and builds object with flags and sc
 
 	SECTION("Missing receiver defaults do not warn")
 	{
-		LogLevelGuard log_level(logging::Level::WARNING);
-		CerrCapture capture;
+		LogLevelGuard const log_level(logging::Level::WARNING);
+		CerrCapture const capture;
 		auto doc = loadXml("<receiver name=\"rx_defaults\" antenna=\"a1\" timing=\"t1\">"
 						   "  <cw_mode/>"
 						   "</receiver>");
@@ -1103,7 +1103,7 @@ TEST_CASE("parseReceiver resolves references and builds object with flags and sc
 
 TEST_CASE("parseMonostatic reuses one shared timing instance for a common timing id", "[serial][xml_parser_utils]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(10000.0);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 10.0);
@@ -1121,10 +1121,10 @@ TEST_CASE("parseMonostatic reuses one shared timing instance for a common timing
 	timing_proto->setFrequency(1e6);
 	world.add(std::move(timing_proto));
 
-	std::unordered_map<std::string, SimId> w_refs = {{"w1", 10}};
-	std::unordered_map<std::string, SimId> a_refs = {{"a1", 20}};
-	std::unordered_map<std::string, SimId> t_refs = {{"t1", 30}};
-	serial::xml_parser_utils::ReferenceLookup refs{&w_refs, &a_refs, &t_refs};
+	std::unordered_map<std::string, SimId> const w_refs = {{"w1", 10}};
+	std::unordered_map<std::string, SimId> const a_refs = {{"a1", 20}};
+	std::unordered_map<std::string, SimId> const t_refs = {{"t1", 30}};
+	serial::xml_parser_utils::ReferenceLookup const refs{&w_refs, &a_refs, &t_refs};
 
 	radar::Platform platform("plat");
 
@@ -1142,7 +1142,7 @@ TEST_CASE("parseMonostatic reuses one shared timing instance for a common timing
 TEST_CASE("parseMonostatic derives FMCW mode from the monostatic block without receiver override",
 		  "[serial][xml_parser_utils][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(2.0e6);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 10.0);
@@ -1160,10 +1160,10 @@ TEST_CASE("parseMonostatic derives FMCW mode from the monostatic block without r
 	timing_proto->setFrequency(1e6);
 	world.add(std::move(timing_proto));
 
-	std::unordered_map<std::string, SimId> w_refs = {{"w1", 10}};
-	std::unordered_map<std::string, SimId> a_refs = {{"a1", 20}};
-	std::unordered_map<std::string, SimId> t_refs = {{"t1", 30}};
-	serial::xml_parser_utils::ReferenceLookup refs{&w_refs, &a_refs, &t_refs};
+	std::unordered_map<std::string, SimId> const w_refs = {{"w1", 10}};
+	std::unordered_map<std::string, SimId> const a_refs = {{"a1", 20}};
+	std::unordered_map<std::string, SimId> const t_refs = {{"t1", 30}};
+	serial::xml_parser_utils::ReferenceLookup const refs{&w_refs, &a_refs, &t_refs};
 
 	radar::Platform platform("plat");
 
@@ -1212,10 +1212,10 @@ TEST_CASE("parsePlatform prefers rotationpath over fixedrotation and supports fi
 	serial::xml_parser_utils::ParserContext ctx;
 	ctx.world = &world;
 
-	std::unordered_map<std::string, SimId> w_refs;
-	std::unordered_map<std::string, SimId> a_refs;
-	std::unordered_map<std::string, SimId> t_refs;
-	serial::xml_parser_utils::ReferenceLookup refs{&w_refs, &a_refs, &t_refs};
+	std::unordered_map<std::string, SimId> const w_refs;
+	std::unordered_map<std::string, SimId> const a_refs;
+	std::unordered_map<std::string, SimId> const t_refs;
+	serial::xml_parser_utils::ReferenceLookup const refs{&w_refs, &a_refs, &t_refs};
 
 	auto register_name = [](const XmlElement&, std::string_view) {};
 

--- a/packages/libfers/tests/serial/test_xml_parser_utils.cpp
+++ b/packages/libfers/tests/serial/test_xml_parser_utils.cpp
@@ -30,6 +30,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 
@@ -38,6 +42,10 @@ namespace
 		std::ostringstream buffer;
 		std::streambuf* old{nullptr};
 		CerrCapture() { old = std::cerr.rdbuf(buffer.rdbuf()); }
+		CerrCapture(const CerrCapture&) = delete;
+		CerrCapture& operator=(const CerrCapture&) = delete;
+		CerrCapture(CerrCapture&&) = delete;
+		CerrCapture& operator=(CerrCapture&&) = delete;
 		~CerrCapture() { std::cerr.rdbuf(old); }
 		[[nodiscard]] std::string str() const { return buffer.str(); }
 	};
@@ -45,6 +53,10 @@ namespace
 	struct LogLevelGuard
 	{
 		explicit LogLevelGuard(const logging::Level level) { logging::logger.setLevel(level); }
+		LogLevelGuard(const LogLevelGuard&) = delete;
+		LogLevelGuard& operator=(const LogLevelGuard&) = delete;
+		LogLevelGuard(LogLevelGuard&&) = delete;
+		LogLevelGuard& operator=(LogLevelGuard&&) = delete;
 		~LogLevelGuard() { logging::logger.setLevel(logging::Level::INFO); }
 	};
 

--- a/packages/libfers/tests/serial/test_xml_parser_utils.cpp
+++ b/packages/libfers/tests/serial/test_xml_parser_utils.cpp
@@ -85,6 +85,21 @@ namespace
 		{ return radar::createIsoTarget(platform, name, 1.0, seed, id); };
 		return loaders;
 	}
+
+	[[nodiscard]] params::Parameters parseParametersXml(const std::string& xml)
+	{
+		auto doc = loadXml(xml);
+		params::Parameters parameters;
+		serial::xml_parser_utils::parseParameters(doc.getRootElement(), parameters);
+		return parameters;
+	}
+
+	void parseInvalidParametersXml(const std::string& xml)
+	{
+		auto doc = loadXml(xml);
+		params::Parameters parameters;
+		serial::xml_parser_utils::parseParameters(doc.getRootElement(), parameters);
+	}
 }
 
 TEST_CASE("get_child_real_type extracts floating point values", "[serial][xml_parser_utils]")
@@ -146,180 +161,155 @@ TEST_CASE("parseSchedule handles valid and invalid periods", "[serial][xml_parse
 	REQUIRE_THAT(periods[0].end, WithinAbs(2.0, 1e-5));
 }
 
-TEST_CASE("parseParameters extracts simulation parameters", "[serial][xml_parser_utils]")
+TEST_CASE("parseParameters extracts full UTM south parameters", "[serial][xml_parser_utils]")
 {
 	ParamGuard const guard;
+	const auto p = parseParametersXml("<parameters>"
+									  "  <starttime>1.5</starttime>"
+									  "  <endtime>10.0</endtime>"
+									  "  <rate>2000</rate>"
+									  "  <c>3e8</c>"
+									  "  <adc_bits>12</adc_bits>"
+									  "  <oversample>4</oversample>"
+									  "  <origin latitude=\"-33.0\" longitude=\"18.0\" altitude=\"100.0\"/>"
+									  "  <coordinatesystem frame=\"UTM\" zone=\"34\" hemisphere=\"S\"/>"
+									  "</parameters>");
 
-	SECTION("Full parameters with UTM South")
-	{
-		auto doc = loadXml("<parameters>"
-						   "  <starttime>1.5</starttime>"
-						   "  <endtime>10.0</endtime>"
-						   "  <rate>2000</rate>"
-						   "  <c>3e8</c>"
-						   "  <adc_bits>12</adc_bits>"
-						   "  <oversample>4</oversample>"
-						   "  <origin latitude=\"-33.0\" longitude=\"18.0\" altitude=\"100.0\"/>"
-						   "  <coordinatesystem frame=\"UTM\" zone=\"34\" hemisphere=\"S\"/>"
-						   "</parameters>");
+	REQUIRE_THAT(p.start, WithinAbs(1.5, 1e-5));
+	REQUIRE_THAT(p.end, WithinAbs(10.0, 1e-5));
+	REQUIRE_THAT(p.rate, WithinAbs(2000.0, 1e-5));
+	REQUIRE_THAT(p.c, WithinAbs(3e8, 1e-5));
+	REQUIRE(p.adc_bits == 12);
+	REQUIRE(p.oversample_ratio == 4);
+	REQUIRE_THAT(p.origin_latitude, WithinAbs(-33.0, 1e-5));
+	REQUIRE_THAT(p.origin_longitude, WithinAbs(18.0, 1e-5));
+	REQUIRE_THAT(p.origin_altitude, WithinAbs(100.0, 1e-5));
+	REQUIRE(p.coordinate_frame == params::CoordinateFrame::UTM);
+	REQUIRE(p.utm_zone == 34);
+	REQUIRE(p.utm_north_hemisphere == false);
+}
 
-		params::Parameters p;
-		serial::xml_parser_utils::parseParameters(doc.getRootElement(), p);
+TEST_CASE("parseParameters extracts optional ECEF parameters", "[serial][xml_parser_utils]")
+{
+	ParamGuard const guard;
+	const auto p = parseParametersXml("<parameters>"
+									  "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
+									  "  <simSamplingRate>500.0</simSamplingRate>"
+									  "  <randomseed>42</randomseed>"
+									  "  <rotationangleunit>rad</rotationangleunit>"
+									  "  <coordinatesystem frame=\"ECEF\"/>"
+									  "</parameters>");
 
-		REQUIRE_THAT(p.start, WithinAbs(1.5, 1e-5));
-		REQUIRE_THAT(p.end, WithinAbs(10.0, 1e-5));
-		REQUIRE_THAT(p.rate, WithinAbs(2000.0, 1e-5));
-		REQUIRE_THAT(p.c, WithinAbs(3e8, 1e-5));
-		REQUIRE(p.adc_bits == 12);
-		REQUIRE(p.oversample_ratio == 4);
-		REQUIRE_THAT(p.origin_latitude, WithinAbs(-33.0, 1e-5));
-		REQUIRE_THAT(p.origin_longitude, WithinAbs(18.0, 1e-5));
-		REQUIRE_THAT(p.origin_altitude, WithinAbs(100.0, 1e-5));
-		REQUIRE(p.coordinate_frame == params::CoordinateFrame::UTM);
-		REQUIRE(p.utm_zone == 34);
-		REQUIRE(p.utm_north_hemisphere == false);
-	}
+	REQUIRE_THAT(p.sim_sampling_rate, WithinAbs(500.0, 1e-5));
+	REQUIRE(p.random_seed.has_value());
+	REQUIRE(p.random_seed.value_or(0) == 42);
+	REQUIRE(p.rotation_angle_unit == params::RotationAngleUnit::Radians);
+	REQUIRE(p.coordinate_frame == params::CoordinateFrame::ECEF);
+}
 
-	SECTION("Optional parameters (simSamplingRate, randomseed) and ECEF")
-	{
-		auto doc = loadXml("<parameters>"
-						   "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
-						   "  <simSamplingRate>500.0</simSamplingRate>"
-						   "  <randomseed>42</randomseed>"
-						   "  <rotationangleunit>rad</rotationangleunit>"
-						   "  <coordinatesystem frame=\"ECEF\"/>"
-						   "</parameters>");
+TEST_CASE("parseParameters floors positive fractional unsigned optional values", "[serial][xml_parser_utils]")
+{
+	ParamGuard const guard;
+	const auto p = parseParametersXml("<parameters>"
+									  "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
+									  "  <randomseed>42.9</randomseed>"
+									  "  <adc_bits>12.8</adc_bits>"
+									  "  <oversample>4.2</oversample>"
+									  "</parameters>");
 
-		params::Parameters p;
-		serial::xml_parser_utils::parseParameters(doc.getRootElement(), p);
+	REQUIRE(p.random_seed.has_value());
+	REQUIRE(p.random_seed.value_or(0) == 42);
+	REQUIRE(p.adc_bits == 12);
+	REQUIRE(p.oversample_ratio == 4);
+}
 
-		REQUIRE_THAT(p.sim_sampling_rate, WithinAbs(500.0, 1e-5));
-		REQUIRE(p.random_seed.has_value());
-		REQUIRE(p.random_seed.value_or(0) == 42);
-		REQUIRE(p.rotation_angle_unit == params::RotationAngleUnit::Radians);
-		REQUIRE(p.coordinate_frame == params::CoordinateFrame::ECEF);
-	}
+TEST_CASE("parseParameters uses defaults without warnings for omitted optional parameters",
+		  "[serial][xml_parser_utils]")
+{
+	ParamGuard const guard;
+	LogLevelGuard const log_level(logging::Level::WARNING);
+	CerrCapture const capture;
+	const auto p = parseParametersXml("<parameters>"
+									  "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
+									  "</parameters>");
 
-	SECTION("Unsigned optional parameters floor positive fractional values")
-	{
-		auto doc = loadXml("<parameters>"
-						   "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
-						   "  <randomseed>42.9</randomseed>"
-						   "  <adc_bits>12.8</adc_bits>"
-						   "  <oversample>4.2</oversample>"
-						   "</parameters>");
+	REQUIRE_THAT(p.c, WithinAbs(params::Parameters::DEFAULT_C, 1e-5));
+	REQUIRE_THAT(p.sim_sampling_rate, WithinAbs(1000.0, 1e-5));
+	REQUIRE(p.adc_bits == 0);
+	REQUIRE(p.oversample_ratio == 1);
+	REQUIRE(capture.str().empty());
+}
 
-		params::Parameters p;
-		serial::xml_parser_utils::parseParameters(doc.getRootElement(), p);
+TEST_CASE("parseParameters defaults omitted origin altitude to zero", "[serial][xml_parser_utils]")
+{
+	ParamGuard const guard;
+	LogLevelGuard const log_level(logging::Level::WARNING);
+	CerrCapture const capture;
+	const auto p = parseParametersXml("<parameters>"
+									  "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
+									  "  <origin latitude=\"-33.0\" longitude=\"18.0\"/>"
+									  "  <coordinatesystem frame=\"ENU\"/>"
+									  "</parameters>");
 
-		REQUIRE(p.random_seed.has_value());
-		REQUIRE(p.random_seed.value_or(0) == 42);
-		REQUIRE(p.adc_bits == 12);
-		REQUIRE(p.oversample_ratio == 4);
-	}
+	REQUIRE_THAT(p.origin_latitude, WithinAbs(-33.0, 1e-5));
+	REQUIRE_THAT(p.origin_longitude, WithinAbs(18.0, 1e-5));
+	REQUIRE_THAT(p.origin_altitude, WithinAbs(0.0, 1e-5));
+	REQUIRE(capture.str().empty());
+}
 
-	SECTION("Missing optional parameters use defaults without warnings")
-	{
-		LogLevelGuard const log_level(logging::Level::WARNING);
-		CerrCapture const capture;
-		auto doc = loadXml("<parameters>"
-						   "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
-						   "</parameters>");
+TEST_CASE("parseParameters rejects invalid unsigned optional values", "[serial][xml_parser_utils]")
+{
+	ParamGuard const guard;
+	const auto too_large_unsigned =
+		std::to_string(static_cast<unsigned long long>(std::numeric_limits<unsigned>::max()) + 1ULL);
 
-		params::Parameters p;
-		serial::xml_parser_utils::parseParameters(doc.getRootElement(), p);
+	REQUIRE_THROWS_AS(parseInvalidParametersXml("<parameters>"
+												"  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
+												"  <randomseed>-1</randomseed>"
+												"</parameters>"),
+					  XmlException);
+	REQUIRE_THROWS_AS(parseInvalidParametersXml("<parameters>"
+												"  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
+												"  <adc_bits>nan</adc_bits>"
+												"</parameters>"),
+					  XmlException);
+	REQUIRE_THROWS_AS(parseInvalidParametersXml("<parameters>"
+												"  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
+												"  <oversample>0</oversample>"
+												"</parameters>"),
+					  std::runtime_error);
+	REQUIRE_THROWS_WITH(parseInvalidParametersXml("<parameters>"
+												  "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
+												  "  <oversample>9</oversample>"
+												  "</parameters>"),
+						ContainsSubstring("Oversampling ratios > 8 are not supported"));
+	REQUIRE_THROWS_AS(parseInvalidParametersXml(std::string("<parameters>") +
+												"  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>" +
+												"  <adc_bits>" + too_large_unsigned + "</adc_bits>" + "</parameters>"),
+					  XmlException);
+}
 
-		REQUIRE_THAT(p.c, WithinAbs(params::Parameters::DEFAULT_C, 1e-5));
-		REQUIRE_THAT(p.sim_sampling_rate, WithinAbs(1000.0, 1e-5));
-		REQUIRE(p.adc_bits == 0);
-		REQUIRE(p.oversample_ratio == 1);
-		REQUIRE(capture.str().empty());
-	}
+TEST_CASE("parseParameters handles UTM north hemisphere", "[serial][xml_parser_utils]")
+{
+	ParamGuard const guard;
+	const auto p = parseParametersXml("<parameters>"
+									  "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
+									  "  <coordinatesystem frame=\"UTM\" zone=\"34\" hemisphere=\"N\"/>"
+									  "</parameters>");
 
-	SECTION("Origin altitude defaults to zero when omitted")
-	{
-		LogLevelGuard const log_level(logging::Level::WARNING);
-		CerrCapture const capture;
-		auto doc = loadXml("<parameters>"
-						   "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
-						   "  <origin latitude=\"-33.0\" longitude=\"18.0\"/>"
-						   "  <coordinatesystem frame=\"ENU\"/>"
-						   "</parameters>");
+	REQUIRE(p.coordinate_frame == params::CoordinateFrame::UTM);
+	REQUIRE(p.utm_north_hemisphere == true);
+}
 
-		params::Parameters p;
-		serial::xml_parser_utils::parseParameters(doc.getRootElement(), p);
+TEST_CASE("parseParameters accepts ENU without origin", "[serial][xml_parser_utils]")
+{
+	ParamGuard const guard;
+	const auto p = parseParametersXml("<parameters>"
+									  "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
+									  "  <coordinatesystem frame=\"ENU\"/>"
+									  "</parameters>");
 
-		REQUIRE_THAT(p.origin_latitude, WithinAbs(-33.0, 1e-5));
-		REQUIRE_THAT(p.origin_longitude, WithinAbs(18.0, 1e-5));
-		REQUIRE_THAT(p.origin_altitude, WithinAbs(0.0, 1e-5));
-		REQUIRE(capture.str().empty());
-	}
-
-	SECTION("Unsigned optional parameters reject invalid values")
-	{
-		const auto parse_invalid = [](const std::string& xml)
-		{
-			params::Parameters p;
-			auto doc = loadXml(xml);
-			serial::xml_parser_utils::parseParameters(doc.getRootElement(), p);
-		};
-		const auto too_large_unsigned =
-			std::to_string(static_cast<unsigned long long>(std::numeric_limits<unsigned>::max()) + 1ULL);
-
-		REQUIRE_THROWS_AS(parse_invalid("<parameters>"
-										"  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
-										"  <randomseed>-1</randomseed>"
-										"</parameters>"),
-						  XmlException);
-
-		REQUIRE_THROWS_AS(parse_invalid("<parameters>"
-										"  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
-										"  <adc_bits>nan</adc_bits>"
-										"</parameters>"),
-						  XmlException);
-
-		REQUIRE_THROWS_AS(parse_invalid("<parameters>"
-										"  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
-										"  <oversample>0</oversample>"
-										"</parameters>"),
-						  std::runtime_error);
-
-		REQUIRE_THROWS_WITH(parse_invalid("<parameters>"
-										  "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
-										  "  <oversample>9</oversample>"
-										  "</parameters>"),
-							ContainsSubstring("Oversampling ratios > 8 are not supported"));
-
-		REQUIRE_THROWS_AS(parse_invalid(std::string("<parameters>") +
-										"  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>" +
-										"  <adc_bits>" + too_large_unsigned + "</adc_bits>" + "</parameters>"),
-						  XmlException);
-	}
-
-	SECTION("UTM North Hemisphere")
-	{
-		auto doc = loadXml("<parameters>"
-						   "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
-						   "  <coordinatesystem frame=\"UTM\" zone=\"34\" hemisphere=\"N\"/>"
-						   "</parameters>");
-
-		params::Parameters p;
-		serial::xml_parser_utils::parseParameters(doc.getRootElement(), p);
-		REQUIRE(p.coordinate_frame == params::CoordinateFrame::UTM);
-		REQUIRE(p.utm_north_hemisphere == true);
-	}
-
-	SECTION("ENU without origin logs warning but succeeds")
-	{
-		auto doc = loadXml("<parameters>"
-						   "  <starttime>0</starttime><endtime>1</endtime><rate>1000</rate>"
-						   "  <coordinatesystem frame=\"ENU\"/>"
-						   "</parameters>");
-
-		params::Parameters p;
-		serial::xml_parser_utils::parseParameters(doc.getRootElement(), p);
-		REQUIRE(p.coordinate_frame == params::CoordinateFrame::ENU);
-	}
+	REQUIRE(p.coordinate_frame == params::CoordinateFrame::ENU);
 }
 
 TEST_CASE("parseParameters throws on invalid UTM zones", "[serial][xml_parser_utils]")
@@ -1219,7 +1209,7 @@ TEST_CASE("parseTarget handles chisquare model", "[serial][xml_parser_utils]")
 	REQUIRE_THAT(model->getK(), WithinAbs(2.0, 1e-5));
 }
 
-TEST_CASE("parsePlatform prefers rotationpath over fixedrotation and supports fixed-only", "[serial][xml_parser_utils]")
+TEST_CASE("parsePlatform prefers rotationpath over fixedrotation", "[serial][xml_parser_utils]")
 {
 	core::World world;
 	serial::xml_parser_utils::ParserContext ctx;
@@ -1229,50 +1219,52 @@ TEST_CASE("parsePlatform prefers rotationpath over fixedrotation and supports fi
 	std::unordered_map<std::string, SimId> const a_refs;
 	std::unordered_map<std::string, SimId> const t_refs;
 	serial::xml_parser_utils::ReferenceLookup const refs{&w_refs, &a_refs, &t_refs};
-
 	auto register_name = [](const XmlElement&, std::string_view) {};
+	auto doc =
+		loadXml("<platform name=\"plat_both\">"
+				"  <rotationpath interpolation=\"linear\">"
+				"    <rotationwaypoint><azimuth>0</azimuth><elevation>0</elevation><time>0</time></rotationwaypoint>"
+				"    <rotationwaypoint><azimuth>90</azimuth><elevation>0</elevation><time>1</time></rotationwaypoint>"
+				"  </rotationpath>"
+				"  <fixedrotation>"
+				"    <startazimuth>90</startazimuth><startelevation>0</startelevation>"
+				"    <azimuthrate>10</azimuthrate><elevationrate>0</elevationrate>"
+				"  </fixedrotation>"
+				"</platform>");
 
-	SECTION("Both rotationpath and fixedrotation: rotationpath is used")
-	{
-		auto doc = loadXml(
-			"<platform name=\"plat_both\">"
-			"  <rotationpath interpolation=\"linear\">"
-			"    <rotationwaypoint><azimuth>0</azimuth><elevation>0</elevation><time>0</time></rotationwaypoint>"
-			"    <rotationwaypoint><azimuth>90</azimuth><elevation>0</elevation><time>1</time></rotationwaypoint>"
-			"  </rotationpath>"
-			"  <fixedrotation>"
-			"    <startazimuth>90</startazimuth><startelevation>0</startelevation>"
-			"    <azimuthrate>10</azimuthrate><elevationrate>0</elevationrate>"
-			"  </fixedrotation>"
-			"</platform>");
+	serial::xml_parser_utils::parsePlatform(doc.getRootElement(), ctx, register_name, refs);
 
-		serial::xml_parser_utils::parsePlatform(doc.getRootElement(), ctx, register_name, refs);
+	REQUIRE(world.getPlatforms().size() == 1);
+	auto* plat = world.getPlatforms().front().get();
+	REQUIRE(plat->getRotationPath()->getType() == math::RotationPath::InterpType::INTERP_LINEAR);
+	REQUIRE_THAT(plat->getRotation(1.0).azimuth, WithinAbs(0.0, 1e-5));
+}
 
-		REQUIRE(world.getPlatforms().size() == 1);
-		auto* plat = world.getPlatforms().front().get();
-		REQUIRE(plat->getRotationPath()->getType() == math::RotationPath::InterpType::INTERP_LINEAR);
-		REQUIRE_THAT(plat->getRotation(1.0).azimuth, WithinAbs(0.0, 1e-5));
-	}
+TEST_CASE("parsePlatform supports fixedrotation without rotationpath", "[serial][xml_parser_utils]")
+{
+	core::World world;
+	serial::xml_parser_utils::ParserContext ctx;
+	ctx.world = &world;
 
-	SECTION("Only fixedrotation: constant-rate rotation is used")
-	{
-		world.clear();
+	std::unordered_map<std::string, SimId> const w_refs;
+	std::unordered_map<std::string, SimId> const a_refs;
+	std::unordered_map<std::string, SimId> const t_refs;
+	serial::xml_parser_utils::ReferenceLookup const refs{&w_refs, &a_refs, &t_refs};
+	auto register_name = [](const XmlElement&, std::string_view) {};
+	auto doc = loadXml("<platform name=\"plat_fixed\">"
+					   "  <fixedrotation>"
+					   "    <startazimuth>90</startazimuth><startelevation>0</startelevation>"
+					   "    <azimuthrate>10</azimuthrate><elevationrate>5</elevationrate>"
+					   "  </fixedrotation>"
+					   "</platform>");
 
-		auto doc = loadXml("<platform name=\"plat_fixed\">"
-						   "  <fixedrotation>"
-						   "    <startazimuth>90</startazimuth><startelevation>0</startelevation>"
-						   "    <azimuthrate>10</azimuthrate><elevationrate>5</elevationrate>"
-						   "  </fixedrotation>"
-						   "</platform>");
+	serial::xml_parser_utils::parsePlatform(doc.getRootElement(), ctx, register_name, refs);
 
-		serial::xml_parser_utils::parsePlatform(doc.getRootElement(), ctx, register_name, refs);
-
-		REQUIRE(world.getPlatforms().size() == 1);
-		auto* plat = world.getPlatforms().front().get();
-		REQUIRE(plat->getRotationPath()->getType() == math::RotationPath::InterpType::INTERP_CONSTANT);
-		REQUIRE_THAT(plat->getRotation(1.0).azimuth, WithinAbs(-10.0 * PI / 180.0, 1e-5));
-		REQUIRE_THAT(plat->getRotation(1.0).elevation, WithinAbs(5.0 * PI / 180.0, 1e-5));
-	}
+	REQUIRE(world.getPlatforms().size() == 1);
+	auto* plat = world.getPlatforms().front().get();
+	REQUIRE(plat->getRotationPath()->getType() == math::RotationPath::InterpType::INTERP_CONSTANT);
+	REQUIRE_THAT(plat->getRotation(1.0).azimuth, WithinAbs(-10.0 * PI / 180.0, 1e-5));
+	REQUIRE_THAT(plat->getRotation(1.0).elevation, WithinAbs(5.0 * PI / 180.0, 1e-5));
 }
 
 TEST_CASE("collectIncludeElements skips empty and unreadable includes", "[serial][xml_parser_utils]")

--- a/packages/libfers/tests/serial/test_xml_parser_utils.cpp
+++ b/packages/libfers/tests/serial/test_xml_parser_utils.cpp
@@ -1197,7 +1197,7 @@ TEST_CASE("parseTarget handles chisquare model", "[serial][xml_parser_utils]")
 {
 	core::World world;
 	std::mt19937 seeder(42);
-	const unsigned expected_seed = static_cast<unsigned>(seeder());
+	const auto expected_seed = static_cast<unsigned>(seeder());
 	seeder.seed(42);
 	serial::xml_parser_utils::ParserContext ctx;
 	ctx.world = &world;
@@ -1213,7 +1213,7 @@ TEST_CASE("parseTarget handles chisquare model", "[serial][xml_parser_utils]")
 	REQUIRE(world.getTargets().size() == 1);
 
 	auto* tgt = world.getTargets().front().get();
-	auto* model = dynamic_cast<const radar::RcsChiSquare*>(tgt->getFluctuationModel());
+	const auto* model = dynamic_cast<const radar::RcsChiSquare*>(tgt->getFluctuationModel());
 	REQUIRE(model != nullptr);
 	REQUIRE(tgt->getSeed() == expected_seed);
 	REQUIRE_THAT(model->getK(), WithinAbs(2.0, 1e-5));

--- a/packages/libfers/tests/serial/test_xml_parser_utils.cpp
+++ b/packages/libfers/tests/serial/test_xml_parser_utils.cpp
@@ -195,7 +195,7 @@ TEST_CASE("parseParameters extracts simulation parameters", "[serial][xml_parser
 
 		REQUIRE_THAT(p.sim_sampling_rate, WithinAbs(500.0, 1e-5));
 		REQUIRE(p.random_seed.has_value());
-		REQUIRE(p.random_seed.value() == 42);
+		REQUIRE(p.random_seed.value_or(0) == 42);
 		REQUIRE(p.rotation_angle_unit == params::RotationAngleUnit::Radians);
 		REQUIRE(p.coordinate_frame == params::CoordinateFrame::ECEF);
 	}
@@ -213,7 +213,7 @@ TEST_CASE("parseParameters extracts simulation parameters", "[serial][xml_parser
 		serial::xml_parser_utils::parseParameters(doc.getRootElement(), p);
 
 		REQUIRE(p.random_seed.has_value());
-		REQUIRE(p.random_seed.value() == 42);
+		REQUIRE(p.random_seed.value_or(0) == 42);
 		REQUIRE(p.adc_bits == 12);
 		REQUIRE(p.oversample_ratio == 4);
 	}
@@ -462,7 +462,8 @@ TEST_CASE("parseWaveform validates FMCW chirp schema constraints", "[serial][xml
 		REQUIRE(triangle != nullptr);
 		REQUIRE(wave->isFmcwFamily());
 		REQUIRE_THAT(wave->getLength(), WithinAbs(2.0e-3, 1.0e-12));
-		REQUIRE(triangle->getTriangleCount().value() == 4);
+		REQUIRE(triangle->getTriangleCount().has_value());
+		REQUIRE(triangle->getTriangleCount().value_or(0u) == 4u);
 	}
 
 	SECTION("chirp period shorter than duration is rejected")
@@ -555,10 +556,10 @@ TEST_CASE("parseTiming extracts clock parameters and noise entries", "[serial][x
 	REQUIRE_THAT(timing->getFrequency(), WithinAbs(1e6, 1e-5));
 
 	REQUIRE(timing->getFreqOffset().has_value());
-	REQUIRE_THAT(timing->getFreqOffset().value(), WithinAbs(10.0, 1e-5));
+	REQUIRE_THAT(timing->getFreqOffset().value_or(0.0), WithinAbs(10.0, 1e-5));
 
 	REQUIRE(timing->getPhaseOffset().has_value());
-	REQUIRE_THAT(timing->getPhaseOffset().value(), WithinAbs(3.14, 1e-5));
+	REQUIRE_THAT(timing->getPhaseOffset().value_or(0.0), WithinAbs(3.14, 1e-5));
 
 	REQUIRE(timing->getSyncOnPulse() == true);
 	// Noise entries are added internally, we just verify it didn't crash
@@ -1048,9 +1049,9 @@ TEST_CASE("parseReceiver resolves references and builds object with flags and sc
 		REQUIRE(if_chain.sample_rate_hz.has_value());
 		REQUIRE(if_chain.filter_bandwidth_hz.has_value());
 		REQUIRE(if_chain.filter_transition_width_hz.has_value());
-		REQUIRE_THAT(*if_chain.sample_rate_hz, WithinAbs(1000.0, 1.0e-9));
-		REQUIRE_THAT(*if_chain.filter_bandwidth_hz, WithinAbs(400.0, 1.0e-9));
-		REQUIRE_THAT(*if_chain.filter_transition_width_hz, WithinAbs(100.0, 1.0e-9));
+		REQUIRE_THAT(if_chain.sample_rate_hz.value_or(0.0), WithinAbs(1000.0, 1.0e-9));
+		REQUIRE_THAT(if_chain.filter_bandwidth_hz.value_or(0.0), WithinAbs(400.0, 1.0e-9));
+		REQUIRE_THAT(if_chain.filter_transition_width_hz.value_or(0.0), WithinAbs(100.0, 1.0e-9));
 	}
 
 	SECTION("FMCW receiver rejects orphan dechirp reference")

--- a/packages/libfers/tests/serial/test_xml_serializer.cpp
+++ b/packages/libfers/tests/serial/test_xml_serializer.cpp
@@ -49,8 +49,8 @@ namespace
 
 TEST_CASE("serializeParameters creates correct tags across frames", "[serial][xml_serializer]")
 {
-	XmlDocument doc;
-	XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlDocument const doc;
+	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 
 	params::Parameters p;
@@ -114,7 +114,7 @@ TEST_CASE("serializeParameters creates correct tags across frames", "[serial][xm
 
 	SECTION("Defaults parameters omitted gracefully")
 	{
-		params::Parameters p2; // Default constructor
+		params::Parameters const p2; // Default constructor
 		serial::xml_serializer_utils::serializeParameters(root, p2);
 		std::string s = dumpElement(root);
 		REQUIRE_THAT(s, !ContainsSubstring("<c>"));
@@ -128,14 +128,14 @@ TEST_CASE("serializeParameters creates correct tags across frames", "[serial][xm
 
 TEST_CASE("serializeWaveform processes CW and Pulsed correctly", "[serial][xml_serializer]")
 {
-	XmlDocument doc;
-	XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlDocument const doc;
+	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 
 	SECTION("CW Mode")
 	{
 		auto sig = std::make_unique<fers_signal::CwSignal>();
-		fers_signal::RadarSignal wave("w1", 10.0, 1e9, 1.0, std::move(sig));
+		fers_signal::RadarSignal const wave("w1", 10.0, 1e9, 1.0, std::move(sig));
 		serial::xml_serializer_utils::serializeWaveform(wave, root);
 		std::string s = dumpElement(root);
 		REQUIRE_THAT(s, ContainsSubstring("name=\"w1\""));
@@ -156,7 +156,7 @@ TEST_CASE("serializeWaveform processes CW and Pulsed correctly", "[serial][xml_s
 	SECTION("Pulsed Missing Filename safely defaults")
 	{
 		auto sig = std::make_unique<fers_signal::Signal>();
-		fers_signal::RadarSignal wave("w3", 20.0, 2e9, 1.0, std::move(sig));
+		fers_signal::RadarSignal const wave("w3", 20.0, 2e9, 1.0, std::move(sig));
 		serial::xml_serializer_utils::serializeWaveform(wave, root);
 		std::string s = dumpElement(root);
 		REQUIRE_THAT(s, ContainsSubstring("<pulsed_from_file filename=\"\"/>"));
@@ -165,18 +165,18 @@ TEST_CASE("serializeWaveform processes CW and Pulsed correctly", "[serial][xml_s
 
 TEST_CASE("serializeWaveform round trips FMCW linear chirp direction", "[serial][xml_serializer][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(2.0e6);
 	params::setOversampleRatio(1);
 	params::setTime(0.0, 1.0);
 
-	XmlDocument doc;
-	XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("waveform")));
+	XmlDocument const doc;
+	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("waveform")));
 	doc.setRootElement(root);
 
 	auto sig = std::make_unique<fers_signal::FmcwChirpSignal>(1.0e6, 1.0e-3, 1.0e-3, 0.0, std::nullopt,
 															  fers_signal::FmcwChirpDirection::Down);
-	fers_signal::RadarSignal wave("down", 20.0, 2e9, 1.0e-3, std::move(sig));
+	fers_signal::RadarSignal const wave("down", 20.0, 2e9, 1.0e-3, std::move(sig));
 
 	serial::xml_serializer_utils::serializeWaveform(wave, root);
 	const std::string serialized = dumpElement(root);
@@ -200,8 +200,8 @@ TEST_CASE("serializeWaveform round trips FMCW linear chirp direction", "[serial]
 
 TEST_CASE("serializeTiming preserves clock phase and jitter characteristics", "[serial][xml_serializer]")
 {
-	XmlDocument doc;
-	XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlDocument const doc;
+	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 
 	timing::PrototypeTiming t("t1");
@@ -227,8 +227,8 @@ TEST_CASE("serializeTiming preserves clock phase and jitter characteristics", "[
 
 TEST_CASE("serializeAntenna dispatches to correct pattern forms", "[serial][xml_serializer]")
 {
-	XmlDocument doc;
-	XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlDocument const doc;
+	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 
 	SECTION("Isotropic")
@@ -243,7 +243,7 @@ TEST_CASE("serializeAntenna dispatches to correct pattern forms", "[serial][xml_
 
 	SECTION("Sinc")
 	{
-		antenna::Sinc ant("a2", 1.0, 2.0, 3.0);
+		antenna::Sinc const ant("a2", 1.0, 2.0, 3.0);
 		serial::xml_serializer_utils::serializeAntenna(ant, root);
 		std::string s = dumpElement(root);
 		REQUIRE_THAT(s, ContainsSubstring("pattern=\"sinc\""));
@@ -252,7 +252,7 @@ TEST_CASE("serializeAntenna dispatches to correct pattern forms", "[serial][xml_
 
 	SECTION("Gaussian")
 	{
-		antenna::Gaussian ant("a3", 1.5, 2.5);
+		antenna::Gaussian const ant("a3", 1.5, 2.5);
 		serial::xml_serializer_utils::serializeAntenna(ant, root);
 		std::string s = dumpElement(root);
 		REQUIRE_THAT(s, ContainsSubstring("pattern=\"gaussian\""));
@@ -261,7 +261,7 @@ TEST_CASE("serializeAntenna dispatches to correct pattern forms", "[serial][xml_
 
 	SECTION("SquareHorn")
 	{
-		antenna::SquareHorn ant("a4", 0.5);
+		antenna::SquareHorn const ant("a4", 0.5);
 		serial::xml_serializer_utils::serializeAntenna(ant, root);
 		std::string s = dumpElement(root);
 		REQUIRE_THAT(s, ContainsSubstring("pattern=\"squarehorn\""));
@@ -270,7 +270,7 @@ TEST_CASE("serializeAntenna dispatches to correct pattern forms", "[serial][xml_
 
 	SECTION("Parabolic")
 	{
-		antenna::Parabolic ant("a5", 2.0);
+		antenna::Parabolic const ant("a5", 2.0);
 		serial::xml_serializer_utils::serializeAntenna(ant, root);
 		std::string s = dumpElement(root);
 		REQUIRE_THAT(s, ContainsSubstring("pattern=\"parabolic\""));
@@ -282,8 +282,8 @@ TEST_CASE("serializeAntenna dispatches to correct pattern forms", "[serial][xml_
 
 TEST_CASE("serializeMotionPath sets right interpolation models", "[serial][xml_serializer]")
 {
-	XmlDocument doc;
-	XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlDocument const doc;
+	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 
 	math::Path path;
@@ -316,8 +316,8 @@ TEST_CASE("serializeMotionPath sets right interpolation models", "[serial][xml_s
 
 TEST_CASE("serializeRotation translates internal math to compass correctly", "[serial][xml_serializer]")
 {
-	XmlDocument doc;
-	XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlDocument const doc;
+	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 
 	math::RotationPath rot;
@@ -325,9 +325,9 @@ TEST_CASE("serializeRotation translates internal math to compass correctly", "[s
 	SECTION("Fixed Constant")
 	{
 		// Internal math equivalent to Compass 90 (East), Elevation 0
-		math::RotationCoord start{(90.0 - 90.0) * PI / 180.0, 0, 0};
+		math::RotationCoord const start{(90.0 - 90.0) * PI / 180.0, 0, 0};
 		// Rotate +10 deg/sec in compass, up 5 deg/sec in elevation
-		math::RotationCoord rate{-10.0 * PI / 180.0, 5.0 * PI / 180.0, 0};
+		math::RotationCoord const rate{-10.0 * PI / 180.0, 5.0 * PI / 180.0, 0};
 		rot.setConstantRate(start, rate);
 
 		serial::xml_serializer_utils::serializeRotation(rot, root);
@@ -379,11 +379,11 @@ TEST_CASE("serializeRotation translates internal math to compass correctly", "[s
 
 TEST_CASE("serializeTransmitter", "[serial][xml_serializer]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(10000.0);
 
-	XmlDocument doc;
-	XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlDocument const doc;
+	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 
 	radar::Platform plat("p1");
@@ -414,8 +414,8 @@ TEST_CASE("serializeTransmitter", "[serial][xml_serializer]")
 
 TEST_CASE("serializeReceiver", "[serial][xml_serializer]")
 {
-	XmlDocument doc;
-	XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlDocument const doc;
+	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 
 	radar::Platform plat("p1");
@@ -475,8 +475,8 @@ TEST_CASE("serializeReceiver", "[serial][xml_serializer]")
 
 TEST_CASE("serializeMonostatic pairs matching attached Transmitter/Receiver", "[serial][xml_serializer]")
 {
-	XmlDocument doc;
-	XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlDocument const doc;
+	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 
 	radar::Platform plat("p1");
@@ -500,8 +500,8 @@ TEST_CASE("serializeMonostatic pairs matching attached Transmitter/Receiver", "[
 
 TEST_CASE("serializeTarget models", "[serial][xml_serializer]")
 {
-	XmlDocument doc;
-	XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlDocument const doc;
+	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 
 	radar::Platform plat("p1");
@@ -529,8 +529,8 @@ TEST_CASE("serializeTarget models", "[serial][xml_serializer]")
 
 TEST_CASE("serializePlatform iterates correctly linked nodes", "[serial][xml_serializer]")
 {
-	XmlDocument doc;
-	XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlDocument const doc;
+	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 
 	core::World world;
@@ -566,8 +566,8 @@ TEST_CASE("serializePlatform iterates correctly linked nodes", "[serial][xml_ser
 
 TEST_CASE("world_to_xml_string outputs a full well-formed simulation", "[serial][xml_serializer]")
 {
-	ParamGuard guard;
-	core::World world;
+	ParamGuard const guard;
+	core::World const world;
 	SECTION("Custom Name")
 	{
 		params::params.simulation_name = "Custom Name";
@@ -590,8 +590,8 @@ TEST_CASE("world_to_xml_string outputs a full well-formed simulation", "[serial]
 
 TEST_CASE("addChildWithNumber handles various floating point values", "[serial][xml_serializer]")
 {
-	XmlDocument doc;
-	XmlElement root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlDocument const doc;
+	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
 	doc.setRootElement(root);
 
 	serial::xml_serializer_utils::addChildWithNumber(root, "nan_val", std::numeric_limits<double>::quiet_NaN());

--- a/packages/libfers/tests/serial/test_xml_serializer.cpp
+++ b/packages/libfers/tests/serial/test_xml_serializer.cpp
@@ -34,6 +34,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/serial/test_xml_serializer.cpp
+++ b/packages/libfers/tests/serial/test_xml_serializer.cpp
@@ -336,7 +336,7 @@ TEST_CASE("serializeRotation translates internal math to compass correctly", "[s
 	SECTION("Fixed Constant")
 	{
 		// Internal math equivalent to Compass 90 (East), Elevation 0
-		math::RotationCoord const start{(90.0 - 90.0) * PI / 180.0, 0, 0};
+		math::RotationCoord const start{0.0, 0, 0};
 		// Rotate +10 deg/sec in compass, up 5 deg/sec in elevation
 		math::RotationCoord const rate{-10.0 * PI / 180.0, 5.0 * PI / 180.0, 0};
 		rot.setConstantRate(start, rate);

--- a/packages/libfers/tests/serial/test_xml_serializer.cpp
+++ b/packages/libfers/tests/serial/test_xml_serializer.cpp
@@ -41,7 +41,14 @@ namespace
 	{
 		xmlBufferPtr buf = xmlBufferCreate();
 		xmlNodeDump(buf, nullptr, elem.getNode(), 0, 0);
-		std::string result(reinterpret_cast<const char*>(xmlBufferContent(buf)));
+		std::string result;
+		if (const xmlChar* content = xmlBufferContent(buf); content != nullptr)
+		{
+			for (const xmlChar* cursor = content; *cursor != 0; ++cursor)
+			{
+				result.push_back(static_cast<char>(*cursor));
+			}
+		}
 		xmlBufferFree(buf);
 		return result;
 	}
@@ -50,7 +57,7 @@ namespace
 TEST_CASE("serializeParameters creates correct tags across frames", "[serial][xml_serializer]")
 {
 	XmlDocument const doc;
-	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlElement const root = XmlElement::create("root");
 	doc.setRootElement(root);
 
 	params::Parameters p;
@@ -129,7 +136,7 @@ TEST_CASE("serializeParameters creates correct tags across frames", "[serial][xm
 TEST_CASE("serializeWaveform processes CW and Pulsed correctly", "[serial][xml_serializer]")
 {
 	XmlDocument const doc;
-	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlElement const root = XmlElement::create("root");
 	doc.setRootElement(root);
 
 	SECTION("CW Mode")
@@ -171,7 +178,7 @@ TEST_CASE("serializeWaveform round trips FMCW linear chirp direction", "[serial]
 	params::setTime(0.0, 1.0);
 
 	XmlDocument const doc;
-	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("waveform")));
+	XmlElement const root = XmlElement::create("waveform");
 	doc.setRootElement(root);
 
 	auto sig = std::make_unique<fers_signal::FmcwChirpSignal>(1.0e6, 1.0e-3, 1.0e-3, 0.0, std::nullopt,
@@ -201,7 +208,7 @@ TEST_CASE("serializeWaveform round trips FMCW linear chirp direction", "[serial]
 TEST_CASE("serializeTiming preserves clock phase and jitter characteristics", "[serial][xml_serializer]")
 {
 	XmlDocument const doc;
-	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlElement const root = XmlElement::create("root");
 	doc.setRootElement(root);
 
 	timing::PrototypeTiming t("t1");
@@ -228,7 +235,7 @@ TEST_CASE("serializeTiming preserves clock phase and jitter characteristics", "[
 TEST_CASE("serializeAntenna dispatches to correct pattern forms", "[serial][xml_serializer]")
 {
 	XmlDocument const doc;
-	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlElement const root = XmlElement::create("root");
 	doc.setRootElement(root);
 
 	SECTION("Isotropic")
@@ -283,7 +290,7 @@ TEST_CASE("serializeAntenna dispatches to correct pattern forms", "[serial][xml_
 TEST_CASE("serializeMotionPath sets right interpolation models", "[serial][xml_serializer]")
 {
 	XmlDocument const doc;
-	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlElement const root = XmlElement::create("root");
 	doc.setRootElement(root);
 
 	math::Path path;
@@ -317,7 +324,7 @@ TEST_CASE("serializeMotionPath sets right interpolation models", "[serial][xml_s
 TEST_CASE("serializeRotation translates internal math to compass correctly", "[serial][xml_serializer]")
 {
 	XmlDocument const doc;
-	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlElement const root = XmlElement::create("root");
 	doc.setRootElement(root);
 
 	math::RotationPath rot;
@@ -383,7 +390,7 @@ TEST_CASE("serializeTransmitter", "[serial][xml_serializer]")
 	params::setRate(10000.0);
 
 	XmlDocument const doc;
-	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlElement const root = XmlElement::create("root");
 	doc.setRootElement(root);
 
 	radar::Platform plat("p1");
@@ -415,7 +422,7 @@ TEST_CASE("serializeTransmitter", "[serial][xml_serializer]")
 TEST_CASE("serializeReceiver", "[serial][xml_serializer]")
 {
 	XmlDocument const doc;
-	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlElement const root = XmlElement::create("root");
 	doc.setRootElement(root);
 
 	radar::Platform plat("p1");
@@ -476,7 +483,7 @@ TEST_CASE("serializeReceiver", "[serial][xml_serializer]")
 TEST_CASE("serializeMonostatic pairs matching attached Transmitter/Receiver", "[serial][xml_serializer]")
 {
 	XmlDocument const doc;
-	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlElement const root = XmlElement::create("root");
 	doc.setRootElement(root);
 
 	radar::Platform plat("p1");
@@ -501,7 +508,7 @@ TEST_CASE("serializeMonostatic pairs matching attached Transmitter/Receiver", "[
 TEST_CASE("serializeTarget models", "[serial][xml_serializer]")
 {
 	XmlDocument const doc;
-	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlElement const root = XmlElement::create("root");
 	doc.setRootElement(root);
 
 	radar::Platform plat("p1");
@@ -530,7 +537,7 @@ TEST_CASE("serializeTarget models", "[serial][xml_serializer]")
 TEST_CASE("serializePlatform iterates correctly linked nodes", "[serial][xml_serializer]")
 {
 	XmlDocument const doc;
-	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlElement const root = XmlElement::create("root");
 	doc.setRootElement(root);
 
 	core::World world;
@@ -591,7 +598,7 @@ TEST_CASE("world_to_xml_string outputs a full well-formed simulation", "[serial]
 TEST_CASE("addChildWithNumber handles various floating point values", "[serial][xml_serializer]")
 {
 	XmlDocument const doc;
-	XmlElement const root(xmlNewNode(nullptr, reinterpret_cast<const xmlChar*>("root")));
+	XmlElement const root = XmlElement::create("root");
 	doc.setRootElement(root);
 
 	serial::xml_serializer_utils::addChildWithNumber(root, "nan_val", std::numeric_limits<double>::quiet_NaN());

--- a/packages/libfers/tests/signal/test_dsp_filters.cpp
+++ b/packages/libfers/tests/signal/test_dsp_filters.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
@@ -27,10 +28,10 @@ namespace
 
 TEST_CASE("IirFilter acts as identity with unity coefficients", "[signal][dsp][iir]")
 {
-	const RealType a[] = {1.0, 0.0};
-	const RealType b[] = {1.0, 0.0};
+	const std::array<RealType, 2> a = {1.0, 0.0};
+	const std::array<RealType, 2> b = {1.0, 0.0};
 
-	fers_signal::IirFilter filter(a, b, 2);
+	fers_signal::IirFilter filter(a.data(), b.data(), static_cast<unsigned>(a.size()));
 	std::vector<RealType> samples = {1.0, -2.5, 3.25, 0.0};
 
 	filter.filter(samples);
@@ -44,10 +45,10 @@ TEST_CASE("IirFilter acts as identity with unity coefficients", "[signal][dsp][i
 
 TEST_CASE("IirFilter feedback produces expected decay", "[signal][dsp][iir]")
 {
-	const RealType a[] = {1.0, -0.5};
-	const RealType b[] = {1.0, 0.0};
+	const std::array<RealType, 2> a = {1.0, -0.5};
+	const std::array<RealType, 2> b = {1.0, 0.0};
 
-	fers_signal::IirFilter filter(a, b, 2);
+	fers_signal::IirFilter filter(a.data(), b.data(), static_cast<unsigned>(a.size()));
 	std::vector<RealType> input = {1.0, 0.0, 0.0, 0.0};
 	std::vector<RealType> expected = {1.0, 0.5, 0.25, 0.125};
 

--- a/packages/libfers/tests/signal/test_dsp_filters.cpp
+++ b/packages/libfers/tests/signal/test_dsp_filters.cpp
@@ -59,7 +59,7 @@ TEST_CASE("FirFilter applies coefficients to complex samples", "[signal][dsp][fi
 	const std::vector<RealType> coeffs = {1.0, 2.0};
 	std::vector<ComplexType> samples = {ComplexType{1.0, 1.0}, ComplexType{0.0, 0.0}, ComplexType{0.0, 0.0}};
 
-	fers_signal::FirFilter filter(coeffs);
+	fers_signal::FirFilter const filter(coeffs);
 	filter.filter(samples);
 
 	REQUIRE(samples.size() == 3);
@@ -98,14 +98,14 @@ TEST_CASE("FirFilter real-span overload is a no-op", "[signal][dsp][fir]")
 
 TEST_CASE("DecadeUpsampler rejects incorrect output size", "[signal][dsp][upsample]")
 {
-	fers_signal::DecadeUpsampler upsampler;
+	fers_signal::DecadeUpsampler const upsampler;
 	std::vector<RealType> out(9, 0.0);
 	REQUIRE_THROWS_AS(upsampler.upsample(1.0, out), std::invalid_argument);
 }
 
 TEST_CASE("DecadeUpsampler produces zeros for zero input", "[signal][dsp][upsample]")
 {
-	fers_signal::DecadeUpsampler upsampler;
+	fers_signal::DecadeUpsampler const upsampler;
 	std::vector<RealType> out(10, 1.0);
 
 	upsampler.upsample(0.0, out);
@@ -118,7 +118,7 @@ TEST_CASE("DecadeUpsampler produces zeros for zero input", "[signal][dsp][upsamp
 
 TEST_CASE("Upsample and downsample preserve low-frequency content", "[signal][dsp][resample]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.filter_length = 8;
 	params::setOversampleRatio(2);
 
@@ -147,7 +147,7 @@ TEST_CASE("Upsample and downsample preserve low-frequency content", "[signal][ds
 
 TEST_CASE("Upsample and downsample preserve boundary-ratio low-frequency content", "[signal][dsp][resample]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.filter_length = 33;
 	params::setOversampleRatio(8);
 
@@ -186,7 +186,7 @@ TEST_CASE("Upsample and downsample preserve boundary-ratio low-frequency content
 
 TEST_CASE("Downsample truncates non-divisible oversampled buffers", "[signal][dsp][downsample]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setOversampleRatio(8);
 
 	const std::vector<ComplexType> oversampled(17, ComplexType{0.0, 0.0});
@@ -197,7 +197,7 @@ TEST_CASE("Downsample truncates non-divisible oversampled buffers", "[signal][ds
 
 TEST_CASE("Resampler fails fast when oversample ratio exceeds fixed-filter limit", "[signal][dsp][resample]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.oversample_ratio = 9;
 
 	const std::vector<ComplexType> input = {ComplexType{1.0, 0.0}, ComplexType{0.0, 1.0}};

--- a/packages/libfers/tests/signal/test_dsp_filters.cpp
+++ b/packages/libfers/tests/signal/test_dsp_filters.cpp
@@ -17,6 +17,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 }

--- a/packages/libfers/tests/signal/test_if_resampler.cpp
+++ b/packages/libfers/tests/signal/test_if_resampler.cpp
@@ -24,6 +24,38 @@ namespace
 		}
 		return data;
 	}
+
+	void requireHalfBandStages(const fers_signal::FmcwIfResamplerPlan& plan)
+	{
+		REQUIRE(plan.stages.size() == 7);
+		for (std::size_t i = 0; i < 6; ++i)
+		{
+			REQUIRE(plan.stages[i].kind == fers_signal::FmcwIfResamplerStageKind::HalfBandDecimateBy2);
+			REQUIRE(plan.stages[i].down_factor == 2);
+		}
+	}
+
+	void requireFinalRationalStage(const fers_signal::FmcwIfResamplerPlan& plan,
+								   const fers_signal::FmcwIfResamplerRequest& request)
+	{
+		const auto& final_stage = plan.stages.back();
+		REQUIRE(final_stage.kind == fers_signal::FmcwIfResamplerStageKind::RationalPolyphase);
+		REQUIRE(final_stage.up_factor == 5);
+		REQUIRE(final_stage.down_factor == 8);
+		REQUIRE(final_stage.phase_refinement == request.limits.max_phase_refinement);
+		REQUIRE(final_stage.phase_count == 5 * request.limits.max_phase_refinement);
+	}
+
+	void requirePlanDelayAndCost(const fers_signal::FmcwIfResamplerPlan& plan,
+								 const fers_signal::FmcwIfResamplerRequest& request)
+	{
+		REQUIRE(plan.group_delay_seconds > 0.0);
+		REQUIRE(plan.group_delay_output_samples > 0.0);
+		REQUIRE(plan.warmup_discard_samples > 0);
+		REQUIRE(plan.fractional_output_delay_samples >= 0.0);
+		REQUIRE(plan.fractional_output_delay_samples < 1.0);
+		REQUIRE(plan.estimated_macs_per_output_sample <= request.limits.max_macs_per_output_sample);
+	}
 }
 
 TEST_CASE("FMCW IF resampler plans rational 5/512 conversion", "[signal][if_resampler][plan]")
@@ -38,24 +70,9 @@ TEST_CASE("FMCW IF resampler plans rational 5/512 conversion", "[signal][if_resa
 	REQUIRE(plan.overall_ratio.numerator == 5);
 	REQUIRE(plan.overall_ratio.denominator == 512);
 	REQUIRE_THAT(plan.actual_output_sample_rate_hz, WithinAbs(10.0e6, 1e-6));
-	REQUIRE(plan.stages.size() == 7);
-	for (std::size_t i = 0; i < 6; ++i)
-	{
-		REQUIRE(plan.stages[i].kind == fers_signal::FmcwIfResamplerStageKind::HalfBandDecimateBy2);
-		REQUIRE(plan.stages[i].down_factor == 2);
-	}
-	const auto& final_stage = plan.stages.back();
-	REQUIRE(final_stage.kind == fers_signal::FmcwIfResamplerStageKind::RationalPolyphase);
-	REQUIRE(final_stage.up_factor == 5);
-	REQUIRE(final_stage.down_factor == 8);
-	REQUIRE(final_stage.phase_refinement == request.limits.max_phase_refinement);
-	REQUIRE(final_stage.phase_count == 5 * request.limits.max_phase_refinement);
-	REQUIRE(plan.group_delay_seconds > 0.0);
-	REQUIRE(plan.group_delay_output_samples > 0.0);
-	REQUIRE(plan.warmup_discard_samples > 0);
-	REQUIRE(plan.fractional_output_delay_samples >= 0.0);
-	REQUIRE(plan.fractional_output_delay_samples < 1.0);
-	REQUIRE(plan.estimated_macs_per_output_sample <= request.limits.max_macs_per_output_sample);
+	requireHalfBandStages(plan);
+	requireFinalRationalStage(plan, request);
+	requirePlanDelayAndCost(plan, request);
 }
 
 TEST_CASE("FMCW IF resampler rejects excessive near-Nyquist filter cost", "[signal][if_resampler][plan]")

--- a/packages/libfers/tests/signal/test_radar_signal.cpp
+++ b/packages/libfers/tests/signal/test_radar_signal.cpp
@@ -131,7 +131,7 @@ TEST_CASE("RadarSignal exposes metadata", "[signal][radar]")
 	REQUIRE(radar.getRate() == 1000.0);
 	REQUIRE(radar.getId() == 42);
 	REQUIRE(radar.getFilename().has_value());
-	REQUIRE(radar.getFilename().value() == "waveform.bin");
+	REQUIRE(radar.getFilename().value_or("") == "waveform.bin");
 }
 
 TEST_CASE("RadarSignal autogenerates waveform ids", "[signal][radar]")

--- a/packages/libfers/tests/signal/test_radar_signal.cpp
+++ b/packages/libfers/tests/signal/test_radar_signal.cpp
@@ -41,7 +41,7 @@ namespace
 
 TEST_CASE("CwSignal render returns empty data", "[signal][radar][cw]")
 {
-	fers_signal::CwSignal signal;
+	fers_signal::CwSignal const signal;
 	unsigned size = 99;
 	const std::vector<interp::InterpPoint> points = {{1.0, 0.0, 0.0, 0.0}};
 
@@ -64,9 +64,9 @@ TEST_CASE("FmcwChirpSignal applies sweep direction to phase only", "[signal][rad
 	const RealType offset = 1.0e5;
 	const RealType u = 4.0e-4;
 
-	fers_signal::FmcwChirpSignal up(bandwidth, duration, duration, offset);
-	fers_signal::FmcwChirpSignal down(bandwidth, duration, duration, offset, std::nullopt,
-									  fers_signal::FmcwChirpDirection::Down);
+	fers_signal::FmcwChirpSignal const up(bandwidth, duration, duration, offset);
+	fers_signal::FmcwChirpSignal const down(bandwidth, duration, duration, offset, std::nullopt,
+											fers_signal::FmcwChirpDirection::Down);
 
 	const RealType alpha = bandwidth / duration;
 	REQUIRE_FALSE(up.isDownChirp());
@@ -87,7 +87,7 @@ TEST_CASE("FmcwTriangleSignal keeps phase continuous at leg and period boundarie
 	const RealType alpha = bandwidth / duration;
 	const RealType eps = 1.0e-10;
 
-	fers_signal::FmcwTriangleSignal triangle(bandwidth, duration, offset, 4);
+	fers_signal::FmcwTriangleSignal const triangle(bandwidth, duration, offset, 4);
 
 	REQUIRE(triangle.isFmcwFamily());
 	REQUIRE(triangle.isTriangle());
@@ -111,7 +111,7 @@ TEST_CASE("FmcwTriangleSignal keeps phase continuous at leg and period boundarie
 
 TEST_CASE("RadarSignal exposes metadata", "[signal][radar]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setOversampleRatio(1);
 	std::vector<ComplexType> data = {ComplexType{1.0, 0.0}};
 	auto signal = std::make_unique<fers_signal::Signal>();
@@ -133,7 +133,7 @@ TEST_CASE("RadarSignal exposes metadata", "[signal][radar]")
 TEST_CASE("RadarSignal autogenerates waveform ids", "[signal][radar]")
 {
 	auto signal = std::make_unique<fers_signal::Signal>();
-	fers_signal::RadarSignal radar("waveform", 1.0, 1.0, 1.0, std::move(signal), 0);
+	fers_signal::RadarSignal const radar("waveform", 1.0, 1.0, 1.0, std::move(signal), 0);
 
 	REQUIRE(SimIdGenerator::getType(radar.getId()) == ObjectType::Waveform);
 }
@@ -154,7 +154,7 @@ TEST_CASE("RadarSignal scales rendered data by power", "[signal][radar]")
 	auto signal = std::make_unique<TestSignal>();
 	signal->stored = {ComplexType{1.0, 0.0}, ComplexType{2.0, -1.0}};
 
-	fers_signal::RadarSignal radar("scaled", 4.0, 1.0, 1.0, std::move(signal), 7);
+	fers_signal::RadarSignal const radar("scaled", 4.0, 1.0, 1.0, std::move(signal), 7);
 
 	unsigned size = 0;
 	const std::vector<interp::InterpPoint> points = {{1.0, 0.0, 0.0, 0.0}};
@@ -169,7 +169,7 @@ TEST_CASE("RadarSignal scales rendered data by power", "[signal][radar]")
 
 TEST_CASE("Signal load updates size and rate", "[signal][radar]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setOversampleRatio(2);
 	std::vector<ComplexType> input = {ComplexType{1.0, 0.0}, ComplexType{0.5, -0.5}};
 
@@ -187,7 +187,7 @@ TEST_CASE("Signal load updates size and rate", "[signal][radar]")
 
 TEST_CASE("Signal render matches constant input physics", "[signal][radar]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setOversampleRatio(1);
 
 	const unsigned filter_length = params::renderFilterLength();
@@ -216,7 +216,7 @@ TEST_CASE("Signal render matches constant input physics", "[signal][radar]")
 
 TEST_CASE("Signal render interpolates power and phase", "[signal][radar]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setOversampleRatio(1);
 
 	const unsigned filter_length = params::renderFilterLength();
@@ -252,7 +252,7 @@ TEST_CASE("Signal render interpolates power and phase", "[signal][radar]")
 
 TEST_CASE("Signal render responds to fractional delay", "[signal][radar]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setOversampleRatio(1);
 
 	const unsigned filter_length = params::renderFilterLength();
@@ -279,7 +279,7 @@ TEST_CASE("Signal render responds to fractional delay", "[signal][radar]")
 
 TEST_CASE("Signal renderSlice matches cropped full response with padding", "[signal][radar]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setOversampleRatio(1);
 
 	const unsigned sample_count = params::renderFilterLength() * 6;
@@ -313,7 +313,7 @@ TEST_CASE("Signal renderSlice matches cropped full response with padding", "[sig
 
 TEST_CASE("Signal renderSlice interpolates onto non-native output grids", "[signal][radar]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setOversampleRatio(1);
 
 	constexpr RealType native_rate_hz = 100.0;

--- a/packages/libfers/tests/signal/test_radar_signal.cpp
+++ b/packages/libfers/tests/signal/test_radar_signal.cpp
@@ -19,6 +19,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/simulation/test_channel_model_direct.cpp
+++ b/packages/libfers/tests/simulation/test_channel_model_direct.cpp
@@ -31,6 +31,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/simulation/test_channel_model_direct.cpp
+++ b/packages/libfers/tests/simulation/test_channel_model_direct.cpp
@@ -78,7 +78,7 @@ namespace
 
 TEST_CASE("solveReDirect computes correct Friis power for isotropic antennas", "[simulation][channel_model][direct]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	// Setup: Tx at origin, Rx at (1000, 0, 0)
@@ -131,7 +131,7 @@ TEST_CASE("solveReDirect computes correct Friis power for isotropic antennas", "
 
 TEST_CASE("solveReDirect Friis equation with different distances", "[simulation][channel_model][direct]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	// Verify inverse-square law: doubling distance should quarter the power
@@ -191,7 +191,7 @@ TEST_CASE("solveReDirect Friis equation with different distances", "[simulation]
 
 TEST_CASE("solveReDirect with noproploss flag ignores distance in power", "[simulation][channel_model][direct]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	const RealType c = params::c();
@@ -238,7 +238,7 @@ TEST_CASE("solveReDirect with noproploss flag ignores distance in power", "[simu
 
 TEST_CASE("solveReDirect phase is proportional to carrier frequency", "[simulation][channel_model][direct]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	// Phase = -delay * 2 * pi * carrier
@@ -304,7 +304,7 @@ TEST_CASE("solveReDirect phase is proportional to carrier frequency", "[simulati
 TEST_CASE("calculateDirectPathContribution amplitude matches Friis equation with signal power",
 		  "[simulation][channel_model][direct]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	// Setup: Tx at (0,0,0), Rx at (1000,0,0)
@@ -348,7 +348,7 @@ TEST_CASE("calculateDirectPathContribution amplitude matches Friis equation with
 
 TEST_CASE("calculateDirectPathContribution phase matches propagation delay", "[simulation][channel_model][direct]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	const RealType c = params::c();
@@ -393,7 +393,7 @@ TEST_CASE("calculateDirectPathContribution phase matches propagation delay", "[s
 TEST_CASE("FMCW streaming direct path preserves in-flight segment-end tail",
 		  "[simulation][channel_model][direct][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(80.0e6);
 	params::setSimSamplingRate(80.0e6);
@@ -480,7 +480,7 @@ TEST_CASE("FMCW streaming direct path preserves in-flight segment-end tail",
 
 TEST_CASE("CW streaming direct path gates schedules by retarded transmit time", "[simulation][channel_model][direct]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setC(100.0);
 
@@ -524,7 +524,7 @@ TEST_CASE("CW streaming direct path gates schedules by retarded transmit time", 
 
 TEST_CASE("FMCW streaming direct path keeps chirp cache per source", "[simulation][channel_model][direct][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	const RealType dist = 300.0;
@@ -578,7 +578,7 @@ TEST_CASE("FMCW streaming direct path keeps chirp cache per source", "[simulatio
 TEST_CASE("calculateDirectPathContribution with noproploss gives distance-independent amplitude",
 		  "[simulation][channel_model][direct]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	const RealType c = params::c();
@@ -624,7 +624,7 @@ TEST_CASE("calculateDirectPathContribution with noproploss gives distance-indepe
 TEST_CASE("calculateDirectPathContribution applies buffered delayed timing phase with interpolation",
 		  "[simulation][channel_model][direct]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setTime(0.0, 1.0);
 	params::setRate(10.0);
@@ -673,7 +673,7 @@ TEST_CASE("calculateDirectPathContribution applies buffered delayed timing phase
 
 TEST_CASE("solveReDirect at 3D separation produces correct distance and delay", "[simulation][channel_model][direct]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	// Tx at (100, 200, 300), Rx at (400, 600, 800)
@@ -721,7 +721,7 @@ TEST_CASE("solveReDirect at 3D separation produces correct distance and delay", 
 
 TEST_CASE("solveReDirect power scales with lambda squared", "[simulation][channel_model][direct]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	// Friis: Pr/Pt ∝ lambda^2

--- a/packages/libfers/tests/simulation/test_channel_model_direct.cpp
+++ b/packages/libfers/tests/simulation/test_channel_model_direct.cpp
@@ -413,7 +413,7 @@ TEST_CASE("FMCW streaming direct path preserves in-flight segment-end tail",
 	const RealType chirp_duration = 250.0e-6;
 	const RealType chirp_period = chirp_duration;
 	const RealType chirp_rate = chirp_bandwidth / chirp_duration;
-	const std::size_t sample_count = static_cast<std::size_t>(std::ceil(tau / dt));
+	const auto sample_count = static_cast<std::size_t>(std::ceil(tau / dt));
 
 	radar::Platform tx_plat("tx_plat");
 	setupPlatform(tx_plat, math::Vec3{0.0, 0.0, 0.0});

--- a/packages/libfers/tests/simulation/test_channel_model_helpers.cpp
+++ b/packages/libfers/tests/simulation/test_channel_model_helpers.cpp
@@ -30,6 +30,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/simulation/test_channel_model_helpers.cpp
+++ b/packages/libfers/tests/simulation/test_channel_model_helpers.cpp
@@ -87,7 +87,7 @@ TEST_CASE("ReResults holds assigned values", "[simulation][channel_model][helper
 TEST_CASE("solveReDirect throws RangeError when Tx and Rx are at the same position",
 		  "[simulation][channel_model][helpers]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	// Two platforms at the exact same position
@@ -120,7 +120,7 @@ TEST_CASE("solveReDirect throws RangeError when Tx and Rx are at the same positi
 
 TEST_CASE("solveRe throws RangeError when target is at transmitter position", "[simulation][channel_model][helpers]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	// Tx and target at same position; Rx elsewhere
@@ -158,7 +158,7 @@ TEST_CASE("solveRe throws RangeError when target is at transmitter position", "[
 
 TEST_CASE("solveRe throws RangeError when target is at receiver position", "[simulation][channel_model][helpers]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	radar::Platform tx_plat("tx_plat");
@@ -240,7 +240,7 @@ TEST_CASE("PreviewLink holds assigned values", "[simulation][channel_model][help
 TEST_CASE("calculateDirectPathContribution returns zero for co-located Tx and Rx on same platform",
 		  "[simulation][channel_model][helpers]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	radar::Platform shared_plat("shared");
@@ -268,7 +268,7 @@ TEST_CASE("calculateDirectPathContribution returns zero for co-located Tx and Rx
 TEST_CASE("calculateReflectedPathContribution returns zero when target shares platform with Tx",
 		  "[simulation][channel_model][helpers]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	radar::Platform tx_plat("tx_plat");
@@ -302,7 +302,7 @@ TEST_CASE("calculateReflectedPathContribution returns zero when target shares pl
 TEST_CASE("calculateReflectedPathContribution returns zero when target shares platform with Rx",
 		  "[simulation][channel_model][helpers]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	radar::Platform tx_plat("tx_plat");

--- a/packages/libfers/tests/simulation/test_channel_model_preview.cpp
+++ b/packages/libfers/tests/simulation/test_channel_model_preview.cpp
@@ -72,10 +72,10 @@ namespace
 
 TEST_CASE("calculatePreviewLinks returns empty for empty world", "[simulation][channel_model][preview]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
-	core::World world;
+	core::World const world;
 	const auto links = simulation::calculatePreviewLinks(world, 0.0);
 	REQUIRE(links.empty());
 }
@@ -87,7 +87,7 @@ TEST_CASE("calculatePreviewLinks returns empty for empty world", "[simulation][c
 TEST_CASE("calculatePreviewLinks monostatic produces Monostatic and BistaticTxTgt links",
 		  "[simulation][channel_model][preview]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1e6);
 
@@ -142,7 +142,7 @@ TEST_CASE("calculatePreviewLinks monostatic produces Monostatic and BistaticTxTg
 
 TEST_CASE("calculatePreviewLinks monostatic link references correct IDs", "[simulation][channel_model][preview]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1e6);
 
@@ -212,7 +212,7 @@ TEST_CASE("calculatePreviewLinks monostatic link references correct IDs", "[simu
 
 TEST_CASE("calculatePreviewLinks bistatic produces correct link types", "[simulation][channel_model][preview]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1e6);
 
@@ -275,7 +275,7 @@ TEST_CASE("calculatePreviewLinks bistatic produces correct link types", "[simula
 
 TEST_CASE("calculatePreviewLinks bistatic with NODIRECT flag omits direct link", "[simulation][channel_model][preview]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1e6);
 
@@ -334,7 +334,7 @@ TEST_CASE("calculatePreviewLinks bistatic with NODIRECT flag omits direct link",
 
 TEST_CASE("calculatePreviewLinks respects transmitter schedule", "[simulation][channel_model][preview]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1e6);
 
@@ -390,7 +390,7 @@ TEST_CASE("calculatePreviewLinks respects transmitter schedule", "[simulation][c
 
 TEST_CASE("calculatePreviewLinks respects receiver schedule", "[simulation][channel_model][preview]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1e6);
 
@@ -457,7 +457,7 @@ TEST_CASE("calculatePreviewLinks respects receiver schedule", "[simulation][chan
 
 TEST_CASE("calculatePreviewLinks scales link count with number of targets", "[simulation][channel_model][preview]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1e6);
 
@@ -516,7 +516,7 @@ TEST_CASE("calculatePreviewLinks scales link count with number of targets", "[si
 
 TEST_CASE("calculatePreviewLinks classifies very weak signals as Weak", "[simulation][channel_model][preview]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1e6); // 1 MHz bandwidth for noise floor calculation
 
@@ -577,7 +577,7 @@ TEST_CASE("calculatePreviewLinks classifies very weak signals as Weak", "[simula
 
 TEST_CASE("calculatePreviewLinks classifies strong signals as Strong", "[simulation][channel_model][preview]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1e6);
 
@@ -639,7 +639,7 @@ TEST_CASE("calculatePreviewLinks classifies strong signals as Strong", "[simulat
 
 TEST_CASE("calculatePreviewLinks handles transmitter with no waveform", "[simulation][channel_model][preview]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1e6);
 
@@ -688,7 +688,7 @@ TEST_CASE("calculatePreviewLinks handles transmitter with no waveform", "[simula
 
 TEST_CASE("calculatePreviewLinks monostatic label contains dBm", "[simulation][channel_model][preview]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1e6);
 
@@ -758,7 +758,7 @@ TEST_CASE("calculatePreviewLinks monostatic label contains dBm", "[simulation][c
 
 TEST_CASE("calculatePreviewLinks FMCW labels use single-value preview style", "[simulation][channel_model][preview]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1e6);
 

--- a/packages/libfers/tests/simulation/test_channel_model_preview.cpp
+++ b/packages/libfers/tests/simulation/test_channel_model_preview.cpp
@@ -32,6 +32,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/simulation/test_channel_model_preview.cpp
+++ b/packages/libfers/tests/simulation/test_channel_model_preview.cpp
@@ -68,6 +68,102 @@ namespace
 		REQUIRE(label.find('(') == std::string::npos);
 		REQUIRE(label.find(')') == std::string::npos);
 	}
+
+	struct MonostaticPreviewFixture
+	{
+		antenna::Isotropic antenna{"iso"};
+		std::shared_ptr<timing::Timing> timing = std::make_shared<timing::Timing>("clk", 42);
+		core::World world;
+
+		MonostaticPreviewFixture(const SimId tx_id, const SimId rx_id, const SimId target_id)
+		{
+			auto tx_plat = std::make_unique<radar::Platform>("tx_plat");
+			setupPlatform(*tx_plat, math::Vec3{0.0, 0.0, 0.0});
+			auto* tx_plat_ptr = tx_plat.get();
+
+			auto tgt_plat = std::make_unique<radar::Platform>("tgt_plat");
+			setupPlatform(*tgt_plat, math::Vec3{1000.0, 0.0, 0.0});
+			auto* tgt_plat_ptr = tgt_plat.get();
+
+			auto tx = std::make_unique<radar::Transmitter>(tx_plat_ptr, "tx", radar::OperationMode::PULSED_MODE, tx_id);
+			tx->setAntenna(&antenna);
+			tx->setTiming(timing);
+
+			auto sig = std::make_unique<fers_signal::CwSignal>();
+			auto wave = std::make_unique<fers_signal::RadarSignal>("sig", 1000.0, 1e9, 1e-3, std::move(sig), 300);
+			tx->setSignal(wave.get());
+
+			auto rx =
+				std::make_unique<radar::Receiver>(tx_plat_ptr, "rx", 42, radar::OperationMode::PULSED_MODE, rx_id);
+			rx->setAntenna(&antenna);
+			rx->setTiming(timing);
+			rx->setNoiseTemperature(290.0);
+			tx->setAttached(rx.get());
+
+			auto tgt = radar::createIsoTarget(tgt_plat_ptr, "tgt", 10.0, 42, target_id);
+
+			world.add(std::move(tx_plat));
+			world.add(std::move(tgt_plat));
+			world.add(std::move(tx));
+			world.add(std::move(rx));
+			world.add(std::move(tgt));
+			world.add(std::move(wave));
+		}
+	};
+
+	void requireMonostaticPreviewLinkIds(const std::vector<simulation::PreviewLink>& links, const SimId tx_id,
+										 const SimId target_id)
+	{
+		for (const auto& link : links)
+		{
+			if (link.type == simulation::LinkType::Monostatic || link.type == simulation::LinkType::BistaticTxTgt)
+			{
+				REQUIRE(link.source_id == tx_id);
+				REQUIRE(link.dest_id == target_id);
+				REQUIRE(link.origin_id == tx_id);
+			}
+		}
+	}
+
+	void requireMonostaticPowerLabel(const simulation::PreviewLink& link)
+	{
+		REQUIRE(link.label.find("dBm") != std::string::npos);
+		REQUIRE_THAT(link.rcs, WithinAbs(10.0, 1e-12));
+		REQUIRE(link.actual_power_dbm > -999.0);
+
+		const double label_power_dbm = std::stod(link.label);
+		REQUIRE_THAT(link.display_value, WithinAbs(label_power_dbm, 0.1));
+		REQUIRE_THAT(link.actual_power_dbm, WithinAbs(link.display_value + 10.0 * std::log10(link.rcs), 0.1));
+	}
+
+	void requireBistaticTxTargetPowerLabel(const simulation::PreviewLink& link)
+	{
+		REQUIRE(link.label.find("dBW") != std::string::npos);
+		REQUIRE_THAT(link.display_value, WithinAbs(std::stod(link.label), 0.1));
+	}
+
+	void requireMonostaticLabelSummary(const std::vector<simulation::PreviewLink>& links)
+	{
+		bool saw_monostatic = false;
+		bool saw_tx_tgt = false;
+
+		for (const auto& link : links)
+		{
+			if (link.type == simulation::LinkType::Monostatic)
+			{
+				saw_monostatic = true;
+				requireMonostaticPowerLabel(link);
+			}
+			if (link.type == simulation::LinkType::BistaticTxTgt)
+			{
+				saw_tx_tgt = true;
+				requireBistaticTxTargetPowerLabel(link);
+			}
+		}
+
+		REQUIRE(saw_monostatic);
+		REQUIRE(saw_tx_tgt);
+	}
 }
 
 // =============================================================================
@@ -153,61 +249,10 @@ TEST_CASE("calculatePreviewLinks monostatic link references correct IDs", "[simu
 	const SimId tx_id = 100;
 	const SimId rx_id = 200;
 	const SimId tgt_id = 400;
+	MonostaticPreviewFixture fixture(tx_id, rx_id, tgt_id);
 
-	auto tx_plat = std::make_unique<radar::Platform>("tx_plat");
-	setupPlatform(*tx_plat, math::Vec3{0.0, 0.0, 0.0});
-	auto* tx_plat_ptr = tx_plat.get();
-
-	auto tgt_plat = std::make_unique<radar::Platform>("tgt_plat");
-	setupPlatform(*tgt_plat, math::Vec3{1000.0, 0.0, 0.0});
-	auto* tgt_plat_ptr = tgt_plat.get();
-
-	antenna::Isotropic iso_ant("iso");
-	auto timing = std::make_shared<timing::Timing>("clk", 42);
-
-	auto tx = std::make_unique<radar::Transmitter>(tx_plat_ptr, "tx", radar::OperationMode::PULSED_MODE, tx_id);
-	tx->setAntenna(&iso_ant);
-	tx->setTiming(timing);
-
-	auto sig = std::make_unique<fers_signal::CwSignal>();
-	auto wave = std::make_unique<fers_signal::RadarSignal>("sig", 1000.0, 1e9, 1e-3, std::move(sig), 300);
-	tx->setSignal(wave.get());
-
-	auto rx = std::make_unique<radar::Receiver>(tx_plat_ptr, "rx", 42, radar::OperationMode::PULSED_MODE, rx_id);
-	rx->setAntenna(&iso_ant);
-	rx->setTiming(timing);
-	rx->setNoiseTemperature(290.0);
-
-	tx->setAttached(rx.get());
-
-	auto tgt = radar::createIsoTarget(tgt_plat_ptr, "tgt", 10.0, 42, tgt_id);
-
-	core::World world;
-	world.add(std::move(tx_plat));
-	world.add(std::move(tgt_plat));
-	world.add(std::move(tx));
-	world.add(std::move(rx));
-	world.add(std::move(tgt));
-	world.add(std::move(wave));
-
-	const auto links = simulation::calculatePreviewLinks(world, 0.0);
-
-	// Find the Monostatic link
-	for (const auto& link : links)
-	{
-		if (link.type == simulation::LinkType::Monostatic)
-		{
-			REQUIRE(link.source_id == tx_id);
-			REQUIRE(link.dest_id == tgt_id);
-			REQUIRE(link.origin_id == tx_id);
-		}
-		if (link.type == simulation::LinkType::BistaticTxTgt)
-		{
-			REQUIRE(link.source_id == tx_id);
-			REQUIRE(link.dest_id == tgt_id);
-			REQUIRE(link.origin_id == tx_id);
-		}
-	}
+	const auto links = simulation::calculatePreviewLinks(fixture.world, 0.0);
+	requireMonostaticPreviewLinkIds(links, tx_id, tgt_id);
 }
 
 // =============================================================================
@@ -695,69 +740,10 @@ TEST_CASE("calculatePreviewLinks monostatic label contains dBm", "[simulation][c
 	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1e6);
+	MonostaticPreviewFixture fixture(100, 200, 400);
 
-	auto tx_plat = std::make_unique<radar::Platform>("tx_plat");
-	setupPlatform(*tx_plat, math::Vec3{0.0, 0.0, 0.0});
-	auto* tx_plat_ptr = tx_plat.get();
-
-	auto tgt_plat = std::make_unique<radar::Platform>("tgt_plat");
-	setupPlatform(*tgt_plat, math::Vec3{1000.0, 0.0, 0.0});
-	auto* tgt_plat_ptr = tgt_plat.get();
-
-	antenna::Isotropic iso_ant("iso");
-	auto timing = std::make_shared<timing::Timing>("clk", 42);
-
-	auto tx = std::make_unique<radar::Transmitter>(tx_plat_ptr, "tx", radar::OperationMode::PULSED_MODE, 100);
-	tx->setAntenna(&iso_ant);
-	tx->setTiming(timing);
-
-	auto sig = std::make_unique<fers_signal::CwSignal>();
-	auto wave = std::make_unique<fers_signal::RadarSignal>("sig", 1000.0, 1e9, 1e-3, std::move(sig), 300);
-	tx->setSignal(wave.get());
-
-	auto rx = std::make_unique<radar::Receiver>(tx_plat_ptr, "rx", 42, radar::OperationMode::PULSED_MODE, 200);
-	rx->setAntenna(&iso_ant);
-	rx->setTiming(timing);
-	rx->setNoiseTemperature(290.0);
-	tx->setAttached(rx.get());
-
-	auto tgt = radar::createIsoTarget(tgt_plat_ptr, "tgt", 10.0, 42, 400);
-
-	core::World world;
-	world.add(std::move(tx_plat));
-	world.add(std::move(tgt_plat));
-	world.add(std::move(tx));
-	world.add(std::move(rx));
-	world.add(std::move(tgt));
-	world.add(std::move(wave));
-
-	const auto links = simulation::calculatePreviewLinks(world, 0.0);
-	bool saw_monostatic = false;
-	bool saw_tx_tgt = false;
-
-	for (const auto& link : links)
-	{
-		if (link.type == simulation::LinkType::Monostatic)
-		{
-			saw_monostatic = true;
-			REQUIRE(link.label.find("dBm") != std::string::npos);
-			REQUIRE_THAT(link.rcs, WithinAbs(10.0, 1e-12));
-			REQUIRE(link.actual_power_dbm > -999.0);
-
-			const double label_power_dbm = std::stod(link.label);
-			REQUIRE_THAT(link.display_value, WithinAbs(label_power_dbm, 0.1));
-			REQUIRE_THAT(link.actual_power_dbm, WithinAbs(link.display_value + 10.0 * std::log10(link.rcs), 0.1));
-		}
-		if (link.type == simulation::LinkType::BistaticTxTgt)
-		{
-			saw_tx_tgt = true;
-			REQUIRE(link.label.find("dBW") != std::string::npos);
-			REQUIRE_THAT(link.display_value, WithinAbs(std::stod(link.label), 0.1));
-		}
-	}
-
-	REQUIRE(saw_monostatic);
-	REQUIRE(saw_tx_tgt);
+	const auto links = simulation::calculatePreviewLinks(fixture.world, 0.0);
+	requireMonostaticLabelSummary(links);
 }
 
 TEST_CASE("calculatePreviewLinks FMCW labels use single-value preview style", "[simulation][channel_model][preview]")

--- a/packages/libfers/tests/simulation/test_channel_model_reflected.cpp
+++ b/packages/libfers/tests/simulation/test_channel_model_reflected.cpp
@@ -34,6 +34,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/simulation/test_channel_model_reflected.cpp
+++ b/packages/libfers/tests/simulation/test_channel_model_reflected.cpp
@@ -71,7 +71,7 @@ namespace
 
 TEST_CASE("solveRe computes correct bistatic power for isotropic antennas", "[simulation][channel_model][reflected]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	// Setup: Tx at (0,0,0), Target at (500,0,0), Rx at (500,500,0)
@@ -133,7 +133,7 @@ TEST_CASE("solveRe computes correct bistatic power for isotropic antennas", "[si
 TEST_CASE("CW streaming reflected path gates schedules by retarded transmit time",
 		  "[simulation][channel_model][reflected]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setC(100.0);
 
@@ -181,7 +181,7 @@ TEST_CASE("CW streaming reflected path gates schedules by retarded transmit time
 TEST_CASE("FMCW monostatic reflected path dechirps to expected stationary-target beat frequency",
 		  "[simulation][channel_model][reflected][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1.0e6);
 	params::setSimSamplingRate(1.0e6);
@@ -251,7 +251,7 @@ TEST_CASE("FMCW monostatic reflected path dechirps to expected stationary-target
 TEST_CASE("FMCW native dechirp convention produces positive up-chirp beat frequency",
 		  "[simulation][channel_model][reflected][fmcw][dechirp]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1.0e6);
 	params::setSimSamplingRate(1.0e6);
@@ -323,7 +323,7 @@ TEST_CASE("FMCW native dechirp convention produces positive up-chirp beat freque
 TEST_CASE("FMCW physical dechirp preserves timing decorrelation while ideal mode removes it",
 		  "[simulation][channel_model][reflected][fmcw][dechirp]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(2.0e6);
 	params::setSimSamplingRate(2.0e6);
@@ -390,7 +390,7 @@ TEST_CASE("FMCW physical dechirp preserves timing decorrelation while ideal mode
 TEST_CASE("FMCW down-chirp monostatic reflected path reverses stationary-target beat sign",
 		  "[simulation][channel_model][reflected][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1.0e6);
 	params::setSimSamplingRate(1.0e6);
@@ -461,7 +461,7 @@ TEST_CASE("FMCW down-chirp monostatic reflected path reverses stationary-target 
 TEST_CASE("FMCW chirp-boundary tracker matches cold-path direct contribution across chirps",
 		  "[simulation][channel_model][direct][fmcw]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setRate(1.0e6);
 	params::setSimSamplingRate(1.0e6);
@@ -518,7 +518,7 @@ TEST_CASE("FMCW chirp-boundary tracker matches cold-path direct contribution acr
 
 TEST_CASE("solveRe power scales linearly with RCS", "[simulation][channel_model][reflected]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	// RCS is a linear multiplier in the bistatic equation
@@ -582,7 +582,7 @@ TEST_CASE("solveRe power scales linearly with RCS", "[simulation][channel_model]
 
 TEST_CASE("solveRe delay is sum of Tx-Tgt and Tgt-Rx distances divided by c", "[simulation][channel_model][reflected]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	const RealType c = params::c();
@@ -628,7 +628,7 @@ TEST_CASE("solveRe delay is sum of Tx-Tgt and Tgt-Rx distances divided by c", "[
 
 TEST_CASE("solveRe with noproploss flag ignores distance in power", "[simulation][channel_model][reflected]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	const RealType c = params::c();
@@ -674,7 +674,7 @@ TEST_CASE("solveRe with noproploss flag ignores distance in power", "[simulation
 
 TEST_CASE("solveRe power follows R^-4 for monostatic geometry", "[simulation][channel_model][reflected]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	// For monostatic-like geometry (Tx and Rx co-located, target along x-axis):
@@ -749,7 +749,7 @@ TEST_CASE("solveRe power follows R^-4 for monostatic geometry", "[simulation][ch
 TEST_CASE("calculateReflectedPathContribution amplitude matches bistatic equation with signal power",
 		  "[simulation][channel_model][reflected]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	const RealType c = params::c();
@@ -802,7 +802,7 @@ TEST_CASE("calculateReflectedPathContribution amplitude matches bistatic equatio
 TEST_CASE("calculateReflectedPathContribution phase matches bistatic propagation delay",
 		  "[simulation][channel_model][reflected]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	const RealType c = params::c();
@@ -861,7 +861,7 @@ TEST_CASE("calculateReflectedPathContribution phase matches bistatic propagation
 TEST_CASE("calculateReflectedPathContribution preserves stronger phase-noise cancellation for shorter delays",
 		  "[simulation][channel_model][reflected]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setTime(0.0, 1.0);
 	params::setRate(10.0);
@@ -923,7 +923,7 @@ TEST_CASE("calculateReflectedPathContribution preserves stronger phase-noise can
 
 TEST_CASE("solveRe with 3D geometry computes correct bistatic range", "[simulation][channel_model][reflected]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 
 	const RealType c = params::c();

--- a/packages/libfers/tests/simulation/test_channel_model_response.cpp
+++ b/packages/libfers/tests/simulation/test_channel_model_response.cpp
@@ -30,6 +30,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/packages/libfers/tests/simulation/test_channel_model_response.cpp
+++ b/packages/libfers/tests/simulation/test_channel_model_response.cpp
@@ -62,7 +62,7 @@ namespace
 TEST_CASE("calculateResponse returns nullptr when Tx and Rx share same platform (direct path)",
 		  "[simulation][channel_model][response]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setSimSamplingRate(1000.0);
 
@@ -93,7 +93,7 @@ TEST_CASE("calculateResponse returns nullptr when Tx and Rx share same platform 
 TEST_CASE("calculateResponse returns nullptr when Tx is attached to Rx (monostatic, direct path)",
 		  "[simulation][channel_model][response]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setSimSamplingRate(1000.0);
 
@@ -129,7 +129,7 @@ TEST_CASE("calculateResponse returns nullptr when Tx is attached to Rx (monostat
 TEST_CASE("calculateResponse returns nullptr for reflected path when target co-located with Tx",
 		  "[simulation][channel_model][response]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setSimSamplingRate(1000.0);
 
@@ -165,7 +165,7 @@ TEST_CASE("calculateResponse returns nullptr for reflected path when target co-l
 TEST_CASE("calculateResponse returns nullptr for reflected path when target co-located with Rx",
 		  "[simulation][channel_model][response]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setSimSamplingRate(1000.0);
 
@@ -205,7 +205,7 @@ TEST_CASE("calculateResponse returns nullptr for reflected path when target co-l
 TEST_CASE("calculateResponse direct path produces non-null response with interp points",
 		  "[simulation][channel_model][response]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setSimSamplingRate(1000.0); // 1000 samples/sec
 
@@ -246,7 +246,7 @@ TEST_CASE("calculateResponse direct path produces non-null response with interp 
 
 TEST_CASE("calculateResponse reflected path produces valid response", "[simulation][channel_model][response]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setSimSamplingRate(1000.0);
 
@@ -290,7 +290,7 @@ TEST_CASE("calculateResponse reflected path produces valid response", "[simulati
 TEST_CASE("calculateResponse direct path interp points have consistent Friis power",
 		  "[simulation][channel_model][response]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setSimSamplingRate(10000.0); // High sample rate for many points
 
@@ -338,7 +338,7 @@ TEST_CASE("calculateResponse direct path interp points have consistent Friis pow
 
 TEST_CASE("calculateResponse exposes transmitter id", "[simulation][channel_model][response]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::params.reset();
 	params::setSimSamplingRate(1000.0);
 

--- a/packages/libfers/tests/test_main.cpp
+++ b/packages/libfers/tests/test_main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char* argv[])
 	logging::logger.setLevel(testLogLevel);
 
 	// Run the Catch2 test session
-	int result = Catch::Session().run(argc, argv);
+	int const result = Catch::Session().run(argc, argv);
 
 	return result;
 }

--- a/packages/libfers/tests/test_main.cpp
+++ b/packages/libfers/tests/test_main.cpp
@@ -41,8 +41,7 @@ int main(int argc, char* argv[])
 		testLogLevel = levelFromString(env_level);
 		if (testLogLevel != logging::Level::OFF)
 		{
-			std::cout << "[Test Runner] Overriding log level to: " << logging::getLevelString(testLogLevel)
-					  << std::endl;
+			std::cout << "[Test Runner] Overriding log level to: " << logging::getLevelString(testLogLevel) << '\n';
 		}
 	}
 

--- a/packages/libfers/tests/test_main.cpp
+++ b/packages/libfers/tests/test_main.cpp
@@ -10,7 +10,7 @@
 #include "core/logging.h"
 
 // Helper to parse log level from an environment variable string
-logging::Level levelFromString(std::string_view levelStr)
+static logging::Level levelFromString(std::string_view levelStr)
 {
 	if (levelStr == "TRACE")
 		return logging::Level::TRACE;

--- a/packages/libfers/tests/test_main.cpp
+++ b/packages/libfers/tests/test_main.cpp
@@ -36,6 +36,7 @@ int main(int argc, char* argv[])
 
 	// Allow overriding the log level with an environment variable for debugging.
 	// Example: FERS_TEST_LOG_LEVEL=DEBUG ctest -R my_failing_test
+	// NOLINTNEXTLINE(concurrency-mt-unsafe): Test runner reads environment before tests start worker threads.
 	if (const char* env_level = std::getenv("FERS_TEST_LOG_LEVEL"))
 	{
 		testLogLevel = levelFromString(env_level);

--- a/packages/libfers/tests/timing/test_prototype_timing.cpp
+++ b/packages/libfers/tests/timing/test_prototype_timing.cpp
@@ -8,7 +8,7 @@ using Catch::Matchers::WithinAbs;
 TEST_CASE("PrototypeTiming stores basic metadata", "[timing][prototype]")
 {
 	const SimId id = 12345;
-	timing::PrototypeTiming proto("reference", id);
+	timing::PrototypeTiming const proto("reference", id);
 
 	REQUIRE(proto.getName() == "reference");
 	REQUIRE(proto.getId() == id);

--- a/packages/libfers/tests/timing/test_prototype_timing.cpp
+++ b/packages/libfers/tests/timing/test_prototype_timing.cpp
@@ -47,8 +47,8 @@ TEST_CASE("PrototypeTiming manages offsets and noise parameters", "[timing][prot
 	REQUIRE(proto.getPhaseOffset().has_value());
 	REQUIRE(proto.getRandomFreqOffsetStdev().has_value());
 	REQUIRE(proto.getRandomPhaseOffsetStdev().has_value());
-	REQUIRE_THAT(proto.getFreqOffset().value(), WithinAbs(0.25, 1e-12));
-	REQUIRE_THAT(proto.getPhaseOffset().value(), WithinAbs(-0.5, 1e-12));
+	REQUIRE_THAT(proto.getFreqOffset().value_or(0.0), WithinAbs(0.25, 1e-12));
+	REQUIRE_THAT(proto.getPhaseOffset().value_or(0.0), WithinAbs(-0.5, 1e-12));
 }
 
 TEST_CASE("PrototypeTiming allows clearing optional parameters and updating name", "[timing][prototype]")

--- a/packages/libfers/tests/timing/test_timing.cpp
+++ b/packages/libfers/tests/timing/test_timing.cpp
@@ -39,7 +39,7 @@ TEST_CASE("Timing defaults to disabled", "[timing]")
 
 TEST_CASE("Timing initializes model and produces deterministic offsets", "[timing]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 
 	timing::PrototypeTiming proto("clock", 77);
@@ -67,7 +67,7 @@ TEST_CASE("Timing initializes model and produces deterministic offsets", "[timin
 
 TEST_CASE("Timing applies random frequency and phase offsets", "[timing]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 
 	const unsigned seed = 4242;
@@ -99,7 +99,7 @@ TEST_CASE("Timing applies random frequency and phase offsets", "[timing]")
 
 TEST_CASE("Timing handles zero frequency initialization", "[timing]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 
 	timing::PrototypeTiming proto("zero");
@@ -117,7 +117,7 @@ TEST_CASE("Timing handles zero frequency initialization", "[timing]")
 
 TEST_CASE("Timing reports disabled when no offsets or noise", "[timing]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 
 	timing::PrototypeTiming proto("quiet");
@@ -132,14 +132,14 @@ TEST_CASE("Timing reports disabled when no offsets or noise", "[timing]")
 
 TEST_CASE("Timing clone requires initialized prototype", "[timing]")
 {
-	timing::Timing timing_source("clock", 11, 5);
+	timing::Timing const timing_source("clock", 11, 5);
 
 	REQUIRE_THROWS_AS(timing_source.clone(), std::logic_error);
 }
 
 TEST_CASE("Timing clone reproduces prototype behavior", "[timing]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 
 	timing::PrototypeTiming proto("cloneable", 19);
@@ -165,7 +165,7 @@ TEST_CASE("Timing clone reproduces prototype behavior", "[timing]")
 
 TEST_CASE("Timing initializeModel is idempotent", "[timing]")
 {
-	ParamGuard guard;
+	ParamGuard const guard;
 	params::setRate(1000.0);
 
 	timing::PrototypeTiming proto_a("clock", 3);
@@ -191,6 +191,6 @@ TEST_CASE("Timing initializeModel is idempotent", "[timing]")
 
 TEST_CASE("Timing exposes initial seed", "[timing]")
 {
-	timing::Timing timing_source("clk", 54321, 9);
+	timing::Timing const timing_source("clk", 54321, 9);
 	REQUIRE(timing_source.getSeed() == 54321);
 }

--- a/packages/libfers/tests/timing/test_timing.cpp
+++ b/packages/libfers/tests/timing/test_timing.cpp
@@ -15,6 +15,10 @@ namespace
 	{
 		params::Parameters saved;
 		ParamGuard() : saved(params::params) {}
+		ParamGuard(const ParamGuard&) = delete;
+		ParamGuard& operator=(const ParamGuard&) = delete;
+		ParamGuard(ParamGuard&&) = delete;
+		ParamGuard& operator=(ParamGuard&&) = delete;
 		~ParamGuard() { params::params = saved; }
 	};
 

--- a/scripts/run_tests_gen_coverage.sh
+++ b/scripts/run_tests_gen_coverage.sh
@@ -12,18 +12,7 @@ readonly LCOV_IGNORE_ERRORS="source,gcov,negative,inconsistent,inconsistent"
 readonly GENHTML_IGNORE_ERRORS="source,inconsistent,inconsistent"
 
 TESTS_ONLY=false
-
-# --- argument parsing ---
-for arg in "$@"; do
-	case "$arg" in
-		--tests-only)
-			TESTS_ONLY=true
-			;;
-		*)
-			die "unknown argument: $arg"
-			;;
-	esac
-done
+SHOW_PASSING=false
 
 die() {
 	printf 'Error: %s\n' "$*" >&2
@@ -41,12 +30,135 @@ require_cmd() {
 	command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
 }
 
+print_failed_ctest_output() {
+	local log_file="$1"
+
+	awk '
+		function is_result_line(line) {
+			return line ~ /^[[:space:]]*[0-9]+\/[0-9]+ Test[[:space:]]+#[0-9]+:/
+		}
+
+		function is_boundary(line) {
+			return line ~ /^Test project / ||
+				line ~ /^[[:space:]]*Start[[:space:]][0-9]+:/ ||
+				is_result_line(line) ||
+				line ~ /^[[:space:]]*[0-9]+% tests passed/ ||
+				line ~ /^Total Test time/ ||
+				line ~ /^The following tests FAILED:/ ||
+				line ~ /^Errors while running CTest/
+		}
+
+		/\*\*\*(Failed|Timeout|Not Run|Exception|SEGFAULT|Subprocess aborted)/ {
+			if (printed) {
+				print ""
+			}
+			print
+			capturing_failure = 1
+			printed = 1
+			next
+		}
+
+		/^The following tests FAILED:/ {
+			if (printed) {
+				print ""
+			}
+			print
+			capturing_failure = 0
+			capturing_failed_list = 1
+			printed = 1
+			next
+		}
+
+		capturing_failed_list {
+			if ($0 ~ /^Errors while running CTest/) {
+				next
+			}
+			print
+			next
+		}
+
+		capturing_failure {
+			if (is_boundary($0)) {
+				capturing_failure = 0
+				next
+			}
+			print
+		}
+
+		END {
+			exit printed ? 0 : 1
+		}
+	' "$log_file" >&2
+}
+
+run_ctest_failed_only() {
+	local log_file
+	local exit_code
+
+	log_file="$(mktemp "${TMPDIR:-/tmp}/fers-ctest.XXXXXX")" || die "failed to create CTest log file"
+
+	set +e
+	ctest --preset=coverage --parallel --output-on-failure >"$log_file" 2>&1
+	exit_code=$?
+	set -e
+
+	if [ "$exit_code" -ne 0 ]; then
+		print_failed_ctest_output "$log_file" || {
+			printf 'CTest failed before reporting failed tests:\n' >&2
+			sed -n '1,200p' "$log_file" >&2
+		}
+	fi
+
+	rm -f "$log_file"
+	return "$exit_code"
+}
+
+run_ctest_show_passing() {
+	local exit_code
+
+	set +e
+	ctest --preset=coverage --parallel --output-on-failure
+	exit_code=$?
+	set -e
+
+	return "$exit_code"
+}
+
+run_ctest() {
+	if [ "$SHOW_PASSING" = true ]; then
+		run_ctest_show_passing
+	else
+		run_ctest_failed_only
+	fi
+}
+
+# --- argument parsing ---
+for arg in "$@"; do
+	case "$arg" in
+		--tests-only)
+			TESTS_ONLY=true
+			;;
+		--show-passing)
+			SHOW_PASSING=true
+			;;
+		*)
+			die "unknown argument: $arg"
+			;;
+	esac
+done
+
 trap on_err ERR
 
 # Only require lcov/genhtml if we actually use them
 for cmd in cmake ctest; do
 	require_cmd "$cmd"
 done
+
+if [ "$SHOW_PASSING" = false ]; then
+	for cmd in awk mktemp sed; do
+		require_cmd "$cmd"
+	done
+fi
 
 if [ "$TESTS_ONLY" = false ]; then
 	for cmd in lcov genhtml; do
@@ -58,7 +170,7 @@ cd "$REPO_ROOT"
 
 cmake --preset=coverage
 cmake --build --preset=coverage --parallel
-ctest --preset=coverage --parallel
+run_ctest || exit "$?"
 
 # --- early exit if tests-only ---
 if [ "$TESTS_ONLY" = true ]; then


### PR DESCRIPTION
This pull request tightens the FERS code-quality baseline, cleans up the resulting hotspots across `libfers`, the CLI, VITA 49 streaming, and the test suite, and fixes a UI gap around target/RCS editing. The diff is primarily a behavior-preserving refactor, with focused fixes for receiver stream defaults, coverage test output, and platform component visibility in the scene tree.

### Key Changes

**1. Strict Clang-Tidy Baseline & C++ Modernization**
*   **Restored Complexity Threshold:** Reinstated the default `readability-function-cognitive-complexity` threshold of 25 and updated `clangtidy:run` to use the coverage build directory so diagnostics match the actively tested configuration.
*   **Targeted Warning Cleanup:** Addressed clang-tidy findings across `libfers`, including const-correct locals, explicit special members for RAII guards, scoped locks, range algorithms, initialized fields, enum sizing, optional guards, and widened arithmetic before sample-count multiplication.
*   **C API & CLI Ownership Cleanup:** Reworked repeated raw cleanup paths into small RAII/helper structures and documented intentional public-ABI ownership boundaries with focused `NOLINT` annotations.

**2. Simulation, Serialization, and Output Pipeline Refactoring**
*   **Simulation Hotspot Decomposition:** Split large helpers in simulation threading, world updates, channel preview-link generation, finalizer streaming metadata, and FMCW IF resampler setup while preserving existing simulation behavior.
*   **Serializer & Parser Cleanup:** Broke down JSON/XML parsing and serialization helpers, KML antenna visualization logic, XML antenna gain loading, and rotation-unit warning inference into smaller, testable functions.
*   **VITA 49 Stream Robustness:** Cleaned up packetization and serializer request plumbing, default-initialized receiver stream metadata fields, and moved UDP address ownership to RAII-managed storage with Windows-specific socket casting handled explicitly.

**3. CLI and Test Tooling**
*   **CLI Runner Refactor:** Deduplicated VITA 49 value-option parsing and split logging, scenario loading, output directory setup, KML generation, and simulation execution into focused helper functions.
*   **Cleaner CTest Failures:** Updated `scripts/run_tests_gen_coverage.sh` to print only failing CTest output by default, while preserving full output through `--show-passing` and keeping the existing `--tests-only` path.
*   **Coverage-Oriented Tooling:** Aligned the clang-tidy command with the coverage preset and kept the coverage script's `lcov`/`genhtml` error handling intact.

**4. Test Suite Cleanup and Regression Coverage**
*   **Reusable Test Helpers:** Refactored high-churn API preview, JSON serializer, XML parser, VITA 49, finalizer, and channel-model tests into smaller helper functions to keep the stricter complexity baseline enforceable.
*   **FMCW & VITA 49 Checks:** Strengthened checks around FMCW chirp direction round-trips, VITA 49 context metadata and packet padding, packet caps, paced sender behavior, and receiver stream default fields.
*   **Preview Link Validation:** Expanded preview-link assertions for label termination, finite display values, and expected transmitter/receiver/target link IDs across bistatic and monostatic scenarios.

**5. FERS-UI Target RCS Controls**
*   **Scene Tree Components:** Expanded the scene tree so platform components render under their platforms with type-specific icons, selectable item IDs, and remove actions.
*   **Target RCS File Picker:** Restricted target RCS file selection to XML assets, matching the standalone target RCS schema workflow.
