### PR TITLE
feat(sfcw): add native stepped frequency mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 build_cov/
 fixes.yaml
 .codex
+.agents
 .code-review-graph/
 .code-review-graphignore
 .mcp.json

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ semi-independent packages.
   simulation of both pulsed and continuous-wave scenarios, with optimized multithreading.
 - **Visual Scenario Builder:** An intuitive 3D interface to construct, configure, and visualize radar scenarios.
 - **Flexible System Modeling:** Simulate a wide range of radar systems, including monostatic, multistatic, pulsed,
-  continuous wave (CW), and native FMCW streaming modes.
+  continuous wave (CW), native FMCW streaming, and native stepped-frequency continuous-wave (SFCW) modes.
 - **Advanced Data Export:** Output simulation data in HDF5 format for analysis.
 - **Geographic Visualization:** Generate KML files from scenarios for accurate visualization in tools like Google Earth.
 - **Modern Documentation:** A continuously updated and
@@ -48,6 +48,7 @@ should rely on it for important results.
 | Pulsed radar | Stable | Verified |
 | CW radar | Beta | Unverified |
 | FMCW radar | Alpha | Unverified |
+| SFCW radar | Alpha | Unverified |
 | Multimodal | Alpha | Unverified |
 | VITA 49.2 UDP output | Alpha | Unverified |
 | KML generation | Stable | Verified |

--- a/docs/wiki/Examples.md
+++ b/docs/wiki/Examples.md
@@ -74,6 +74,39 @@ python3 genpulse.py
 ../../build/release/packages/fers-cli/fers-cli example.fersxml --out-dir=. --vita49 127.0.0.1:4991 --vita49-fullscale 1.0 --log-level=INFO -n=2
 ```
 
+## SFCW Monostatic
+
+Directory:
+
+```text
+examples/sfcw_monostatic
+```
+
+This scenario contains one monostatic stepped-frequency continuous-wave radar, one static point target, and a finite stepped-frequency sweep.
+
+Run it:
+
+```bash
+cd examples/sfcw_monostatic
+../../build/release/packages/fers-cli/fers-cli example.fersxml --out-dir=. --log-level=INFO -n=2
+python3 analysis.py
+```
+
+Expected generated files:
+
+```text
+SfcwRadar_results.h5
+sfcw_range_profile.png
+sfcw_analysis_summary.json
+```
+
+What to look at:
+
+- The waveform uses `<stepped_frequency>`.
+- The monostatic radar uses `<sfcw_mode/>`.
+- The output metadata includes `sfcw` and `sfcw_sources` blocks with first/last RF frequency, effective bandwidth, range resolution, unambiguous range, sweep count, and emitted step counts.
+- `analysis.py` samples each SFCW dwell, forms an IFFT range profile, and checks the peak against the target range.
+
 ## FMCW Monostatic Dechirp
 
 Directory:

--- a/docs/wiki/FERS-CLI.md
+++ b/docs/wiki/FERS-CLI.md
@@ -52,6 +52,12 @@ Run an FMCW example into a separate output folder:
 ./build/release/packages/fers-cli/fers-cli examples/fmcw_monostatic_dechirp/example.fersxml --out-dir=./results --log-level=INFO -n=4
 ```
 
+Run an SFCW example:
+
+```bash
+./build/release/packages/fers-cli/fers-cli examples/sfcw_monostatic/example.fersxml --out-dir=. --log-level=INFO
+```
+
 Export KML for a scenario:
 
 ```bash

--- a/docs/wiki/FERS-UI.md
+++ b/docs/wiki/FERS-UI.md
@@ -153,8 +153,11 @@ Waveform editing supports:
 - CW waveforms.
 - FMCW linear chirps.
 - FMCW triangular chirps.
+- SFCW stepped-frequency sweeps.
 
 For FMCW waveforms, the UI warns or blocks when settings violate major FMCW constraints, such as chirp period shorter than chirp duration or a baseband sweep edge too close to the effective sample-rate limit `<rate> * <oversample>`.
+
+For SFCW waveforms, the UI validates step count, step size, dwell time, step period, optional sweep count, and whether the generated RF steps remain positive.
 
 ### Timings
 
@@ -204,7 +207,7 @@ For static motion or rotation, the UI uses the first waypoint. Use linear or cub
 Monostatic radars, transmitters, and receivers share common fields:
 
 - Component name.
-- Radar mode: pulsed, CW, or FMCW.
+- Radar mode: pulsed, CW, FMCW, or SFCW.
 - Compatible waveform selection.
 - Antenna selection.
 - Timing source selection.
@@ -233,6 +236,10 @@ For FMCW receivers and monostatic radars, the UI supports:
 IF settings are valid only when dechirping is enabled. If dechirping is enabled without an IF sample rate, FERS writes legacy full-rate IF output at `<rate> * <oversample>`. If an IF sample rate is provided, it is receiver-local and must be no higher than `<rate> * <oversample>`.
 
 The UI blocks simulations and KML generation when it detects invalid FMCW settings that would fail later.
+
+### SFCW Receiver Settings
+
+SFCW transmitters, receivers, and monostatic radars use `<sfcw_mode/>`. There are no receiver-local LO/dechirp controls in the first native implementation; the step timing and RF values come from the attached or referenced `<stepped_frequency>` waveform.
 
 ### Targets
 
@@ -302,6 +309,7 @@ The output metadata table shows:
 - Pulse count or streaming segment summary.
 - Output file path.
 - FMCW details when available.
+- SFCW details when available, including effective bandwidth, range resolution, unambiguous range, and emitted step counts.
 
 Use `Export JSON` to save the output metadata beside the generated HDF5 files.
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -11,6 +11,7 @@ FERS can model:
 - Pulsed radar using complex baseband waveform files.
 - Continuous-wave radar.
 - FMCW linear chirps and triangular chirps.
+- Stepped-frequency continuous-wave radar.
 - Monostatic radars, where the transmitter and receiver are attached to the same platform.
 - Bistatic or multistatic layouts, where transmitters, receivers, and targets are on separate moving platforms.
 - Multiple transmitters, receivers, radars, and targets in the same scenario.
@@ -34,6 +35,7 @@ Current limitations to keep in mind:
 - Clutter and environmental propagation effects are not modeled as first-class scenario objects.
 - Target shape is represented through RCS values or RCS pattern files, not physical meshes.
 - Built-in FMCW support is available but still marked alpha in the project README.
+- Built-in SFCW support is available but still marked alpha in the project README.
 - CW support is available but still marked beta in the project README.
 - VITA 49.2 UDP output support is available but still marked Alpha and Unverified in the project README.
 - The XML schema validates structure, but some physical limits are checked only when FERS loads or runs the scenario.
@@ -61,11 +63,11 @@ Current limitations to keep in mind:
 - [[libfers]]: when and how to use the FERS library from another application.
 - [[XML Schema Reference]]: every XML element, attribute, parameter, unit, and practical caveat.
 - [[Examples]]: walkthroughs of the scenarios in the `examples/` directory.
-- [[Simulation Pipelines]]: Mermaid diagrams showing how FERS runs pulsed, CW, and FMCW simulations.
+- [[Simulation Pipelines]]: Mermaid diagrams showing how FERS runs pulsed, CW, FMCW, and SFCW simulations.
 
 ## Migrating Old Scenarios
 
-Older FERS XML used names such as `<pulse>`, `pulse="..."`, and inline radar mode attributes. Current FERS uses `<waveform>`, `waveform="..."`, and explicit mode blocks such as `<pulsed_mode>`, `<cw_mode>`, and `<fmcw_mode>`.
+Older FERS XML used names such as `<pulse>`, `pulse="..."`, and inline radar mode attributes. Current FERS uses `<waveform>`, `waveform="..."`, and explicit mode blocks such as `<pulsed_mode>`, `<cw_mode>`, `<fmcw_mode>`, and `<sfcw_mode>`.
 
 Use the migration script as a starting point:
 

--- a/docs/wiki/Simulation-Pipelines.md
+++ b/docs/wiki/Simulation-Pipelines.md
@@ -88,10 +88,35 @@ Events include:
 
 - Pulsed transmitter pulse starts.
 - Pulsed receiver window starts and ends.
-- CW/FMCW transmitter streaming starts and ends.
-- CW/FMCW receiver streaming starts and ends.
+- CW/FMCW/SFCW transmitter streaming starts and ends.
+- CW/FMCW/SFCW receiver streaming starts and ends.
 
 Schedules control when these events are created.
+
+## SFCW Streaming Pipeline
+
+Stepped-frequency continuous-wave radar uses the same streaming event path as CW and raw FMCW, but the active RF frequency changes at each configured step.
+
+```mermaid
+flowchart TD
+    A[Stepped-frequency waveform] --> B[Active schedule period starts]
+    B --> C[Create one SFCW streaming source]
+    C --> D[For each receiver sample and path, compute retarded transmit time]
+    D --> E[Select active RF step from dwell/step timing]
+    E --> F[Use step RF for phase, wavelength, antenna gain, and path power]
+    F --> G[Write I_data and Q_data]
+    G --> H[Store SFCW metadata and emitted step counts]
+```
+
+Important SFCW settings:
+
+| Setting | Effect |
+| --- | --- |
+| `<step_size>` | RF spacing between consecutive dwells. Its magnitude controls unambiguous range. |
+| `<step_count>` | Number of frequency steps in one sweep. Together with `abs(step_size)`, it controls effective bandwidth. |
+| `<dwell_time>` | Active transmit time inside each step period. |
+| `<step_period>` | Time from one step start to the next. Larger values introduce silent gaps. |
+| `<sweep_count>` | Optional finite number of sweeps per active schedule period. |
 
 ## Pulsed Radar Pipeline
 

--- a/docs/wiki/Using-FERS.md
+++ b/docs/wiki/Using-FERS.md
@@ -44,6 +44,7 @@ The complete XML reference is in [[XML Schema Reference]].
 | Pulsed | You have a pulse waveform and want range-gated receiver windows. | `<pulsed_from_file>`, `<pulsed_mode>`, `prf`, `window_skip`, `window_length`. |
 | CW | You want continuous-wave Doppler-style output. | `<cw/>`, `<cw_mode/>`. |
 | FMCW | You want chirp-based ranging or range-Doppler analysis. | `<fmcw_linear_chirp>` or `<fmcw_triangle>`, `<fmcw_mode>`, optional dechirp settings. |
+| SFCW | You want stepped narrowband RF dwells that synthesize a wider range profile without one wide baseband waveform. | `<stepped_frequency>`, `<sfcw_mode/>`, step size/count, dwell time, and step period. |
 
 The waveform type and radar mode must match. For example, a `<cw/>` waveform must be used with `<cw_mode/>`.
 
@@ -77,7 +78,7 @@ chunk_000001_Q
 
 Each chunk represents one receiver window. Use `window_skip` and `window_length` from the scenario, plus the metadata stored in the HDF5 file, to convert samples to range.
 
-### CW And FMCW Output
+### CW, FMCW, And SFCW Output
 
 Streaming receivers write:
 
@@ -86,7 +87,7 @@ I_data
 Q_data
 ```
 
-For FMCW with dechirping enabled, these datasets contain the dechirped IF output. Without dechirping, they contain the received complex baseband signal.
+For FMCW with dechirping enabled, these datasets contain the dechirped IF output. Without dechirping, they contain the received complex baseband signal. SFCW output is raw streaming complex baseband; the HDF5 metadata records the step timing and RF frequencies needed for downstream range-profile reconstruction.
 
 ## Reconstruct Physical I/Q Values
 
@@ -112,7 +113,7 @@ with h5py.File("PulsedRadar_results.h5", "r") as h5:
 
 ## Metadata
 
-FERS stores metadata in the HDF5 output, including receiver mode, sample rates, sample counts, time span, fullscale values, and FMCW settings when applicable.
+FERS stores metadata in the HDF5 output, including receiver mode, sample rates, sample counts, time span, fullscale values, and FMCW or SFCW settings when applicable.
 
 Use the metadata whenever possible instead of hard-coding assumptions in analysis scripts.
 
@@ -122,12 +123,12 @@ The most important rates are:
 
 | Setting | Meaning |
 | --- | --- |
-| `<rate>` | Base output sample rate in Hz. Raw CW/FMCW streaming output is written at this rate. |
+| `<rate>` | Base output sample rate in Hz. Raw CW/FMCW/SFCW streaming output is written at this rate. |
 | `<simSamplingRate>` | Rate used for geometry interpolation in pulsed response generation. |
 | `<oversample>` | Internal oversampling multiplier. FMCW aliasing checks and legacy full-rate dechirped IF output use `<rate> * <oversample>`. |
 | `<if_sample_rate>` | Optional receiver-local FMCW IF output rate after dechirping and resampling. |
 
-Use a high enough `<rate>` and `<oversample>` to represent the signal bandwidth you expect. For FMCW, the waveform definition must also satisfy the baseband sweep-edge checks described in [[XML Schema Reference]].
+Use a high enough `<rate>` and `<oversample>` to represent the signal bandwidth you expect. For FMCW, the waveform definition must also satisfy the baseband sweep-edge checks described in [[XML Schema Reference]]. For SFCW, `<rate>` must be high enough to capture the dwell intervals you want to analyze; the wide effective bandwidth comes from RF step metadata, not a wide instantaneous baseband waveform.
 
 ## Validation
 
@@ -172,6 +173,7 @@ If KML generation fails, `fers-cli` exits with a nonzero status and logs the rea
 | Output is all zeros | Receiver schedule/window may miss the return, antenna pointing may be wrong, target may be outside the simulated time span, or path loss may make the signal very small. |
 | Pulsed range looks offset | Check `window_skip`, `window_length`, waveform sample rate, and speed of propagation `c`. |
 | FMCW run fails validation | Check chirp bandwidth, chirp duration, chirp period, count fields, `start_frequency_offset`, `<rate>`, `<oversample>`, and IF-chain settings. |
+| SFCW run fails validation | Check `step_size`, `step_count`, `dwell_time`, `step_period`, `sweep_count`, and that every RF step remains positive. |
 | KML looks wrong geographically | Check KML/geospatial `<origin>`, `<coordinatesystem>`, UTM zone, and hemisphere. |
 
 ## Old XML Files

--- a/docs/wiki/VITA49-Streaming-Implementation.md
+++ b/docs/wiki/VITA49-Streaming-Implementation.md
@@ -295,6 +295,7 @@ Context flag bits:
 | `5` | `ContextFlagFmcwMetadataPresent` | FMCW metadata is present and allowed by receiver mode. |
 | `6` | `ContextFlagCwMetadataPresent` | CW metadata is present and allowed by receiver mode. |
 | `7` | `ContextFlagPulsedMetadataPresent` | Pulsed metadata is present and allowed by receiver mode. |
+| `8` | `ContextFlagSfcwMetadataPresent` | SFCW metadata is present and allowed by receiver mode. |
 
 ## Context ASCII JSON
 
@@ -342,6 +343,7 @@ The context ASCII metadata JSON always includes:
 - `pulsed`
 - `cw`
 - `fmcw`
+- `sfcw`
 
 The serializer follows the receiver mode when stale mode blocks are present. For example, if receiver mode is `cw`, CW metadata is emitted and stale FMCW metadata is not emitted.
 
@@ -397,6 +399,26 @@ The serializer follows the receiver mode when stale mode blocks are present. For
 - `dechirp_reference_transmitter_name`
 - `dechirp_reference_waveform_id`
 - `dechirp_reference_waveform_name`
+
+### SFCW Metadata
+
+`sfcw` contains:
+
+- `present`
+- `waveform_id`
+- `waveform_name`
+- `carrier_hz`
+- `start_frequency_offset_hz`
+- `step_size_hz`
+- `step_count`
+- `dwell_time_s`
+- `step_period_s`
+- `sweep_period_s`
+- `sweep_count`
+- `first_frequency_hz`
+- `last_frequency_hz`
+- `frequency_span_hz`
+- `effective_bandwidth_hz`
 
 ## Final Output Metadata
 

--- a/docs/wiki/XML-Schema-Reference.md
+++ b/docs/wiki/XML-Schema-Reference.md
@@ -60,7 +60,7 @@ Required children, in order:
 | --- | --- | --- |
 | `<starttime>` | seconds | Start time of the simulation. Usually `0`. |
 | `<endtime>` | seconds | End time of the simulation. Must be after `starttime`. |
-| `<rate>` | Hz | Base output sample rate. Raw CW/FMCW streaming output is written at this rate. Dechirped FMCW without `<if_sample_rate>` is written at the effective simulation rate, `<rate> * <oversample>`. Dechirped FMCW with `<if_sample_rate>` is written at the realized IF output rate. |
+| `<rate>` | Hz | Base output sample rate. Raw CW/FMCW/SFCW streaming output is written at this rate. Dechirped FMCW without `<if_sample_rate>` is written at the effective simulation rate, `<rate> * <oversample>`. Dechirped FMCW with `<if_sample_rate>` is written at the realized IF output rate. |
 
 Optional children, in order:
 
@@ -148,6 +148,7 @@ Then choose exactly one waveform type:
 - `<cw/>`.
 - `<fmcw_linear_chirp>`.
 - `<fmcw_triangle>`.
+- `<stepped_frequency>`.
 
 The chosen waveform type must match the radar mode that uses it.
 
@@ -181,6 +182,44 @@ Use this for continuous-wave simulation.
 ```
 
 There are no child parameters. The signal is a continuous tone at the chosen carrier frequency.
+
+### `<stepped_frequency>`
+
+Use this for native stepped-frequency continuous-wave operation. The transmitter emits narrowband CW dwells at a sequence of RF frequencies instead of one wide instantaneous baseband waveform.
+
+```xml
+<stepped_frequency>
+    <start_frequency_offset>-1.5e9</start_frequency_offset>
+    <step_size>3.0e6</step_size>
+    <step_count>1000</step_count>
+    <dwell_time>2.0e-6</dwell_time>
+    <step_period>3.0e-6</step_period>
+    <sweep_count>1</sweep_count>
+</stepped_frequency>
+```
+
+| Element | Required | Unit | Meaning |
+| --- | --- | --- | --- |
+| `<start_frequency_offset>` | Yes | Hz | Offset from `<carrier_frequency>` for the first RF step. |
+| `<step_size>` | Yes | Hz | Frequency increment between adjacent steps. May be positive or negative, but not zero. |
+| `<step_count>` | Yes | count | Positive integer number of frequency steps in one sweep. |
+| `<dwell_time>` | Yes | seconds | Active transmit time within each step period. Must be positive. |
+| `<step_period>` | Yes | seconds | Time from one step start to the next. Must be positive and at least `dwell_time`. |
+| `<sweep_count>` | No | count | Positive integer maximum sweeps per active schedule period. If omitted, sweeps continue until the active period ends. |
+
+For every active schedule period, the SFCW sweep restarts at that period's start time. If `dwell_time` is less than `step_period`, the transmitter is silent between dwells.
+
+Derived values reported in metadata include:
+
+```text
+first_frequency = carrier_frequency + start_frequency_offset
+last_frequency = first_frequency + (step_count - 1) * step_size
+effective_bandwidth = step_count * abs(step_size)
+range_resolution = c / (2 * effective_bandwidth)
+unambiguous_range = c / (2 * abs(step_size))
+```
+
+FERS rejects SFCW waveforms with zero step size, non-positive counts or timing values, `dwell_time > step_period`, or any generated RF step at or below zero.
 
 ### `<fmcw_linear_chirp>`
 
@@ -471,6 +510,7 @@ Each transmitter, receiver, or monostatic radar chooses exactly one mode:
 - `<pulsed_mode>`.
 - `<cw_mode/>`.
 - `<fmcw_mode>`.
+- `<sfcw_mode/>`.
 
 The mode must match the waveform type.
 
@@ -511,6 +551,10 @@ No child parameters.
 ### Transmitter `<fmcw_mode>`
 
 No child parameters for transmitters. Dechirp and IF settings belong on receivers or monostatic radars.
+
+### Transmitter `<sfcw_mode/>`
+
+No child parameters. The transmitter must reference a `<stepped_frequency>` waveform.
 
 ## `<receiver>`
 
@@ -559,6 +603,10 @@ No child parameters.
 
 See the "FMCW Mode: Receiver And Monostatic" section below.
 
+### Receiver `<sfcw_mode/>`
+
+No child parameters in the first native implementation. The receiver writes raw streaming complex baseband; step timing and RF metadata come from active SFCW transmitters.
+
 ### `<noise_temp>`
 
 | Element | Unit | Default | Meaning |
@@ -596,6 +644,8 @@ Children:
 3. Optional `<schedule>`.
 
 Mode blocks are the same as receiver mode blocks, except that a monostatic pulsed mode also supplies the transmitter PRF.
+
+A monostatic `<sfcw_mode/>` must use a `<stepped_frequency>` waveform and writes raw streaming complex baseband with SFCW metadata in the result file.
 
 ## FMCW Mode: Receiver And Monostatic
 
@@ -795,6 +845,7 @@ The XML schema is intentionally simple, so some important checks happen when FER
 - FMCW count fields must be positive integers when present.
 - FMCW sweep edges, including `start_frequency_offset`, must fit the effective sample rate `<rate> * <oversample>`.
 - FMCW receiver IF-chain fields are allowed only when dechirping is enabled.
+- SFCW `step_size` must be nonzero, count fields must be positive integers, `dwell_time` must be no greater than `step_period`, and every emitted RF step must be positive.
 - Receiver noise temperature must not be negative.
 - UTM KML/geospatial export needs a valid zone and hemisphere.
 - File-backed waveform, antenna, and RCS assets must exist and match the expected file structure.

--- a/docs/wiki/libfers.md
+++ b/docs/wiki/libfers.md
@@ -104,6 +104,7 @@ After a run, applications can request JSON metadata describing the output files.
 - Sample counts.
 - Time span.
 - FMCW dechirp and IF settings, when applicable.
+- SFCW step timing, frequency, bandwidth, range, and emitted-step metadata, when applicable.
 - Fullscale information.
 
 Prefer this metadata over hard-coded output assumptions.

--- a/examples/sfcw_monostatic/analysis.py
+++ b/examples/sfcw_monostatic/analysis.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("MPLCONFIGDIR", str(Path(tempfile.gettempdir()) / "matplotlib"))
+
+import h5py
+import matplotlib
+import numpy as np
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+C = 299_792_458.0
+RESULT_FILE = "SfcwRadar_results.h5"
+PLOT_FILE = "sfcw_range_profile.png"
+SUMMARY_FILE = "sfcw_analysis_summary.json"
+
+TARGET_RANGE_M = 100.0
+STEP_COUNT = 16
+STEP_SIZE_HZ = 100_000.0
+DWELL_TIME_S = 1.0e-4
+STEP_PERIOD_S = 2.0e-4
+SWEEP_COUNT = 4
+
+
+def attr_text(attrs, name):
+    value = attrs[name]
+    return value.decode("utf-8") if isinstance(value, bytes) else value
+
+
+def load_iq(path):
+    if not path.exists():
+        raise FileNotFoundError(f"missing simulation output: {path}")
+
+    with h5py.File(path, "r") as h5:
+        fs = float(h5.attrs["sampling_rate"])
+        start_time = float(h5.attrs["start_time"])
+        fullscale = float(h5.attrs["fullscale"])
+        metadata = json.loads(attr_text(h5.attrs, "fers_metadata_json"))
+        iq = (h5["I_data"][:] + 1j * h5["Q_data"][:]) * fullscale
+
+        assert attr_text(h5.attrs, "data_mode") == "sfcw"
+        assert int(h5.attrs["sfcw_step_count"]) == STEP_COUNT
+        assert int(h5.attrs["sfcw_sweep_count"]) == SWEEP_COUNT
+        assert int(h5.attrs["sfcw_source_count"]) == 1
+        assert np.isclose(float(h5.attrs["sfcw_step_size"]), STEP_SIZE_HZ)
+        assert np.isclose(float(h5.attrs["sfcw_dwell_time"]), DWELL_TIME_S)
+        assert np.isclose(float(h5.attrs["sfcw_step_period"]), STEP_PERIOD_S)
+        assert metadata["mode"] == "sfcw"
+        assert metadata["sfcw"]["step_count"] == STEP_COUNT
+        assert metadata["sfcw"]["sweep_count"] == SWEEP_COUNT
+
+    if fullscale <= 0.0:
+        raise ValueError("simulation produced an all-zero SFCW result")
+    return iq, fs, start_time, fullscale, metadata
+
+
+def extract_step_samples(iq, fs, start_time):
+    delay = 2.0 * TARGET_RANGE_M / C
+    samples = np.zeros((SWEEP_COUNT, STEP_COUNT), dtype=np.complex128)
+    sweep_period = STEP_COUNT * STEP_PERIOD_S
+
+    for sweep in range(SWEEP_COUNT):
+        for step in range(STEP_COUNT):
+            t = sweep * sweep_period + step * STEP_PERIOD_S + delay + 0.5 * DWELL_TIME_S
+            index = int(round((t - start_time) * fs))
+            if index < 0 or index >= len(iq):
+                raise IndexError(f"step sample outside result: sweep={sweep}, step={step}, index={index}")
+            samples[sweep, step] = iq[index]
+
+    return samples
+
+
+def range_profile(step_response, nfft=1024):
+    profile = np.fft.ifft(step_response, n=nfft)
+    ranges = np.arange(nfft) * C / (2.0 * nfft * abs(STEP_SIZE_HZ))
+    magnitude_db = 20.0 * np.log10(np.abs(profile) + 1.0e-30)
+    magnitude_db -= float(np.max(magnitude_db))
+    return ranges, magnitude_db
+
+
+def make_plot(output_path, ranges, magnitude_db, estimated_range):
+    fig, ax = plt.subplots(figsize=(10, 5), constrained_layout=True)
+    ax.plot(ranges, magnitude_db)
+    ax.axvline(TARGET_RANGE_M, color="k", linestyle="--", label="target range")
+    ax.axvline(estimated_range, color="tab:red", linestyle=":", label="SFCW peak")
+    ax.set_xlim(0.0, 400.0)
+    ax.set_ylim(-60.0, 3.0)
+    ax.set_title("SFCW Range Profile")
+    ax.set_xlabel("Range (m)")
+    ax.set_ylabel("Relative magnitude (dB)")
+    ax.grid(True, alpha=0.35)
+    ax.legend()
+    fig.savefig(output_path, dpi=180)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze the monostatic SFCW example.")
+    parser.add_argument("--results-dir", type=Path, default=Path(__file__).resolve().parent)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    args = parser.parse_args()
+
+    results_dir = args.results_dir.resolve()
+    output_dir = (args.output_dir or results_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    iq, fs, start_time, fullscale, metadata = load_iq(results_dir / RESULT_FILE)
+    samples = extract_step_samples(iq, fs, start_time)
+    step_response = np.mean(samples, axis=0)
+    ranges, magnitude_db = range_profile(step_response)
+
+    peak_index = int(np.argmax(magnitude_db))
+    estimated_range = float(ranges[peak_index])
+    range_error = abs(estimated_range - TARGET_RANGE_M)
+    resolution = float(metadata["sfcw"]["range_resolution"])
+    unambiguous = float(metadata["sfcw"]["unambiguous_range"])
+
+    print("Monostatic SFCW verification")
+    print(f"Samples: {len(iq)} at {fs:.1f} Hz, fullscale={fullscale:.6e}")
+    print(f"Metadata mode: {metadata['mode']}")
+    print(f"Resolution / unambiguous range: {resolution:.3f} / {unambiguous:.3f} m")
+    print(f"Estimated target range: {estimated_range:.3f} m")
+    print(f"Range error: {range_error:.3f} m")
+
+    if range_error > 0.5 * resolution:
+        raise SystemExit("verification failed: SFCW range profile peak is not near the target")
+
+    plot_path = output_dir / PLOT_FILE
+    make_plot(plot_path, ranges, magnitude_db, estimated_range)
+    print(f"Saved {plot_path}")
+
+    summary = {
+        "mode": metadata["mode"],
+        "samples": int(len(iq)),
+        "sample_rate_hz": fs,
+        "target_range_m": TARGET_RANGE_M,
+        "estimated_range_m": estimated_range,
+        "range_error_m": range_error,
+        "range_resolution_m": resolution,
+        "unambiguous_range_m": unambiguous,
+        "effective_bandwidth_hz": float(metadata["sfcw"]["effective_bandwidth"]),
+    }
+    summary_path = output_dir / SUMMARY_FILE
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    print(f"Saved {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sfcw_monostatic/example.fersxml
+++ b/examples/sfcw_monostatic/example.fersxml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE simulation SYSTEM "fers-xml.dtd">
+<simulation name="SfcwMonostaticScenario">
+    <parameters>
+        <starttime>0.0</starttime>
+        <endtime>0.0128</endtime>
+        <rate>100000.0</rate>
+        <simSamplingRate>100000.0</simSamplingRate>
+        <randomseed>20260701</randomseed>
+        <adc_bits>12</adc_bits>
+    </parameters>
+
+    <antenna name="SfcwIsotropicAntenna" pattern="isotropic">
+        <efficiency>1.0</efficiency>
+    </antenna>
+
+    <waveform name="SfcwStepSweep">
+        <power>100.0</power>
+        <carrier_frequency>2.4e9</carrier_frequency>
+        <stepped_frequency>
+            <start_frequency_offset>-7.5e5</start_frequency_offset>
+            <step_size>1.0e5</step_size>
+            <step_count>16</step_count>
+            <dwell_time>1.0e-4</dwell_time>
+            <step_period>2.0e-4</step_period>
+            <sweep_count>4</sweep_count>
+        </stepped_frequency>
+    </waveform>
+
+    <timing name="SfcwClock">
+        <frequency>10.0e6</frequency>
+    </timing>
+
+    <platform name="SfcwRadarPlatform">
+        <motionpath interpolation="static">
+            <positionwaypoint>
+                <x>0.0</x>
+                <y>0.0</y>
+                <altitude>0.0</altitude>
+                <time>0.0</time>
+            </positionwaypoint>
+        </motionpath>
+        <fixedrotation>
+            <startazimuth>0.0</startazimuth>
+            <startelevation>0.0</startelevation>
+            <azimuthrate>0.0</azimuthrate>
+            <elevationrate>0.0</elevationrate>
+        </fixedrotation>
+        <monostatic name="SfcwRadar" antenna="SfcwIsotropicAntenna" waveform="SfcwStepSweep"
+                    timing="SfcwClock" nodirect="true">
+            <sfcw_mode/>
+            <noise_temp>0.0</noise_temp>
+        </monostatic>
+    </platform>
+
+    <platform name="SfcwTargetPlatform">
+        <motionpath interpolation="static">
+            <positionwaypoint>
+                <x>100.0</x>
+                <y>0.0</y>
+                <altitude>0.0</altitude>
+                <time>0.0</time>
+            </positionwaypoint>
+        </motionpath>
+        <fixedrotation>
+            <startazimuth>0.0</startazimuth>
+            <startelevation>0.0</startelevation>
+            <azimuthrate>0.0</azimuthrate>
+            <elevationrate>0.0</elevationrate>
+        </fixedrotation>
+        <target name="SfcwPointTarget">
+            <rcs type="isotropic">
+                <value>10.0</value>
+            </rcs>
+        </target>
+    </platform>
+</simulation>

--- a/packages/fers-cli/README.md
+++ b/packages/fers-cli/README.md
@@ -13,6 +13,7 @@ terminal and to maintain backward compatibility with the original FERS workflow.
 - Full access to all core `libfers` simulation capabilities.
 - Parses command-line arguments for simulation control.
 - Loads scenarios from FERS XML files.
+- Runs pulsed, CW, FMCW, and SFCW scenarios using the same XML workflow.
 - Displays real-time simulation progress in the console.
 - Automatically outputs results to the scenario's directory by default.
 - Generates KML files for scenario visualization.

--- a/packages/fers-ui/src/components/LinkVisualizer.tsx
+++ b/packages/fers-ui/src/components/LinkVisualizer.tsx
@@ -419,7 +419,16 @@ export default function LinkVisualizer() {
                                         waveform.chirp_period
                                 )
                             )
-                          : null;
+                          : waveform.waveformType === 'stepped_frequency' &&
+                              waveform.step_period > 0
+                            ? Math.min(
+                                  1,
+                                  Math.max(
+                                      0,
+                                      waveform.dwell_time / waveform.step_period
+                                  )
+                              )
+                            : null;
                 if (dutyCycle === null) {
                     return;
                 }

--- a/packages/fers-ui/src/components/inspectors/InspectorControls.test.ts
+++ b/packages/fers-ui/src/components/inspectors/InspectorControls.test.ts
@@ -102,6 +102,7 @@ describe('Waveform inspector authoring options', () => {
             { value: 'cw', label: 'CW' },
             { value: 'fmcw_linear_chirp', label: 'FMCW Linear Chirp' },
             { value: 'fmcw_triangle', label: 'FMCW Triangle' },
+            { value: 'stepped_frequency', label: 'SFCW' },
         ]);
     });
 
@@ -136,6 +137,35 @@ describe('Waveform inspector authoring options', () => {
         });
     });
 
+    test('creates SFCW defaults while preserving common waveform fields', () => {
+        const sfcwWaveform = createWaveformForType(
+            {
+                id: '2',
+                type: 'Waveform',
+                name: 'Step sweep',
+                waveformType: 'cw',
+                power: 125,
+                carrier_frequency: 5.8e9,
+            },
+            'stepped_frequency'
+        );
+
+        expect(sfcwWaveform).toMatchObject({
+            id: '2',
+            type: 'Waveform',
+            name: 'Step sweep',
+            waveformType: 'stepped_frequency',
+            power: 125,
+            carrier_frequency: 5.8e9,
+            start_frequency_offset: 0,
+            step_size: 1e3,
+            step_count: 16,
+            dwell_time: 1e-3,
+            step_period: 1e-3,
+            sweep_count: null,
+        });
+    });
+
     test('reports FMCW chirp fields only for FMCW waveforms', () => {
         expect(getVisibleWaveformFieldLabels('fmcw_linear_chirp')).toEqual([
             'Direction',
@@ -150,6 +180,14 @@ describe('Waveform inspector authoring options', () => {
             'Chirp Duration (s)',
             'Start Frequency Offset (Hz)',
             'Triangle Count',
+        ]);
+        expect(getVisibleWaveformFieldLabels('stepped_frequency')).toEqual([
+            'Start Frequency Offset (Hz)',
+            'Step Size (Hz)',
+            'Step Count',
+            'Dwell Time (s)',
+            'Step Period (s)',
+            'Sweep Count',
         ]);
         expect(getVisibleWaveformFieldLabels('cw')).toEqual([]);
     });
@@ -209,6 +247,7 @@ describe('Platform component inspector waveform compatibility', () => {
         { id: '2', name: 'Tone', waveformType: 'cw' },
         { id: '3', name: 'Chirp', waveformType: 'fmcw_linear_chirp' },
         { id: '4', name: 'Triangle', waveformType: 'fmcw_triangle' },
+        { id: '5', name: 'Steps', waveformType: 'stepped_frequency' },
     ];
 
     test('offers FMCW radar mode and hides pulsed-only fields for FMCW/CW', () => {
@@ -216,6 +255,7 @@ describe('Platform component inspector waveform compatibility', () => {
             { value: 'pulsed', label: 'Pulsed' },
             { value: 'cw', label: 'CW' },
             { value: 'fmcw', label: 'FMCW' },
+            { value: 'sfcw', label: 'SFCW' },
         ]);
 
         expect(getPulsedRadarFieldLabels('pulsed')).toEqual([
@@ -225,6 +265,7 @@ describe('Platform component inspector waveform compatibility', () => {
         ]);
         expect(getPulsedRadarFieldLabels('cw')).toEqual([]);
         expect(getPulsedRadarFieldLabels('fmcw')).toEqual([]);
+        expect(getPulsedRadarFieldLabels('sfcw')).toEqual([]);
     });
 
     test('filters waveform dropdown choices by radar mode', () => {
@@ -235,6 +276,9 @@ describe('Platform component inspector waveform compatibility', () => {
         expect(getCompatibleWaveforms(waveforms, 'fmcw')).toEqual([
             waveforms[2],
             waveforms[3],
+        ]);
+        expect(getCompatibleWaveforms(waveforms, 'sfcw')).toEqual([
+            waveforms[4],
         ]);
     });
 
@@ -251,6 +295,13 @@ describe('Platform component inspector waveform compatibility', () => {
         expect(resolveWaveformSelectValue('1', waveforms, 'fmcw')).toBe('');
         expect(resolveWaveformSelectValue('3', waveforms, 'fmcw')).toBe('3');
         expect(resolveWaveformSelectValue('4', waveforms, 'fmcw')).toBe('4');
+        expect(shouldClearWaveformForRadarType('3', waveforms, 'sfcw')).toBe(
+            true
+        );
+        expect(shouldClearWaveformForRadarType('5', waveforms, 'sfcw')).toBe(
+            false
+        );
+        expect(resolveWaveformSelectValue('5', waveforms, 'sfcw')).toBe('5');
     });
 
     test('offers dechirp modes and source options for receiver FMCW mode', () => {

--- a/packages/fers-ui/src/components/inspectors/PlatformComponentInspector.tsx
+++ b/packages/fers-ui/src/components/inspectors/PlatformComponentInspector.tsx
@@ -46,7 +46,7 @@ import {
     Section,
 } from './InspectorControls';
 
-export type RadarType = 'pulsed' | 'cw' | 'fmcw';
+export type RadarType = 'pulsed' | 'cw' | 'fmcw' | 'sfcw';
 type CompatibleWaveform = {
     id: string;
     name: string;
@@ -64,12 +64,14 @@ export const RADAR_MODE_OPTIONS: ReadonlyArray<{
     { value: 'pulsed', label: 'Pulsed' },
     { value: 'cw', label: 'CW' },
     { value: 'fmcw', label: 'FMCW' },
+    { value: 'sfcw', label: 'SFCW' },
 ];
 
 const WAVEFORM_TYPE_BY_RADAR_TYPE: Record<RadarType, string[]> = {
     pulsed: ['pulsed_from_file'],
     cw: ['cw'],
     fmcw: ['fmcw_linear_chirp', 'fmcw_triangle'],
+    sfcw: ['stepped_frequency'],
 };
 
 export function isWaveformCompatibleWithRadarType(

--- a/packages/fers-ui/src/components/inspectors/WaveformInspector.tsx
+++ b/packages/fers-ui/src/components/inspectors/WaveformInspector.tsx
@@ -18,7 +18,8 @@ export type WaveformType =
     | 'pulsed_from_file'
     | 'cw'
     | 'fmcw_linear_chirp'
-    | 'fmcw_triangle';
+    | 'fmcw_triangle'
+    | 'stepped_frequency';
 
 type FmcwLinearChirpFields = {
     direction: 'up' | 'down';
@@ -36,9 +37,19 @@ type FmcwTriangleFields = {
     triangle_count: number | null;
 };
 
+type SfcwFields = {
+    start_frequency_offset: number | null;
+    step_size: number;
+    step_count: number;
+    dwell_time: number;
+    step_period: number;
+    sweep_count: number | null;
+};
+
 type AuthorableWaveform = Omit<Waveform, 'waveformType'> &
     Partial<FmcwLinearChirpFields> &
-    Partial<FmcwTriangleFields> & {
+    Partial<FmcwTriangleFields> &
+    Partial<SfcwFields> & {
         waveformType: WaveformType;
         filename?: string;
     };
@@ -51,12 +62,14 @@ export const WAVEFORM_TYPE_OPTIONS: ReadonlyArray<{
     { value: 'cw', label: 'CW' },
     { value: 'fmcw_linear_chirp', label: 'FMCW Linear Chirp' },
     { value: 'fmcw_triangle', label: 'FMCW Triangle' },
+    { value: 'stepped_frequency', label: 'SFCW' },
 ];
 
 const DEFAULT_FMCW_LINEAR_CHIRP_FIELDS =
     createWaveformDefaultsForType('fmcw_linear_chirp');
 const DEFAULT_FMCW_TRIANGLE_FIELDS =
     createWaveformDefaultsForType('fmcw_triangle');
+const DEFAULT_SFCW_FIELDS = createWaveformDefaultsForType('stepped_frequency');
 
 interface WaveformInspectorProps {
     item: Waveform;
@@ -139,6 +152,32 @@ export function createWaveformForType(
         };
     }
 
+    if (waveformType === 'stepped_frequency') {
+        return {
+            ...nextWaveform,
+            start_frequency_offset: asNumberOrDefault(
+                waveform.start_frequency_offset,
+                DEFAULT_SFCW_FIELDS.start_frequency_offset
+            ),
+            step_size: asNumberOrDefault(
+                waveform.step_size,
+                DEFAULT_SFCW_FIELDS.step_size
+            ),
+            step_count:
+                asNullableInteger(waveform.step_count) ??
+                DEFAULT_SFCW_FIELDS.step_count,
+            dwell_time: asNumberOrDefault(
+                waveform.dwell_time,
+                DEFAULT_SFCW_FIELDS.dwell_time
+            ),
+            step_period: asNumberOrDefault(
+                waveform.step_period,
+                DEFAULT_SFCW_FIELDS.step_period
+            ),
+            sweep_count: asNullableInteger(waveform.sweep_count),
+        };
+    }
+
     return nextWaveform;
 }
 
@@ -169,6 +208,17 @@ export function getVisibleWaveformFieldLabels(
         ];
     }
 
+    if (waveformType === 'stepped_frequency') {
+        return [
+            'Start Frequency Offset (Hz)',
+            'Step Size (Hz)',
+            'Step Count',
+            'Dwell Time (s)',
+            'Step Period (s)',
+            'Sweep Count',
+        ];
+    }
+
     return [];
 }
 
@@ -179,6 +229,18 @@ export function WaveformInspector({ item }: WaveformInspectorProps) {
     const getFieldIssue = (field: string) =>
         fmcwIssues.find((issue) => issue.field === field);
     const globalFmcwIssues = fmcwIssues.filter((issue) => !issue.field);
+    const sfcwStepPeriodIssue =
+        waveform.waveformType === 'stepped_frequency' &&
+        asNumberOrDefault(
+            waveform.step_period,
+            DEFAULT_SFCW_FIELDS.step_period
+        ) <
+            asNumberOrDefault(
+                waveform.dwell_time,
+                DEFAULT_SFCW_FIELDS.dwell_time
+            )
+            ? 'Step period must be greater than or equal to dwell time.'
+            : undefined;
     const handleChange = (path: string, value: unknown) =>
         updateItem(item.id, path, value);
     const handleTypeChange = (waveformType: WaveformType) => {
@@ -366,6 +428,72 @@ export function WaveformInspector({ item }: WaveformInspectorProps) {
                         onChange={(v) =>
                             handleChange(
                                 'triangle_count',
+                                v === null ? null : Math.trunc(v)
+                            )
+                        }
+                    />
+                </>
+            )}
+            {waveform.waveformType === 'stepped_frequency' && (
+                <>
+                    <NumberField
+                        label="Start Frequency Offset (Hz)"
+                        value={asNumberOrDefault(
+                            waveform.start_frequency_offset,
+                            DEFAULT_SFCW_FIELDS.start_frequency_offset
+                        )}
+                        emptyBehavior="revert"
+                        onChange={(v) =>
+                            handleChange('start_frequency_offset', v)
+                        }
+                    />
+                    <NumberField
+                        label="Step Size (Hz)"
+                        value={asNumberOrDefault(
+                            waveform.step_size,
+                            DEFAULT_SFCW_FIELDS.step_size
+                        )}
+                        emptyBehavior="revert"
+                        onChange={(v) => handleChange('step_size', v)}
+                    />
+                    <NumberField
+                        label="Step Count"
+                        value={
+                            asNullableInteger(waveform.step_count) ??
+                            DEFAULT_SFCW_FIELDS.step_count
+                        }
+                        emptyBehavior="revert"
+                        onChange={(v) =>
+                            handleChange('step_count', Math.trunc(v ?? 1))
+                        }
+                    />
+                    <NumberField
+                        label="Dwell Time (s)"
+                        value={asNumberOrDefault(
+                            waveform.dwell_time,
+                            DEFAULT_SFCW_FIELDS.dwell_time
+                        )}
+                        emptyBehavior="revert"
+                        onChange={(v) => handleChange('dwell_time', v)}
+                    />
+                    <NumberField
+                        label="Step Period (s)"
+                        value={asNumberOrDefault(
+                            waveform.step_period,
+                            DEFAULT_SFCW_FIELDS.step_period
+                        )}
+                        emptyBehavior="revert"
+                        helperText={sfcwStepPeriodIssue}
+                        externalError={Boolean(sfcwStepPeriodIssue)}
+                        onChange={(v) => handleChange('step_period', v)}
+                    />
+                    <NumberField
+                        label="Sweep Count"
+                        value={asNullableInteger(waveform.sweep_count)}
+                        emptyBehavior="null"
+                        onChange={(v) =>
+                            handleChange(
+                                'sweep_count',
                                 v === null ? null : Math.trunc(v)
                             )
                         }

--- a/packages/fers-ui/src/stores/scenarioSchema.ts
+++ b/packages/fers-ui/src/stores/scenarioSchema.ts
@@ -105,6 +105,25 @@ export const WaveformSchema = z
                 z.number().int().positive().nullable()
             ),
         }),
+        BaseWaveformSchema.extend({
+            waveformType: z.literal('stepped_frequency'),
+            start_frequency_offset: z.number().finite(),
+            step_size: z
+                .number()
+                .finite()
+                .refine((val) => val !== 0, {
+                    message: 'Step size cannot be zero.',
+                }),
+            step_count: z
+                .number()
+                .int()
+                .positive('Step count must be positive.'),
+            dwell_time: z.number().positive('Dwell time must be positive.'),
+            step_period: z.number().positive('Step period must be positive.'),
+            sweep_count: nullableNumber.pipe(
+                z.number().int().positive().nullable()
+            ),
+        }),
     ])
     .superRefine((data, ctx) => {
         if (
@@ -116,6 +135,17 @@ export const WaveformSchema = z
                 message:
                     'Chirp period must be greater than or equal to chirp duration.',
                 path: ['chirp_period'],
+            });
+        }
+        if (
+            data.waveformType === 'stepped_frequency' &&
+            data.step_period < data.dwell_time
+        ) {
+            ctx.addIssue({
+                code: 'custom',
+                message:
+                    'Step period must be greater than or equal to dwell time.',
+                path: ['step_period'],
             });
         }
     });
@@ -251,7 +281,7 @@ const MonostaticComponentSchema = z.object({
     name: z.string().min(1),
     txId: SimIdSchema,
     rxId: SimIdSchema,
-    radarType: z.enum(['pulsed', 'cw', 'fmcw']),
+    radarType: z.enum(['pulsed', 'cw', 'fmcw', 'sfcw']),
     window_skip: nullableNumber,
     window_length: nullableNumber,
     prf: nullableNumber,
@@ -269,7 +299,7 @@ const TransmitterComponentSchema = z.object({
     id: SimIdSchema,
     type: z.literal('transmitter'),
     name: z.string().min(1),
-    radarType: z.enum(['pulsed', 'cw', 'fmcw']),
+    radarType: z.enum(['pulsed', 'cw', 'fmcw', 'sfcw']),
     prf: nullableNumber,
     antennaId: SimIdSchema.nullable(),
     waveformId: SimIdSchema.nullable(),
@@ -281,7 +311,7 @@ const ReceiverComponentSchema = z.object({
     id: SimIdSchema,
     type: z.literal('receiver'),
     name: z.string().min(1),
-    radarType: z.enum(['pulsed', 'cw', 'fmcw']),
+    radarType: z.enum(['pulsed', 'cw', 'fmcw', 'sfcw']),
     window_skip: nullableNumber,
     window_length: nullableNumber,
     prf: nullableNumber,

--- a/packages/fers-ui/src/stores/scenarioStore/defaults.ts
+++ b/packages/fers-ui/src/stores/scenarioStore/defaults.ts
@@ -55,6 +55,9 @@ export function createWaveformForType(
     waveformType: 'fmcw_triangle'
 ): WaveformDefaults<'fmcw_triangle'>;
 export function createWaveformForType(
+    waveformType: 'stepped_frequency'
+): WaveformDefaults<'stepped_frequency'>;
+export function createWaveformForType(
     waveformType: WaveformType
 ): WaveformDefaults {
     const common = {
@@ -94,6 +97,17 @@ export function createWaveformForType(
                 chirp_duration: 1e-3,
                 start_frequency_offset: 0,
                 triangle_count: null,
+            };
+        case 'stepped_frequency':
+            return {
+                ...common,
+                waveformType,
+                start_frequency_offset: 0,
+                step_size: 1e3,
+                step_count: 16,
+                dwell_time: 1e-3,
+                step_period: 1e-3,
+                sweep_count: null,
             };
     }
 }

--- a/packages/fers-ui/src/stores/scenarioStore/fmcwValidation.ts
+++ b/packages/fers-ui/src/stores/scenarioStore/fmcwValidation.ts
@@ -31,6 +31,8 @@ type FmcwWaveform = Extract<
     { waveformType: 'fmcw_linear_chirp' | 'fmcw_triangle' }
 >;
 
+type SfcwWaveform = Extract<Waveform, { waveformType: 'stepped_frequency' }>;
+
 type FmcwEmitterComponent = Extract<
     PlatformComponent,
     { type: 'transmitter' | 'monostatic' }
@@ -48,6 +50,10 @@ const isFmcwWaveform = (
 ): waveform is FmcwWaveform =>
     waveform?.waveformType === 'fmcw_linear_chirp' ||
     waveform?.waveformType === 'fmcw_triangle';
+
+const isSfcwWaveform = (
+    waveform: Waveform | undefined
+): waveform is SfcwWaveform => waveform?.waveformType === 'stepped_frequency';
 
 const formatNumber = (value: number): string =>
     value.toLocaleString(undefined, { maximumSignificantDigits: 6 });
@@ -104,6 +110,52 @@ export function validateFmcwWaveform(
     waveform: Waveform,
     globalParameters: GlobalParameters
 ): FmcwValidationIssue[] {
+    if (isSfcwWaveform(waveform)) {
+        const issues: FmcwValidationIssue[] = [];
+        const firstFrequency =
+            waveform.carrier_frequency + waveform.start_frequency_offset;
+        const lastFrequency =
+            firstFrequency + (waveform.step_count - 1) * waveform.step_size;
+        const lowerFrequency = Math.min(firstFrequency, lastFrequency);
+        if (waveform.step_size === 0) {
+            pushIssue(issues, {
+                severity: 'error',
+                itemId: waveform.id,
+                waveformId: waveform.id,
+                field: 'step_size',
+                message: 'SFCW step size cannot be zero.',
+            });
+        }
+        if (waveform.step_period < waveform.dwell_time) {
+            pushIssue(issues, {
+                severity: 'error',
+                itemId: waveform.id,
+                waveformId: waveform.id,
+                field: 'step_period',
+                message:
+                    'Step period must be greater than or equal to dwell time.',
+            });
+        }
+        if (globalParameters.rate * waveform.dwell_time < 1) {
+            pushIssue(issues, {
+                severity: 'warning',
+                itemId: waveform.id,
+                waveformId: waveform.id,
+                message: `${waveform.name} has fewer than one output sample per SFCW dwell.`,
+            });
+        }
+        if (lowerFrequency <= 0) {
+            pushIssue(issues, {
+                severity: 'error',
+                itemId: waveform.id,
+                waveformId: waveform.id,
+                message:
+                    'Carrier frequency plus the lowest SFCW step frequency must stay positive.',
+            });
+        }
+        return issues;
+    }
+
     if (!isFmcwWaveform(waveform)) {
         return [];
     }
@@ -242,6 +294,49 @@ function validateFmcwEmitterSchedule(
                 message: `${component.name} schedule leaves ${formatNumber(
                     leftover
                 )} s silent after the last complete FMCW triangle.`,
+            });
+        }
+    }
+
+    return issues;
+}
+
+function validateSfcwEmitterSchedule(
+    component: FmcwEmitterComponent,
+    waveform: SfcwWaveform,
+    globalParameters: GlobalParameters
+): FmcwValidationIssue[] {
+    const issues: FmcwValidationIssue[] = [];
+    const schedule = effectiveSchedule(component.schedule, globalParameters);
+    const sweepPeriod = waveform.step_count * waveform.step_period;
+
+    for (const period of schedule) {
+        const duration = period.end - period.start;
+        if (duration < waveform.dwell_time) {
+            pushIssue(issues, {
+                severity: 'error',
+                itemId: component.id,
+                componentId: component.id,
+                waveformId: waveform.id,
+                field: 'schedule',
+                message: `${component.name} has schedule duration ${formatNumber(
+                    duration
+                )} s shorter than SFCW dwell time ${formatNumber(
+                    waveform.dwell_time
+                )} s.`,
+            });
+        } else if (duration < sweepPeriod) {
+            pushIssue(issues, {
+                severity: 'warning',
+                itemId: component.id,
+                componentId: component.id,
+                waveformId: waveform.id,
+                field: 'schedule',
+                message: `${component.name} has schedule duration ${formatNumber(
+                    duration
+                )} s shorter than SFCW sweep period ${formatNumber(
+                    sweepPeriod
+                )} s.`,
             });
         }
     }
@@ -530,6 +625,29 @@ export function validateFmcwScenario(
             }
 
             if (component.radarType !== 'fmcw' || !component.waveformId) {
+                if (component.radarType !== 'sfcw' || !component.waveformId) {
+                    continue;
+                }
+
+                const waveform = waveformsById.get(component.waveformId);
+                if (!isSfcwWaveform(waveform)) {
+                    pushIssue(issues, {
+                        severity: 'error',
+                        itemId: component.id,
+                        componentId: component.id,
+                        waveformId: component.waveformId,
+                        message: `${component.name} is SFCW but does not reference an SFCW waveform.`,
+                    });
+                    continue;
+                }
+
+                issues.push(
+                    ...validateSfcwEmitterSchedule(
+                        component,
+                        waveform,
+                        scenario.globalParameters
+                    )
+                );
                 continue;
             }
 

--- a/packages/fers-ui/src/stores/scenarioStore/hydration.ts
+++ b/packages/fers-ui/src/stores/scenarioStore/hydration.ts
@@ -53,6 +53,7 @@ interface BackendPlatformComponentData {
     pulsed_mode?: BackendPulsedMode;
     cw_mode?: object;
     fmcw_mode?: Record<string, unknown>;
+    sfcw_mode?: object;
     schedule?: BackendSchedulePeriod[];
     rcs?: { type: 'isotropic' | 'file'; value?: number; filename?: string };
     model?: { type: 'constant' | 'chisquare' | 'gamma'; k?: number };
@@ -113,6 +114,14 @@ interface BackendWaveform {
         chirp_duration: number;
         start_frequency_offset?: number | null;
         triangle_count?: number | null;
+    };
+    stepped_frequency?: {
+        start_frequency_offset: number;
+        step_size: number;
+        step_count: number;
+        dwell_time: number;
+        step_period: number;
+        sweep_count?: number | null;
     };
 }
 
@@ -323,6 +332,18 @@ export function parseScenarioData(backendData: unknown): ScenarioData | null {
                         w.fmcw_triangle.start_frequency_offset ?? null,
                     triangle_count: w.fmcw_triangle.triangle_count ?? null,
                 };
+            } else if (w.stepped_frequency) {
+                waveform = {
+                    ...commonWaveform,
+                    waveformType: 'stepped_frequency',
+                    start_frequency_offset:
+                        w.stepped_frequency.start_frequency_offset,
+                    step_size: w.stepped_frequency.step_size,
+                    step_count: w.stepped_frequency.step_count,
+                    dwell_time: w.stepped_frequency.dwell_time,
+                    step_period: w.stepped_frequency.step_period,
+                    sweep_count: w.stepped_frequency.sweep_count ?? null,
+                };
             } else if (w.cw) {
                 waveform = {
                     ...commonWaveform,
@@ -464,7 +485,9 @@ export function parseScenarioData(backendData: unknown): ScenarioData | null {
                           ? 'cw'
                           : cData.fmcw_mode
                             ? 'fmcw'
-                            : 'pulsed';
+                            : cData.sfcw_mode
+                              ? 'sfcw'
+                              : 'pulsed';
                     const pulsed = cData.pulsed_mode;
                     const fmcwModeConfig =
                         radarType === 'fmcw' && cData.fmcw_mode

--- a/packages/fers-ui/src/stores/scenarioStore/serializers.test.ts
+++ b/packages/fers-ui/src/stores/scenarioStore/serializers.test.ts
@@ -164,6 +164,55 @@ describe('FMCW schema', () => {
     });
 });
 
+describe('SFCW schema', () => {
+    const validWaveform: Extract<
+        Waveform,
+        { waveformType: 'stepped_frequency' }
+    > = {
+        ...createWaveformForType('stepped_frequency'),
+        id: '14',
+        name: 'SFCW',
+    };
+
+    test('accepts valid SFCW waveform fields and radar mode', () => {
+        expect(WaveformSchema.safeParse(validWaveform).success).toBe(true);
+        const component: PlatformComponent = {
+            id: '21',
+            type: 'transmitter',
+            name: 'SFCW TX',
+            radarType: 'sfcw',
+            prf: null,
+            antennaId: null,
+            waveformId: null,
+            timingId: null,
+            schedule: [],
+        };
+
+        expect(PlatformComponentSchema.safeParse(component).success).toBe(true);
+    });
+
+    test('rejects invalid SFCW waveform fields', () => {
+        const invalidWaveforms = [
+            { ...validWaveform, step_size: 0 },
+            { ...validWaveform, step_count: 0 },
+            { ...validWaveform, step_count: 1.5 },
+            { ...validWaveform, dwell_time: 0 },
+            { ...validWaveform, step_period: 0 },
+            {
+                ...validWaveform,
+                dwell_time: 2e-3,
+                step_period: 1e-3,
+            },
+            { ...validWaveform, sweep_count: 0 },
+            { ...validWaveform, sweep_count: 2.5 },
+        ];
+
+        for (const waveform of invalidWaveforms) {
+            expect(WaveformSchema.safeParse(waveform).success).toBe(false);
+        }
+    });
+});
+
 describe('serializeWaveform', () => {
     test('serializes FMCW waveform payload and omits unset optional fields', () => {
         const waveform: Waveform = {
@@ -226,6 +275,35 @@ describe('serializeWaveform', () => {
             },
         });
     });
+
+    test('serializes SFCW waveform payload', () => {
+        const waveform: Waveform = {
+            ...createWaveformForType('stepped_frequency'),
+            id: '33',
+            name: 'SFCW',
+            start_frequency_offset: 0,
+            step_size: 2e5,
+            step_count: 8,
+            dwell_time: 1e-4,
+            step_period: 2e-4,
+            sweep_count: 4,
+        };
+
+        expect(serializeWaveform(waveform)).toEqual({
+            id: '33',
+            name: 'SFCW',
+            power: 1000,
+            carrier_frequency: 1e9,
+            stepped_frequency: {
+                start_frequency_offset: 0,
+                step_size: 2e5,
+                step_count: 8,
+                dwell_time: 1e-4,
+                step_period: 2e-4,
+                sweep_count: 4,
+            },
+        });
+    });
 });
 
 describe('serializeComponentInner', () => {
@@ -280,6 +358,30 @@ describe('serializeComponentInner', () => {
             noise_temp: null,
             nodirect: false,
             nopropagationloss: false,
+            schedule: [],
+        });
+    });
+
+    test('serializes SFCW mode without pulsed or dechirp fields', () => {
+        const component: PlatformComponent = {
+            id: '44',
+            type: 'transmitter',
+            name: 'SFCW Tx',
+            radarType: 'sfcw',
+            prf: 3,
+            antennaId: null,
+            waveformId: null,
+            timingId: null,
+            schedule: [],
+        };
+
+        expect(serializeComponentInner(component)).toEqual({
+            id: '44',
+            name: 'SFCW Tx',
+            sfcw_mode: {},
+            antenna: 0,
+            waveform: 0,
+            timing: 0,
             schedule: [],
         });
     });

--- a/packages/fers-ui/src/stores/scenarioStore/serializers.ts
+++ b/packages/fers-ui/src/stores/scenarioStore/serializers.ts
@@ -98,6 +98,8 @@ export const serializeComponentInner = (component: PlatformComponent) => {
                     return { fmcw_mode: component.fmcwModeConfig ?? {} };
                 }
                 return { fmcw_mode: {} };
+            case 'sfcw':
+                return { sfcw_mode: {} };
         }
     })();
 
@@ -238,6 +240,19 @@ export const serializeWaveform = (w: Waveform) => {
                             : {}),
                         ...(w.triangle_count !== null
                             ? { triangle_count: w.triangle_count }
+                            : {}),
+                    },
+                };
+            case 'stepped_frequency':
+                return {
+                    stepped_frequency: {
+                        start_frequency_offset: w.start_frequency_offset,
+                        step_size: w.step_size,
+                        step_count: w.step_count,
+                        dwell_time: w.dwell_time,
+                        step_period: w.step_period,
+                        ...(w.sweep_count !== null
+                            ? { sweep_count: w.sweep_count }
                             : {}),
                     },
                 };

--- a/packages/fers-ui/src/stores/simulationProgressStore.test.ts
+++ b/packages/fers-ui/src/stores/simulationProgressStore.test.ts
@@ -83,6 +83,7 @@ describe('simulation output metadata', () => {
                             ],
                         },
                     ],
+                    sfcw_sources: [],
                 },
             ],
         };

--- a/packages/fers-ui/src/stores/simulationProgressStore.ts
+++ b/packages/fers-ui/src/stores/simulationProgressStore.ts
@@ -19,7 +19,7 @@ export type SimulationProgressDetail = {
 
 export type SimulationRunStatus = 'idle' | 'running' | 'completed' | 'failed';
 
-export type SimulationOutputMode = 'pulsed' | 'cw' | 'fmcw';
+export type SimulationOutputMode = 'pulsed' | 'cw' | 'fmcw' | 'sfcw';
 
 export type SimulationOutputChunkMetadata = {
     chunk_index: number;
@@ -41,6 +41,8 @@ export type SimulationOutputStreamingSegmentMetadata = {
     emitted_chirp_count?: number;
     first_triangle_start_time?: number;
     emitted_triangle_count?: number;
+    first_sfcw_step_start_time?: number;
+    emitted_sfcw_step_count?: number;
 };
 
 export type SimulationOutputFmcwMetadata = {
@@ -74,6 +76,38 @@ export type SimulationOutputFmcwSourceMetadata =
         waveform_name: string;
         carrier_frequency: number;
         segments: SimulationOutputFmcwSourceSegmentMetadata[];
+    };
+
+export type SimulationOutputSfcwMetadata = {
+    carrier_frequency: number;
+    start_frequency_offset: number;
+    step_size: number;
+    step_count: number;
+    dwell_time: number;
+    step_period: number;
+    sweep_count?: number;
+    first_frequency: number;
+    last_frequency: number;
+    frequency_span: number;
+    effective_bandwidth: number;
+    range_resolution: number;
+    unambiguous_range: number;
+};
+
+export type SimulationOutputSfcwSourceSegmentMetadata = {
+    start_time: number;
+    end_time: number;
+    first_step_start_time?: number;
+    emitted_step_count?: number;
+};
+
+export type SimulationOutputSfcwSourceMetadata =
+    SimulationOutputSfcwMetadata & {
+        transmitter_id: number;
+        transmitter_name: string;
+        waveform_id: number;
+        waveform_name: string;
+        segments: SimulationOutputSfcwSourceSegmentMetadata[];
     };
 
 export type SimulationOutputVita49Timestamp = {
@@ -130,6 +164,8 @@ export type SimulationOutputFileMetadata = {
     streaming_segments: SimulationOutputStreamingSegmentMetadata[];
     fmcw?: SimulationOutputFmcwMetadata;
     fmcw_sources: SimulationOutputFmcwSourceMetadata[];
+    sfcw?: SimulationOutputSfcwMetadata;
+    sfcw_sources: SimulationOutputSfcwSourceMetadata[];
     fmcw_dechirp_mode?: 'none' | 'physical' | 'ideal';
     fmcw_dechirp_reference_source?:
         | 'none'
@@ -158,12 +194,13 @@ export type SimulationOutputMetadata = {
 
 export type RawSimulationOutputFileMetadata = Omit<
     SimulationOutputFileMetadata,
-    'sampling_rate' | 'streaming_segments' | 'fmcw_sources'
+    'sampling_rate' | 'streaming_segments' | 'fmcw_sources' | 'sfcw_sources'
 > & {
     sampling_rate?: number;
     streaming_segments?: SimulationOutputStreamingSegmentMetadata[];
     cw_segments?: SimulationOutputStreamingSegmentMetadata[];
     fmcw_sources?: SimulationOutputFmcwSourceMetadata[];
+    sfcw_sources?: SimulationOutputSfcwSourceMetadata[];
 };
 
 export type RawSimulationOutputMetadata = Omit<
@@ -182,6 +219,7 @@ export const normalizeSimulationOutputMetadata = (
             cw_segments,
             streaming_segments,
             fmcw_sources,
+            sfcw_sources,
             sampling_rate,
             ...normalizedFile
         } = file;
@@ -194,6 +232,7 @@ export const normalizeSimulationOutputMetadata = (
                 0,
             streaming_segments: streaming_segments ?? cw_segments ?? [],
             fmcw_sources: fmcw_sources ?? [],
+            sfcw_sources: sfcw_sources ?? [],
         };
     }),
 });

--- a/packages/fers-ui/src/stores/vita49StreamingStore.ts
+++ b/packages/fers-ui/src/stores/vita49StreamingStore.ts
@@ -118,7 +118,7 @@ export type Vita49StreamRow = {
     backendObserved: boolean;
 };
 
-export type Vita49StreamMode = 'pulsed' | 'cw' | 'fmcw' | 'unknown';
+export type Vita49StreamMode = 'pulsed' | 'cw' | 'fmcw' | 'sfcw' | 'unknown';
 
 export const DEFAULT_VITA49_CONFIG: Vita49RuntimeConfig = {
     host: '127.0.0.1',
@@ -212,7 +212,9 @@ export const toVita49BackendConfig = (
 const normalizeStreamMode = (
     mode: string | null | undefined
 ): Vita49StreamMode =>
-    mode === 'pulsed' || mode === 'cw' || mode === 'fmcw' ? mode : 'unknown';
+    mode === 'pulsed' || mode === 'cw' || mode === 'fmcw' || mode === 'sfcw'
+        ? mode
+        : 'unknown';
 
 export const deriveExpectedVita49Streams = (
     scenario: Pick<ScenarioData, 'globalParameters' | 'platforms' | 'waveforms'>
@@ -363,7 +365,8 @@ export const mergeVita49StreamRows = (
         pulsed: 0,
         cw: 1,
         fmcw: 2,
-        unknown: 3,
+        sfcw: 3,
+        unknown: 4,
     };
     return Array.from(rowsByResolvedKey.values()).sort(
         (a, b) =>

--- a/packages/fers-ui/src/views/SimulationView.tsx
+++ b/packages/fers-ui/src/views/SimulationView.tsx
@@ -427,6 +427,14 @@ export const SimulationView = React.memo(function SimulationView() {
             fmcw.chirp_duration
         )}, T_rep=${formatMetric(fmcw.chirp_period ?? 0)}`;
     };
+    const formatSfcwMetadata = (
+        sfcw: NonNullable<SimulationOutputFileMetadata['sfcw']>
+    ) =>
+        `steps=${sfcw.step_count}, df=${formatMetric(
+            sfcw.step_size
+        )} Hz, dwell=${formatMetric(
+            sfcw.dwell_time
+        )}, T_step=${formatMetric(sfcw.step_period)}`;
     const formatPulseOrSegmentSummary = (
         file: SimulationOutputFileMetadata
     ) => {
@@ -441,6 +449,16 @@ export const SimulationView = React.memo(function SimulationView() {
         const segmentSummary = `${
             file.streaming_segments.length
         } streaming segments`;
+        if (file.mode === 'sfcw') {
+            if (file.sfcw) {
+                return `${segmentSummary}, ${formatSfcwMetadata(file.sfcw)}`;
+            }
+            if (file.sfcw_sources.length > 0) {
+                return `${segmentSummary}, ${file.sfcw_sources.length} SFCW sources`;
+            }
+            return segmentSummary;
+        }
+
         if (file.mode !== 'fmcw' || !file.fmcw) {
             if (file.mode === 'fmcw' && file.fmcw_sources.length > 0) {
                 return `${segmentSummary}, ${file.fmcw_sources.length} FMCW sources`;
@@ -525,6 +543,58 @@ export const SimulationView = React.memo(function SimulationView() {
                                     {segment.emitted_triangle_count !==
                                     undefined
                                         ? `${segment.emitted_triangle_count} triangles`
+                                        : ''}
+                                </Typography>
+                            ))}
+                        </Box>
+                    ))
+                )}
+            </Box>
+        );
+    };
+
+    const renderSfcwDetails = (file: SimulationOutputFileMetadata) => {
+        if (file.mode !== 'sfcw') {
+            return null;
+        }
+
+        return (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                <Typography variant="body2">
+                    File sample rate: {formatMetric(file.sampling_rate)}{' '}
+                    samples/s
+                </Typography>
+                {file.sfcw_sources.length === 0 ? (
+                    <Typography variant="body2" color="text.secondary">
+                        No SFCW source metadata was emitted for this receiver.
+                    </Typography>
+                ) : (
+                    file.sfcw_sources.map((source) => (
+                        <Box
+                            key={`${source.transmitter_id}:${source.waveform_id}`}
+                            sx={{ pl: 2 }}
+                        >
+                            <Typography variant="body2">
+                                {source.transmitter_name} /{' '}
+                                {source.waveform_name}:{' '}
+                                {formatSfcwMetadata(source)}, B_eff=
+                                {formatMetric(source.effective_bandwidth)} Hz,
+                                R_res=
+                                {formatMetric(source.range_resolution)} m,
+                                R_amb=
+                                {formatMetric(source.unambiguous_range)} m
+                            </Typography>
+                            {source.segments.map((segment) => (
+                                <Typography
+                                    key={`${segment.start_time}:${segment.end_time}`}
+                                    variant="caption"
+                                    color="text.secondary"
+                                    sx={{ display: 'block' }}
+                                >
+                                    [{formatMetric(segment.start_time)},{' '}
+                                    {formatMetric(segment.end_time)}]:{' '}
+                                    {segment.emitted_step_count !== undefined
+                                        ? `${segment.emitted_step_count} steps`
                                         : ''}
                                 </Typography>
                             ))}
@@ -887,7 +957,8 @@ export const SimulationView = React.memo(function SimulationView() {
                                                         file.path
                                                     );
                                                 const canExpand =
-                                                    file.mode === 'fmcw';
+                                                    file.mode === 'fmcw' ||
+                                                    file.mode === 'sfcw';
                                                 return (
                                                     <React.Fragment
                                                         key={file.path}
@@ -971,6 +1042,9 @@ export const SimulationView = React.memo(function SimulationView() {
                                                                             }}
                                                                         >
                                                                             {renderFmcwDetails(
+                                                                                file
+                                                                            )}
+                                                                            {renderSfcwDetails(
                                                                                 file
                                                                             )}
                                                                         </Box>

--- a/packages/libfers/src/core/memory_projection.cpp
+++ b/packages/libfers/src/core/memory_projection.cpp
@@ -47,7 +47,8 @@ namespace core
 		 */
 		[[nodiscard]] bool isStreamingReceiver(const radar::Receiver& receiver) noexcept
 		{
-			return receiver.getMode() == OperationMode::CW_MODE || receiver.getMode() == OperationMode::FMCW_MODE;
+			return receiver.getMode() == OperationMode::CW_MODE || receiver.getMode() == OperationMode::FMCW_MODE ||
+				receiver.getMode() == OperationMode::SFCW_MODE;
 		}
 
 		/**

--- a/packages/libfers/src/core/output_metadata.cpp
+++ b/packages/libfers/src/core/output_metadata.cpp
@@ -51,6 +51,14 @@ namespace core
 			{
 				result["emitted_triangle_count"] = *segment.emitted_triangle_count;
 			}
+			if (segment.first_sfcw_step_start_time.has_value())
+			{
+				result["first_sfcw_step_start_time"] = *segment.first_sfcw_step_start_time;
+			}
+			if (segment.emitted_sfcw_step_count.has_value())
+			{
+				result["emitted_sfcw_step_count"] = *segment.emitted_sfcw_step_count;
+			}
 			return result;
 		}
 
@@ -128,6 +136,58 @@ namespace core
 			return result;
 		}
 
+		nlohmann::json sfcwToJson(const SfcwMetadata& sfcw)
+		{
+			nlohmann::json result = {{"carrier_frequency", sfcw.carrier_frequency},
+									 {"start_frequency_offset", sfcw.start_frequency_offset},
+									 {"step_size", sfcw.step_size},
+									 {"step_count", sfcw.step_count},
+									 {"dwell_time", sfcw.dwell_time},
+									 {"step_period", sfcw.step_period},
+									 {"first_frequency", sfcw.first_frequency},
+									 {"last_frequency", sfcw.last_frequency},
+									 {"frequency_span", sfcw.frequency_span},
+									 {"effective_bandwidth", sfcw.effective_bandwidth},
+									 {"range_resolution", sfcw.range_resolution},
+									 {"unambiguous_range", sfcw.unambiguous_range}};
+			if (sfcw.sweep_count.has_value())
+			{
+				result["sweep_count"] = *sfcw.sweep_count;
+			}
+			return result;
+		}
+
+		nlohmann::json sfcwSourceSegmentToJson(const SfcwSourceSegmentMetadata& segment)
+		{
+			nlohmann::json result = {{"start_time", segment.start_time}, {"end_time", segment.end_time}};
+			if (segment.first_step_start_time.has_value())
+			{
+				result["first_step_start_time"] = *segment.first_step_start_time;
+			}
+			if (segment.emitted_step_count.has_value())
+			{
+				result["emitted_step_count"] = *segment.emitted_step_count;
+			}
+			return result;
+		}
+
+		nlohmann::json sfcwSourceToJson(const SfcwSourceMetadata& source)
+		{
+			nlohmann::json segments = nlohmann::json::array();
+			for (const auto& segment : source.segments)
+			{
+				segments.push_back(sfcwSourceSegmentToJson(segment));
+			}
+
+			nlohmann::json result = {{"transmitter_id", source.transmitter_id},
+									 {"transmitter_name", source.transmitter_name},
+									 {"waveform_id", source.waveform_id},
+									 {"waveform_name", source.waveform_name},
+									 {"segments", segments}};
+			result.update(sfcwToJson(source.waveform));
+			return result;
+		}
+
 		template <typename T>
 		void addOptional(nlohmann::json& result, const char* key, const std::optional<T>& value)
 		{
@@ -197,6 +257,12 @@ namespace core
 				fmcw_sources.push_back(fmcwSourceToJson(source));
 			}
 
+			nlohmann::json sfcw_sources = nlohmann::json::array();
+			for (const auto& source : file.sfcw_sources)
+			{
+				sfcw_sources.push_back(sfcwSourceToJson(source));
+			}
+
 			nlohmann::json result = {{"receiver_id", file.receiver_id},
 									 {"receiver_name", file.receiver_name},
 									 {"mode", file.mode},
@@ -212,11 +278,16 @@ namespace core
 									 {"chunks", chunks},
 									 {"streaming_segments", streaming_segments},
 									 {"fmcw_sources", fmcw_sources},
+									 {"sfcw_sources", sfcw_sources},
 									 {"fmcw_dechirp_mode", file.fmcw_dechirp_mode},
 									 {"fmcw_dechirp_reference_source", file.fmcw_dechirp_reference_source}};
 			if (file.fmcw.has_value())
 			{
 				result["fmcw"] = fmcwToJson(*file.fmcw);
+			}
+			if (file.sfcw.has_value())
+			{
+				result["sfcw"] = sfcwToJson(*file.sfcw);
 			}
 			addDechirpReferenceJson(result, file);
 			addFmcwIfJson(result, file);

--- a/packages/libfers/src/core/output_metadata.h
+++ b/packages/libfers/src/core/output_metadata.h
@@ -43,6 +43,8 @@ namespace core
 		std::optional<std::uint64_t> emitted_chirp_count = std::nullopt; ///< Number of FMCW chirps emitted.
 		std::optional<RealType> first_triangle_start_time = std::nullopt; ///< First emitted FMCW triangle start time.
 		std::optional<std::uint64_t> emitted_triangle_count = std::nullopt; ///< Number of FMCW triangles emitted.
+		std::optional<RealType> first_sfcw_step_start_time = std::nullopt; ///< First emitted SFCW step start time.
+		std::optional<std::uint64_t> emitted_sfcw_step_count = std::nullopt; ///< Number of SFCW steps emitted.
 	};
 
 	/// FMCW waveform metadata captured for a streaming output file.
@@ -85,6 +87,44 @@ namespace core
 		std::vector<FmcwSourceSegmentMetadata> segments = {}; ///< Active transmitter segments.
 	};
 
+	/// SFCW waveform metadata captured for a streaming output file.
+	struct SfcwMetadata
+	{
+		RealType carrier_frequency = 0.0; ///< Waveform carrier frequency in hertz.
+		RealType start_frequency_offset = 0.0; ///< First-step offset relative to carrier in hertz.
+		RealType step_size = 0.0; ///< Uniform frequency step in hertz.
+		std::uint64_t step_count = 0; ///< Steps per sweep.
+		RealType dwell_time = 0.0; ///< Active dwell time per step in seconds.
+		RealType step_period = 0.0; ///< Step period in seconds.
+		std::optional<std::uint64_t> sweep_count = std::nullopt; ///< Optional finite sweep count.
+		RealType first_frequency = 0.0; ///< First RF step frequency in hertz.
+		RealType last_frequency = 0.0; ///< Last RF step frequency in hertz.
+		RealType frequency_span = 0.0; ///< First-to-last absolute span in hertz.
+		RealType effective_bandwidth = 0.0; ///< DFT-convention effective bandwidth in hertz.
+		RealType range_resolution = 0.0; ///< Approximate range resolution in meters.
+		RealType unambiguous_range = 0.0; ///< Uniform-step unambiguous range in meters.
+	};
+
+	/// Metadata for one active SFCW transmitter schedule segment.
+	struct SfcwSourceSegmentMetadata
+	{
+		RealType start_time = 0.0; ///< Transmitter segment start time in seconds.
+		RealType end_time = 0.0; ///< Transmitter segment end time in seconds.
+		std::optional<RealType> first_step_start_time = std::nullopt; ///< First emitted step start in the segment.
+		std::optional<std::uint64_t> emitted_step_count = std::nullopt; ///< Number of step starts in the segment.
+	};
+
+	/// Metadata for one SFCW illuminator represented in a streaming output file.
+	struct SfcwSourceMetadata
+	{
+		SimId transmitter_id = 0; ///< SFCW transmitter SimId.
+		std::string transmitter_name; ///< SFCW transmitter display name.
+		SimId waveform_id = 0; ///< SFCW waveform SimId.
+		std::string waveform_name; ///< SFCW waveform display name.
+		SfcwMetadata waveform; ///< SFCW waveform parameters.
+		std::vector<SfcwSourceSegmentMetadata> segments = {}; ///< Active transmitter segments.
+	};
+
 	/// Metadata for one receiver output file.
 	struct OutputFileMetadata
 	{
@@ -104,6 +144,8 @@ namespace core
 		std::vector<StreamingSegmentMetadata> streaming_segments = {}; ///< Streaming segments written to the file.
 		std::optional<FmcwMetadata> fmcw = std::nullopt; ///< Optional FMCW metadata for streaming outputs.
 		std::vector<FmcwSourceMetadata> fmcw_sources = {}; ///< FMCW illuminators represented in the output.
+		std::optional<SfcwMetadata> sfcw = std::nullopt; ///< Optional SFCW metadata for streaming outputs.
+		std::vector<SfcwSourceMetadata> sfcw_sources = {}; ///< SFCW illuminators represented in the output.
 		std::string fmcw_dechirp_mode = "none"; ///< Receiver dechirp mode for FMCW streaming outputs.
 		std::string fmcw_dechirp_reference_source = "none"; ///< Receiver dechirp reference source.
 		std::optional<SimId> fmcw_dechirp_reference_transmitter_id = std::nullopt; ///< Referenced LO transmitter ID.

--- a/packages/libfers/src/core/receiver_output.h
+++ b/packages/libfers/src/core/receiver_output.h
@@ -96,6 +96,28 @@ namespace core
 			RealType power = 0.0;
 		};
 
+		struct SfcwContext
+		{
+			bool present = false;
+			SimId waveform_id = 0;
+			std::string waveform_name = {};
+			RealType carrier_frequency = 0.0;
+			RealType power = 0.0;
+			RealType start_frequency_offset = 0.0;
+			RealType step_size = 0.0;
+			std::uint64_t step_count = 0;
+			RealType dwell_time = 0.0;
+			RealType step_period = 0.0;
+			RealType sweep_period = 0.0;
+			std::optional<std::uint64_t> sweep_count = std::nullopt;
+			RealType first_frequency = 0.0;
+			RealType last_frequency = 0.0;
+			RealType frequency_span = 0.0;
+			RealType effective_bandwidth = 0.0;
+			RealType range_resolution = 0.0;
+			RealType unambiguous_range = 0.0;
+		};
+
 		SimId receiver_id = 0;
 		std::string receiver_name = {};
 		std::string mode = {};
@@ -111,6 +133,7 @@ namespace core
 		PulsedContext pulsed = {};
 		CwContext cw = {};
 		FmcwContext fmcw = {};
+		SfcwContext sfcw = {};
 	};
 
 	struct ReceiverSampleBlock

--- a/packages/libfers/src/core/sim_threading.cpp
+++ b/packages/libfers/src/core/sim_threading.cpp
@@ -198,10 +198,71 @@ namespace core
 			logScheduledFmcwTriangleSummary(transmitter, triangle, configured_count, average_power);
 		}
 
+		void logUnscheduledSfcwSummary(const Transmitter& transmitter, const fers_signal::RadarSignal& waveform,
+									   const fers_signal::SteppedFrequencySignal& sfcw,
+									   const std::string& configured_count, const RealType duty_cycle,
+									   const RealType average_power)
+		{
+			const RealType active_start = params::startTime();
+			const auto source = makeActiveSource(&transmitter, active_start, params::endTime());
+			const auto total_step_count = countSfcwStepStarts(source, active_start, source.segment_end);
+			LOG(Level::INFO,
+				"SFCW transmitter '{}' steps={} df={} Hz dwell={} s step_period={} s sweep_period={} s "
+				"f_first={} Hz f_last={} Hz B_eff={} Hz range_resolution={} m unambiguous_range={} m duty_cycle={} "
+				"sweep_count={} total_step_count={} average_power={} W",
+				transmitter.getName(), sfcw.getStepCount(), sfcw.getStepSize(), sfcw.getDwellTime(),
+				sfcw.getStepPeriod(), sfcw.getSweepPeriod(), sfcw.firstFrequency(waveform.getCarrier()),
+				sfcw.lastFrequency(waveform.getCarrier()), sfcw.effectiveBandwidth(),
+				params::c() / (2.0 * sfcw.effectiveBandwidth()), params::c() / (2.0 * std::abs(sfcw.getStepSize())),
+				duty_cycle, configured_count, total_step_count, average_power);
+		}
+
+		void logScheduledSfcwSummary(const Transmitter& transmitter, const fers_signal::RadarSignal& waveform,
+									 const fers_signal::SteppedFrequencySignal& sfcw,
+									 const std::string& configured_count, const RealType duty_cycle,
+									 const RealType average_power)
+		{
+			std::uint64_t total_step_count = 0;
+			for (const auto& period : transmitter.getSchedule())
+			{
+				const RealType active_start = std::max(params::startTime(), period.start);
+				const auto source =
+					makeActiveSource(&transmitter, period.start, std::min(params::endTime(), period.end));
+				const auto segment_step_count = countSfcwStepStarts(source, active_start, source.segment_end);
+				total_step_count += segment_step_count;
+				LOG(Level::INFO,
+					"SFCW transmitter '{}' segment [{}, {}] steps={} df={} Hz dwell={} s step_period={} s "
+					"sweep_period={} s f_first={} Hz f_last={} Hz B_eff={} Hz range_resolution={} m "
+					"unambiguous_range={} m duty_cycle={} sweep_count={} segment_step_count={} total_step_count={} "
+					"average_power={} W",
+					transmitter.getName(), period.start, source.segment_end, sfcw.getStepCount(), sfcw.getStepSize(),
+					sfcw.getDwellTime(), sfcw.getStepPeriod(), sfcw.getSweepPeriod(),
+					sfcw.firstFrequency(waveform.getCarrier()), sfcw.lastFrequency(waveform.getCarrier()),
+					sfcw.effectiveBandwidth(), params::c() / (2.0 * sfcw.effectiveBandwidth()),
+					params::c() / (2.0 * std::abs(sfcw.getStepSize())), duty_cycle, configured_count,
+					segment_step_count, total_step_count, average_power);
+			}
+		}
+
+		void logSfcwSummary(const Transmitter& transmitter, const fers_signal::RadarSignal& waveform,
+							const fers_signal::SteppedFrequencySignal& sfcw)
+		{
+			const RealType duty_cycle = sfcw.getDwellTime() / sfcw.getStepPeriod();
+			const RealType average_power = waveform.getPower() * duty_cycle;
+			const auto configured_count = fmcwCountToken(sfcw.getSweepCount());
+			if (transmitter.getSchedule().empty())
+			{
+				logUnscheduledSfcwSummary(transmitter, waveform, sfcw, configured_count, duty_cycle, average_power);
+				return;
+			}
+			logScheduledSfcwSummary(transmitter, waveform, sfcw, configured_count, duty_cycle, average_power);
+		}
+
 		[[nodiscard]] bool isStreamingReceiver(const Receiver* const receiver) noexcept
 		{
 			return receiver != nullptr &&
-				(receiver->getMode() == OperationMode::CW_MODE || receiver->getMode() == OperationMode::FMCW_MODE);
+				(receiver->getMode() == OperationMode::CW_MODE || receiver->getMode() == OperationMode::FMCW_MODE ||
+				 receiver->getMode() == OperationMode::SFCW_MODE);
 		}
 
 		[[nodiscard]] bool activePastUserEnd(const Receiver* const receiver) noexcept
@@ -848,7 +909,7 @@ namespace core
 		for (const auto& transmitter_ptr : _world->getTransmitters())
 		{
 			const auto* waveform = transmitter_ptr->getSignal();
-			if (waveform == nullptr || !waveform->isFmcwFamily())
+			if (waveform == nullptr)
 			{
 				continue;
 			}
@@ -860,6 +921,10 @@ namespace core
 			else if (const auto* triangle = waveform->getFmcwTriangleSignal(); triangle != nullptr)
 			{
 				logFmcwTriangleSummary(*transmitter_ptr, *waveform, *triangle);
+			}
+			else if (const auto* sfcw = waveform->getSteppedFrequencySignal(); sfcw != nullptr)
+			{
+				logSfcwSummary(*transmitter_ptr, *waveform, *sfcw);
 			}
 		}
 	}
@@ -1104,9 +1169,7 @@ namespace core
 														 const std::size_t sample_index, const RealType t_step)
 	{
 		const auto& receiver_ptr = _world->getReceivers()[receiver_index];
-		if ((receiver_ptr->getMode() != OperationMode::CW_MODE &&
-			 receiver_ptr->getMode() != OperationMode::FMCW_MODE) ||
-			!receiver_ptr->isActive())
+		if (!isStreamingReceiver(receiver_ptr.get()) || !receiver_ptr->isActive())
 		{
 			return;
 		}
@@ -1971,8 +2034,7 @@ namespace core
 		for (std::size_t receiver_index = 0; receiver_index < _world->getReceivers().size(); ++receiver_index)
 		{
 			const auto& receiver_ptr = _world->getReceivers()[receiver_index];
-			if (receiver_ptr->getMode() == OperationMode::CW_MODE ||
-				receiver_ptr->getMode() == OperationMode::FMCW_MODE)
+			if (isStreamingReceiver(receiver_ptr.get()))
 			{
 				if (_output_sink != nullptr)
 				{

--- a/packages/libfers/src/core/simulation_state.cpp
+++ b/packages/libfers/src/core/simulation_state.cpp
@@ -105,6 +105,41 @@ namespace core
 			return first_index;
 		}
 
+		/// Returns the first SFCW flat step index that can contribute inside an interval.
+		std::optional<std::uint64_t> firstSfcwStepIndex(const ActiveStreamingSource& source,
+														const RealType active_start, const RealType active_end)
+		{
+			if (source.kind != StreamingWaveformKind::Sfcw || source.sfcw_step_period <= 0.0 ||
+				source.sfcw_step_count == 0)
+			{
+				return std::nullopt;
+			}
+
+			const RealType clipped_start = std::max(active_start, source.segment_start);
+			const RealType clipped_end = std::min(active_end, source.segment_end);
+			if (clipped_end <= clipped_start)
+			{
+				return std::nullopt;
+			}
+
+			const auto first_index = clipped_start <= source.segment_start
+				? std::uint64_t{0}
+				: ceilToUint((clipped_start - source.segment_start) / source.sfcw_step_period);
+			if (source.sfcw_sweep_count.has_value() &&
+				first_index >= static_cast<std::uint64_t>(*source.sfcw_sweep_count) * source.sfcw_step_count)
+			{
+				return std::nullopt;
+			}
+
+			const RealType first_start =
+				source.segment_start + static_cast<RealType>(first_index) * source.sfcw_step_period;
+			if (first_start >= clipped_end)
+			{
+				return std::nullopt;
+			}
+			return first_index;
+		}
+
 		/// Reduces a phase to [0, 2*pi).
 		RealType positiveModuloTwoPi(const RealType phase)
 		{
@@ -145,6 +180,25 @@ namespace core
 					source.segment_end =
 						std::min(source.segment_end,
 								 segment_start + static_cast<RealType>(*source.chirp_count) * source.chirp_period);
+				}
+				return;
+			}
+
+			if (const auto* const sfcw = signal->getSteppedFrequencySignal(); sfcw != nullptr)
+			{
+				source.kind = StreamingWaveformKind::Sfcw;
+				source.is_sfcw = true;
+				source.sfcw = sfcw;
+				source.start_freq_off = sfcw->getStartFrequencyOffset();
+				source.sfcw_step_size = sfcw->getStepSize();
+				source.sfcw_step_count = sfcw->getStepCount();
+				source.sfcw_dwell_time = sfcw->getDwellTime();
+				source.sfcw_step_period = sfcw->getStepPeriod();
+				source.sfcw_sweep_period = sfcw->getSweepPeriod();
+				source.sfcw_sweep_count = sfcw->getSweepCount();
+				if (const auto duration = sfcw->totalDuration(); duration.has_value())
+				{
+					source.segment_end = std::min(source.segment_end, segment_start + *duration);
 				}
 				return;
 			}
@@ -297,6 +351,39 @@ namespace core
 		}
 
 		const auto configured = static_cast<std::uint64_t>(*source.triangle_count);
+		return std::min(starts_in_interval, configured - *first_index);
+	}
+
+	std::optional<RealType> firstSfcwStepStart(const ActiveStreamingSource& source, const RealType active_start,
+											   const RealType active_end)
+	{
+		const auto first_index = firstSfcwStepIndex(source, active_start, active_end);
+		if (!first_index.has_value())
+		{
+			return std::nullopt;
+		}
+		return source.segment_start + static_cast<RealType>(*first_index) * source.sfcw_step_period;
+	}
+
+	std::uint64_t countSfcwStepStarts(const ActiveStreamingSource& source, const RealType active_start,
+									  const RealType active_end)
+	{
+		const auto first_index = firstSfcwStepIndex(source, active_start, active_end);
+		if (!first_index.has_value())
+		{
+			return 0;
+		}
+
+		const RealType clipped_end = std::min(active_end, source.segment_end);
+		const RealType first_start =
+			source.segment_start + static_cast<RealType>(*first_index) * source.sfcw_step_period;
+		const auto starts_in_interval = ceilToUint((clipped_end - first_start) / source.sfcw_step_period);
+		if (!source.sfcw_sweep_count.has_value())
+		{
+			return starts_in_interval;
+		}
+
+		const auto configured = static_cast<std::uint64_t>(*source.sfcw_sweep_count) * source.sfcw_step_count;
 		return std::min(starts_in_interval, configured - *first_index);
 	}
 }

--- a/packages/libfers/src/core/simulation_state.h
+++ b/packages/libfers/src/core/simulation_state.h
@@ -24,6 +24,7 @@ namespace fers_signal
 	class FmcwChirpSignal;
 	class FmcwTriangleSignal;
 	class RadarSignal;
+	class SteppedFrequencySignal;
 }
 
 namespace core
@@ -33,7 +34,8 @@ namespace core
 	{
 		Cw,
 		FmcwLinear,
-		FmcwTriangle
+		FmcwTriangle,
+		Sfcw
 	};
 
 	/// Cached description of an active streaming transmitter segment.
@@ -47,9 +49,12 @@ namespace core
 		RealType amplitude = 0.0; ///< Cached emitted signal amplitude.
 		StreamingWaveformKind kind = StreamingWaveformKind::Cw; ///< Cached streaming waveform shape.
 		bool is_fmcw = false; ///< Compatibility flag for any FMCW source.
+		bool is_sfcw = false; ///< Compatibility flag for any stepped-frequency source.
 
 		const fers_signal::FmcwChirpSignal* fmcw = nullptr; ///< Stable pointer to the linear FMCW waveform, if any.
 		const fers_signal::FmcwTriangleSignal* triangle = nullptr; ///< Stable pointer to the triangle waveform, if any.
+		const fers_signal::SteppedFrequencySignal* sfcw =
+			nullptr; ///< Stable pointer to the stepped-frequency waveform, if any.
 		RealType chirp_duration = 0.0; ///< Cached FMCW chirp duration in seconds.
 		RealType chirp_period = 0.0; ///< Cached FMCW chirp period in seconds.
 		RealType chirp_rate = 0.0; ///< Cached FMCW chirp rate in hertz per second.
@@ -66,6 +71,13 @@ namespace core
 		RealType mod_phi_tri = 0.0; ///< Triangle period phase increment modulo 2*pi.
 		RealType triangle_period = 0.0; ///< Cached full triangle period in seconds.
 		std::optional<std::size_t> triangle_count; ///< Optional finite triangle count for the segment.
+
+		RealType sfcw_step_size = 0.0; ///< Cached SFCW frequency step in hertz.
+		std::size_t sfcw_step_count = 0; ///< Cached SFCW steps per sweep.
+		RealType sfcw_dwell_time = 0.0; ///< Cached SFCW active dwell time in seconds.
+		RealType sfcw_step_period = 0.0; ///< Cached SFCW step period in seconds.
+		RealType sfcw_sweep_period = 0.0; ///< Cached SFCW sweep period in seconds.
+		std::optional<std::size_t> sfcw_sweep_count; ///< Optional finite SFCW sweep count for the segment.
 	};
 
 	/// Builds an active-source cache from a streaming transmitter and segment bounds.
@@ -91,6 +103,14 @@ namespace core
 	/// Counts FMCW triangles that start inside the absolute interval.
 	[[nodiscard]] std::uint64_t countFmcwTriangleStarts(const ActiveStreamingSource& source, RealType active_start,
 														RealType active_end);
+
+	/// Returns the first SFCW step start inside the absolute interval, if one exists.
+	[[nodiscard]] std::optional<RealType> firstSfcwStepStart(const ActiveStreamingSource& source, RealType active_start,
+															 RealType active_end);
+
+	/// Counts SFCW active dwells that start inside the absolute interval.
+	[[nodiscard]] std::uint64_t countSfcwStepStarts(const ActiveStreamingSource& source, RealType active_start,
+													RealType active_end);
 
 	/// Tracks the current FMCW chirp boundary for a streaming path.
 	struct FmcwChirpBoundaryTracker

--- a/packages/libfers/src/core/world.cpp
+++ b/packages/libfers/src/core/world.cpp
@@ -249,7 +249,8 @@ namespace core
 		{
 			if (receiver_ptr == nullptr ||
 				(receiver_ptr->getMode() != radar::OperationMode::CW_MODE &&
-				 receiver_ptr->getMode() != radar::OperationMode::FMCW_MODE))
+				 receiver_ptr->getMode() != radar::OperationMode::FMCW_MODE &&
+				 receiver_ptr->getMode() != radar::OperationMode::SFCW_MODE))
 			{
 				continue;
 			}

--- a/packages/libfers/src/processing/finalizer.cpp
+++ b/packages/libfers/src/processing/finalizer.cpp
@@ -66,6 +66,32 @@ namespace processing
 					: std::nullopt};
 		}
 
+		core::SfcwMetadata buildSfcwMetadata(const core::ActiveStreamingSource& source)
+		{
+			if (source.sfcw == nullptr)
+			{
+				return {};
+			}
+			const RealType effective_bandwidth = source.sfcw->effectiveBandwidth();
+			const RealType step_size = std::abs(source.sfcw->getStepSize());
+			return core::SfcwMetadata{
+				.carrier_frequency = source.carrier_freq,
+				.start_frequency_offset = source.sfcw->getStartFrequencyOffset(),
+				.step_size = source.sfcw->getStepSize(),
+				.step_count = static_cast<std::uint64_t>(source.sfcw->getStepCount()),
+				.dwell_time = source.sfcw->getDwellTime(),
+				.step_period = source.sfcw->getStepPeriod(),
+				.sweep_count = source.sfcw->getSweepCount().has_value()
+					? std::optional<std::uint64_t>(static_cast<std::uint64_t>(*source.sfcw->getSweepCount()))
+					: std::nullopt,
+				.first_frequency = source.sfcw->firstFrequency(source.carrier_freq),
+				.last_frequency = source.sfcw->lastFrequency(source.carrier_freq),
+				.frequency_span = source.sfcw->frequencySpan(),
+				.effective_bandwidth = effective_bandwidth,
+				.range_resolution = effective_bandwidth > 0.0 ? params::c() / (2.0 * effective_bandwidth) : 0.0,
+				.unambiguous_range = step_size > 0.0 ? params::c() / (2.0 * step_size) : 0.0};
+		}
+
 		/// Builds one FMCW source schedule segment from an active source cache.
 		core::FmcwSourceSegmentMetadata buildFmcwSourceSegment(const core::ActiveStreamingSource& source)
 		{
@@ -134,6 +160,63 @@ namespace processing
 			return fmcw_sources;
 		}
 
+		core::SfcwSourceSegmentMetadata buildSfcwSourceSegment(const core::ActiveStreamingSource& source)
+		{
+			const RealType active_start = std::max(params::startTime(), source.segment_start);
+			const RealType active_end = std::min(params::endTime(), source.segment_end);
+			return core::SfcwSourceSegmentMetadata{
+				.start_time = source.segment_start,
+				.end_time = source.segment_end,
+				.first_step_start_time = core::firstSfcwStepStart(source, active_start, active_end),
+				.emitted_step_count = core::countSfcwStepStarts(source, active_start, active_end)};
+		}
+
+		std::vector<core::SfcwSourceMetadata>::iterator findSfcwSource(std::vector<core::SfcwSourceMetadata>& sources,
+																	   const SimId transmitter_id,
+																	   const SimId waveform_id)
+		{
+			return std::ranges::find_if(
+				sources, [&](const core::SfcwSourceMetadata& source)
+				{ return source.transmitter_id == transmitter_id && source.waveform_id == waveform_id; });
+		}
+
+		std::vector<core::SfcwSourceMetadata>
+		buildSfcwSources(const std::vector<core::ActiveStreamingSource>& streaming_sources)
+		{
+			std::vector<core::SfcwSourceMetadata> sfcw_sources;
+			for (const auto& streaming_source : streaming_sources)
+			{
+				if (!streaming_source.is_sfcw || streaming_source.transmitter == nullptr)
+				{
+					continue;
+				}
+
+				const auto* signal = streaming_source.transmitter->getSignal();
+				if (signal == nullptr)
+				{
+					continue;
+				}
+
+				const auto transmitter_id = streaming_source.transmitter->getId();
+				const auto waveform_id = signal->getId();
+				auto existing = findSfcwSource(sfcw_sources, transmitter_id, waveform_id);
+				if (existing == sfcw_sources.end())
+				{
+					core::SfcwSourceMetadata source{.transmitter_id = transmitter_id,
+													.transmitter_name = streaming_source.transmitter->getName(),
+													.waveform_id = waveform_id,
+													.waveform_name = signal->getName(),
+													.waveform = buildSfcwMetadata(streaming_source)};
+					source.segments.push_back(buildSfcwSourceSegment(streaming_source));
+					sfcw_sources.push_back(std::move(source));
+					continue;
+				}
+
+				existing->segments.push_back(buildSfcwSourceSegment(streaming_source));
+			}
+			return sfcw_sources;
+		}
+
 		/// Adds scalar compatibility chirp metadata to receiver streaming segments for one FMCW source.
 		void annotateStreamingSegmentsForSingleFmcwSource(core::OutputFileMetadata& metadata,
 														  const core::ActiveStreamingSource& source)
@@ -161,6 +244,23 @@ namespace processing
 						segment.first_chirp_start_time = first_chirp;
 						segment.emitted_chirp_count = emitted;
 					}
+				}
+			}
+		}
+
+		void annotateStreamingSegmentsForSingleSfcwSource(core::OutputFileMetadata& metadata,
+														  const core::ActiveStreamingSource& source)
+		{
+			for (auto& segment : metadata.streaming_segments)
+			{
+				const RealType active_start = std::max(segment.start_time, source.segment_start);
+				const RealType active_end = std::min(segment.end_time, source.segment_end);
+				const auto first_step = core::firstSfcwStepStart(source, active_start, active_end);
+				const auto emitted = core::countSfcwStepStarts(source, active_start, active_end);
+				if (first_step.has_value() || emitted > 0)
+				{
+					segment.first_sfcw_step_start_time = first_step;
+					segment.emitted_sfcw_step_count = emitted;
 				}
 			}
 		}
@@ -353,6 +453,26 @@ namespace processing
 			}
 		}
 
+		void annotateSingleSfcwSource(core::OutputFileMetadata& metadata,
+									  const std::vector<core::ActiveStreamingSource>& streaming_sources)
+		{
+			metadata.sfcw_sources = buildSfcwSources(streaming_sources);
+			if (metadata.sfcw_sources.size() != 1)
+			{
+				return;
+			}
+
+			metadata.sfcw = metadata.sfcw_sources.front().waveform;
+			for (const auto& streaming_source : streaming_sources)
+			{
+				if (streaming_source.is_sfcw && streaming_source.transmitter != nullptr &&
+					streaming_source.transmitter->getId() == metadata.sfcw_sources.front().transmitter_id)
+				{
+					annotateStreamingSegmentsForSingleSfcwSource(metadata, streaming_source);
+				}
+			}
+		}
+
 		void populateFmcwIfMetadata(core::OutputFileMetadata& metadata, const radar::Receiver* receiver)
 		{
 			const auto& if_request = receiver->getFmcwIfChainRequest();
@@ -418,18 +538,21 @@ namespace processing
 							   const std::vector<core::ActiveStreamingSource>& streaming_sources,
 							   const RealType output_sample_rate, const std::vector<TimeSpan>& dechirp_time_spans = {})
 		{
-			core::OutputFileMetadata metadata{.receiver_id = receiver->getId(),
-											  .receiver_name = receiver->getName(),
-											  .mode = receiver->getMode() == radar::OperationMode::FMCW_MODE ? "fmcw"
-																											 : "cw",
-											  .path = hdf5_filename,
-											  .sampling_rate = output_sample_rate,
-											  .total_samples = static_cast<std::uint64_t>(total_samples),
-											  .sample_start = 0,
-											  .sample_end_exclusive = static_cast<std::uint64_t>(total_samples)};
+			core::OutputFileMetadata metadata{
+				.receiver_id = receiver->getId(),
+				.receiver_name = receiver->getName(),
+				.mode = receiver->getMode() == radar::OperationMode::FMCW_MODE
+					? "fmcw"
+					: (receiver->getMode() == radar::OperationMode::SFCW_MODE ? "sfcw" : "cw"),
+				.path = hdf5_filename,
+				.sampling_rate = output_sample_rate,
+				.total_samples = static_cast<std::uint64_t>(total_samples),
+				.sample_start = 0,
+				.sample_end_exclusive = static_cast<std::uint64_t>(total_samples)};
 
 			appendStreamingSegments(metadata, receiver, total_samples, output_sample_rate, dechirp_time_spans);
 			annotateSingleFmcwSource(metadata, streaming_sources);
+			annotateSingleSfcwSource(metadata, streaming_sources);
 
 			metadata.fmcw_dechirp_mode = std::string(radar::dechirpModeToken(receiver->getDechirpMode()));
 			if (receiver->isDechirpEnabled())
@@ -450,6 +573,8 @@ namespace processing
 				return "pulsed";
 			case radar::OperationMode::FMCW_MODE:
 				return "fmcw";
+			case radar::OperationMode::SFCW_MODE:
+				return "sfcw";
 			case radar::OperationMode::CW_MODE:
 				return "cw";
 			}
@@ -573,6 +698,41 @@ namespace processing
 			context.power = signal->getPower();
 		}
 
+		void populateWaveformIdentity(core::ReceiverStreamDescriptor::SfcwContext& context,
+									  const fers_signal::RadarSignal* signal)
+		{
+			if (signal == nullptr)
+			{
+				return;
+			}
+			context.waveform_id = signal->getId();
+			context.waveform_name = signal->getName();
+			context.carrier_frequency = signal->getCarrier();
+			context.power = signal->getPower();
+			const auto* sfcw = signal->getSteppedFrequencySignal();
+			if (sfcw == nullptr)
+			{
+				return;
+			}
+			const RealType effective_bandwidth = sfcw->effectiveBandwidth();
+			const RealType step_size = std::abs(sfcw->getStepSize());
+			context.start_frequency_offset = sfcw->getStartFrequencyOffset();
+			context.step_size = sfcw->getStepSize();
+			context.step_count = static_cast<std::uint64_t>(sfcw->getStepCount());
+			context.dwell_time = sfcw->getDwellTime();
+			context.step_period = sfcw->getStepPeriod();
+			context.sweep_period = sfcw->getSweepPeriod();
+			context.sweep_count = sfcw->getSweepCount().has_value()
+				? std::optional<std::uint64_t>(static_cast<std::uint64_t>(*sfcw->getSweepCount()))
+				: std::nullopt;
+			context.first_frequency = sfcw->firstFrequency(signal->getCarrier());
+			context.last_frequency = sfcw->lastFrequency(signal->getCarrier());
+			context.frequency_span = sfcw->frequencySpan();
+			context.effective_bandwidth = effective_bandwidth;
+			context.range_resolution = effective_bandwidth > 0.0 ? params::c() / (2.0 * effective_bandwidth) : 0.0;
+			context.unambiguous_range = step_size > 0.0 ? params::c() / (2.0 * step_size) : 0.0;
+		}
+
 		[[nodiscard]] core::ReceiverStreamDescriptor::PulsedContext buildPulsedContext(const radar::Receiver* receiver)
 		{
 			core::ReceiverStreamDescriptor::PulsedContext context;
@@ -618,6 +778,33 @@ namespace processing
 				if (const auto timing = receiver->getTiming(); timing)
 				{
 					context.carrier_frequency = timing->getFrequency();
+				}
+			}
+			return context;
+		}
+
+		[[nodiscard]] core::ReceiverStreamDescriptor::SfcwContext
+		buildSfcwContext(const radar::Receiver* receiver,
+						 const std::span<const core::ActiveStreamingSource> streaming_sources)
+		{
+			core::ReceiverStreamDescriptor::SfcwContext context;
+			if (receiver == nullptr || receiver->getMode() != radar::OperationMode::SFCW_MODE)
+			{
+				return context;
+			}
+
+			context.present = true;
+			if (const auto* transmitter = attachedTransmitter(receiver); transmitter != nullptr)
+			{
+				populateWaveformIdentity(context, transmitter->getSignal());
+			}
+			if (context.waveform_id == 0)
+			{
+				const auto found = std::ranges::find_if(streaming_sources, [](const core::ActiveStreamingSource& source)
+														{ return source.is_sfcw && source.transmitter != nullptr; });
+				if (found != streaming_sources.end())
+				{
+					populateWaveformIdentity(context, found->transmitter->getSignal());
 				}
 			}
 			return context;
@@ -691,7 +878,8 @@ namespace processing
 												  .initial_platform_state = buildInitialPlatformState(receiver),
 												  .pulsed = buildPulsedContext(receiver),
 												  .cw = buildCwContext(receiver),
-												  .fmcw = buildFmcwContext(receiver, streaming_sources)};
+												  .fmcw = buildFmcwContext(receiver, streaming_sources),
+												  .sfcw = buildSfcwContext(receiver, streaming_sources)};
 		if (const auto timing = receiver->getTiming(); timing)
 		{
 			descriptor.reference_frequency = timing->getFrequency();

--- a/packages/libfers/src/radar/radar_obj.h
+++ b/packages/libfers/src/radar/radar_obj.h
@@ -39,7 +39,8 @@ namespace radar
 	{
 		PULSED_MODE, ///< The component operates in a pulsed mode.
 		CW_MODE, ///< The component operates in a continuous-wave mode.
-		FMCW_MODE ///< The component operates in an FMCW streaming mode.
+		FMCW_MODE, ///< The component operates in an FMCW streaming mode.
+		SFCW_MODE ///< The component operates in a stepped-frequency CW streaming mode.
 	};
 
 	/**

--- a/packages/libfers/src/radar/transmitter.h
+++ b/packages/libfers/src/radar/transmitter.h
@@ -77,7 +77,8 @@ namespace radar
 		/// Returns true when the transmitter uses a continuous streaming mode.
 		[[nodiscard]] bool isStreamingMode() const noexcept
 		{
-			return _mode == OperationMode::CW_MODE || _mode == OperationMode::FMCW_MODE;
+			return _mode == OperationMode::CW_MODE || _mode == OperationMode::FMCW_MODE ||
+				_mode == OperationMode::SFCW_MODE;
 		}
 
 		/**

--- a/packages/libfers/src/serial/fmcw_validation.cpp
+++ b/packages/libfers/src/serial/fmcw_validation.cpp
@@ -20,7 +20,7 @@ namespace serial::fmcw_validation
 	namespace
 	{
 		/// Emits a warning when a streaming scenario may allocate a large I/Q buffer.
-		void warnStreamingMemory(const std::string& owner)
+		void warnStreamingMemory(const std::string& owner, const std::string_view mode_name)
 		{
 			const RealType duration = std::max<RealType>(0.0, params::endTime() - params::startTime());
 			const RealType effective_rate = params::rate() * params::oversampleRatio();
@@ -34,9 +34,9 @@ namespace serial::fmcw_validation
 
 			const double estimated_gib = static_cast<double>(estimated_bytes) / (1024.0 * 1024.0 * 1024.0);
 			LOG(logging::Level::WARNING,
-				"{} will buffer about {:.2f} GiB of FMCW streaming output for simulation_duration={} s at "
+				"{} will buffer about {:.2f} GiB of {} streaming output for simulation_duration={} s at "
 				"effective_rate={} Hz. Large simulation_time * bandwidth/rate products need chunking.",
-				owner, estimated_gib, duration, effective_rate);
+				owner, estimated_gib, mode_name, duration, effective_rate);
 		}
 
 		/// Returns schedule periods, or the full simulation as one implicit active period.
@@ -84,6 +84,51 @@ namespace serial::fmcw_validation
 				throw_error(owner + " yields a non-positive RF-equivalent frequency.");
 			}
 		}
+
+		void validateSfcwWaveform(const fers_signal::RadarSignal& wave, const std::string& owner,
+								  const fers_signal::SteppedFrequencySignal& sfcw, const Thrower& throw_error)
+		{
+			if (sfcw.getStepCount() < 1U)
+			{
+				throw_error(owner + " has SFCW step_count < 1.");
+			}
+			if (sfcw.getStepSize() == 0.0 || !std::isfinite(sfcw.getStepSize()))
+			{
+				throw_error(owner + " has invalid SFCW step_size.");
+			}
+			if (sfcw.getDwellTime() <= 0.0 || !std::isfinite(sfcw.getDwellTime()))
+			{
+				throw_error(owner + " has SFCW dwell_time <= 0.");
+			}
+			if (sfcw.getStepPeriod() <= 0.0 || !std::isfinite(sfcw.getStepPeriod()))
+			{
+				throw_error(owner + " has SFCW step_period <= 0.");
+			}
+			if (sfcw.getDwellTime() > sfcw.getStepPeriod())
+			{
+				throw_error(owner + " has SFCW dwell_time longer than step_period.");
+			}
+
+			const RealType f_low =
+				std::min(sfcw.firstFrequency(wave.getCarrier()), sfcw.lastFrequency(wave.getCarrier()));
+			if (f_low <= 0.0)
+			{
+				throw_error(owner + " yields a non-positive SFCW RF step frequency.");
+			}
+
+			const RealType output_samples_per_dwell = params::rate() * sfcw.getDwellTime();
+			if (output_samples_per_dwell < 1.0)
+			{
+				LOG(logging::Level::WARNING, "{} has fewer than one output sample per SFCW dwell.", owner);
+			}
+			const RealType internal_samples_per_dwell =
+				params::rate() * static_cast<RealType>(params::oversampleRatio()) * sfcw.getDwellTime();
+			if (internal_samples_per_dwell < 1.0)
+			{
+				LOG(logging::Level::WARNING, "{} has fewer than one internal sample per SFCW dwell.", owner);
+			}
+			warnStreamingMemory(owner, "SFCW");
+		}
 	}
 
 	void validateWaveform(const fers_signal::RadarSignal& wave, const std::string& owner, const Thrower& throw_error)
@@ -100,7 +145,7 @@ namespace serial::fmcw_validation
 				sweep_start + (fmcw->isDownChirp() ? -fmcw->getChirpBandwidth() : fmcw->getChirpBandwidth());
 			validateCommonSweep(wave, owner, fmcw->getChirpDuration(), fmcw->getChirpBandwidth(), sweep_start,
 								sweep_end, throw_error);
-			warnStreamingMemory(owner);
+			warnStreamingMemory(owner, "FMCW");
 			return;
 		}
 
@@ -110,17 +155,24 @@ namespace serial::fmcw_validation
 			const RealType sweep_end = sweep_start + triangle->getChirpBandwidth();
 			validateCommonSweep(wave, owner, triangle->getChirpDuration(), triangle->getChirpBandwidth(), sweep_start,
 								sweep_end, throw_error);
-			warnStreamingMemory(owner);
+			warnStreamingMemory(owner, "FMCW");
+			return;
+		}
+
+		if (const auto* sfcw = wave.getSteppedFrequencySignal(); sfcw != nullptr)
+		{
+			validateSfcwWaveform(wave, owner, *sfcw, throw_error);
 		}
 	}
 
 	void validateWaveformModeMatch(const fers_signal::RadarSignal& wave, const radar::OperationMode mode,
 								   const std::string& owner, const Thrower& throw_error)
 	{
-		const bool is_pulsed = !wave.isCw() && !wave.isFmcwFamily();
+		const bool is_pulsed = !wave.isCw() && !wave.isFmcwFamily() && !wave.isSteppedFrequency();
 		const bool matches = (mode == radar::OperationMode::PULSED_MODE && is_pulsed) ||
 			(mode == radar::OperationMode::CW_MODE && wave.isCw()) ||
-			(mode == radar::OperationMode::FMCW_MODE && wave.isFmcwFamily());
+			(mode == radar::OperationMode::FMCW_MODE && wave.isFmcwFamily()) ||
+			(mode == radar::OperationMode::SFCW_MODE && wave.isSteppedFrequency());
 		if (!matches)
 		{
 			throw_error(owner + " mode does not match waveform '" + wave.getName() + "'.");
@@ -153,6 +205,25 @@ namespace serial::fmcw_validation
 		if (const auto* fmcw = wave.getFmcwChirpSignal(); fmcw != nullptr)
 		{
 			validateSchedule(schedule, *fmcw, owner, throw_error);
+			return;
+		}
+
+		if (const auto* sfcw = wave.getSteppedFrequencySignal(); sfcw != nullptr)
+		{
+			for (const auto& period : effectiveSchedule(schedule))
+			{
+				const RealType duration = period.end - period.start;
+				if (duration < sfcw->getDwellTime())
+				{
+					LOG(logging::Level::WARNING, "{} has schedule period [{}, {}] shorter than one SFCW dwell ({}s).",
+						owner, period.start, period.end, sfcw->getDwellTime());
+				}
+				if (duration < sfcw->getSweepPeriod())
+				{
+					LOG(logging::Level::WARNING, "{} has schedule period [{}, {}] shorter than one SFCW sweep ({}s).",
+						owner, period.start, period.end, sfcw->getSweepPeriod());
+				}
+			}
 			return;
 		}
 

--- a/packages/libfers/src/serial/fmcw_validation.h
+++ b/packages/libfers/src/serial/fmcw_validation.h
@@ -17,6 +17,7 @@
 namespace fers_signal
 {
 	class FmcwChirpSignal;
+	class SteppedFrequencySignal;
 	class FmcwTriangleSignal;
 	class RadarSignal;
 }

--- a/packages/libfers/src/serial/hdf5_handler.cpp
+++ b/packages/libfers/src/serial/hdf5_handler.cpp
@@ -69,6 +69,7 @@ namespace serial
 			file.createAttribute("streaming_segment_count",
 								 static_cast<unsigned long long>(metadata.streaming_segments.size()));
 			file.createAttribute("fmcw_source_count", static_cast<unsigned long long>(metadata.fmcw_sources.size()));
+			file.createAttribute("sfcw_source_count", static_cast<unsigned long long>(metadata.sfcw_sources.size()));
 			file.createAttribute("fmcw_dechirp_mode", metadata.fmcw_dechirp_mode);
 			file.createAttribute("fmcw_dechirp_reference_source", metadata.fmcw_dechirp_reference_source);
 			file.createAttribute("fmcw_if_decimation_enabled", metadata.fmcw_if_decimation_enabled);
@@ -209,6 +210,28 @@ namespace serial
 			writeFmcwWaveformAttributes(file, "fmcw_", *metadata.fmcw, true);
 			writeStreamingSegmentFmcwAttributes(file, metadata);
 		}
+
+		void writeSfcwAttributes(HighFive::File& file, const core::OutputFileMetadata& metadata)
+		{
+			if (!metadata.sfcw.has_value())
+			{
+				return;
+			}
+			const auto& sfcw = *metadata.sfcw;
+			file.createAttribute("sfcw_carrier_frequency", sfcw.carrier_frequency);
+			file.createAttribute("sfcw_start_frequency_offset", sfcw.start_frequency_offset);
+			file.createAttribute("sfcw_step_size", sfcw.step_size);
+			file.createAttribute("sfcw_step_count", static_cast<unsigned long long>(sfcw.step_count));
+			file.createAttribute("sfcw_dwell_time", sfcw.dwell_time);
+			file.createAttribute("sfcw_step_period", sfcw.step_period);
+			createOptionalUnsignedAttribute(file, "sfcw_sweep_count", sfcw.sweep_count);
+			file.createAttribute("sfcw_first_frequency", sfcw.first_frequency);
+			file.createAttribute("sfcw_last_frequency", sfcw.last_frequency);
+			file.createAttribute("sfcw_frequency_span", sfcw.frequency_span);
+			file.createAttribute("sfcw_effective_bandwidth", sfcw.effective_bandwidth);
+			file.createAttribute("sfcw_range_resolution", sfcw.range_resolution);
+			file.createAttribute("sfcw_unambiguous_range", sfcw.unambiguous_range);
+		}
 	}
 
 	void writeOutputFileMetadataAttributes(HighFive::File& file, const core::OutputFileMetadata& metadata)
@@ -217,6 +240,7 @@ namespace serial
 		writeFmcwIfAttributes(file, metadata);
 		writeDechirpReferenceAttributes(file, metadata);
 		writeFmcwAttributes(file, metadata);
+		writeSfcwAttributes(file, metadata);
 	}
 
 	void readPulseData(const std::string& name, std::vector<ComplexType>& data)

--- a/packages/libfers/src/serial/json_serializer.cpp
+++ b/packages/libfers/src/serial/json_serializer.cpp
@@ -192,6 +192,15 @@ namespace
 			mode_json.contains("if_filter_transition_width");
 	}
 
+	void reject_non_empty_sfcw_mode(const nlohmann::json& comp_json, const std::string& owner)
+	{
+		if (comp_json.contains("sfcw_mode") &&
+			(!comp_json.at("sfcw_mode").is_object() || !comp_json.at("sfcw_mode").empty()))
+		{
+			throw std::runtime_error(owner + " sfcw_mode must be an empty object.");
+		}
+	}
+
 	std::optional<RealType> get_optional_positive_real(const nlohmann::json& object, const std::string_view key,
 													   const std::string& owner)
 	{
@@ -608,6 +617,18 @@ namespace fers_signal
 		{
 			j["cw"] = nlohmann::json::object();
 		}
+		else if (const auto* sfcw = rs.getSteppedFrequencySignal(); sfcw != nullptr)
+		{
+			j["stepped_frequency"] = {{"start_frequency_offset", sfcw->getStartFrequencyOffset()},
+									  {"step_size", sfcw->getStepSize()},
+									  {"step_count", sfcw->getStepCount()},
+									  {"dwell_time", sfcw->getDwellTime()},
+									  {"step_period", sfcw->getStepPeriod()}};
+			if (sfcw->getSweepCount().has_value())
+			{
+				j["stepped_frequency"]["sweep_count"] = *sfcw->getSweepCount();
+			}
+		}
 		else if (const auto* fmcw = rs.getFmcwChirpSignal(); fmcw != nullptr)
 		{
 			j["fmcw_linear_chirp"] = {{"direction", std::string(fmcwChirpDirectionToken(fmcw->getDirection()))},
@@ -662,6 +683,32 @@ namespace fers_signal
 			auto cw_signal = std::make_unique<CwSignal>();
 			rs = std::make_unique<RadarSignal>(name, power, carrier, params::endTime() - params::startTime(),
 											   std::move(cw_signal), id);
+		}
+		else if (j.contains("stepped_frequency"))
+		{
+			const auto& sfcw_json = j.at("stepped_frequency");
+			const auto step_count = sfcw_json.at("step_count").get<long long>();
+			if (step_count <= 0)
+			{
+				throw std::runtime_error("Waveform '" + name + "' has an invalid step_count.");
+			}
+			std::optional<std::size_t> sweep_count;
+			if (sfcw_json.contains("sweep_count"))
+			{
+				const auto parsed_count = sfcw_json.at("sweep_count").get<long long>();
+				if (parsed_count <= 0)
+				{
+					throw std::runtime_error("Waveform '" + name + "' has an invalid sweep_count.");
+				}
+				sweep_count = static_cast<std::size_t>(parsed_count);
+			}
+			auto sfcw_signal = std::make_unique<SteppedFrequencySignal>(
+				sfcw_json.at("start_frequency_offset").get<RealType>(), sfcw_json.at("step_size").get<RealType>(),
+				static_cast<std::size_t>(step_count), sfcw_json.at("dwell_time").get<RealType>(),
+				sfcw_json.at("step_period").get<RealType>(), sweep_count);
+			rs = std::make_unique<RadarSignal>(name, power, carrier, sfcw_signal->getDwellTime(),
+											   std::move(sfcw_signal), id);
+			validate_fmcw_waveform(*rs, "Waveform '" + name + "'");
 		}
 		else if (j.contains("fmcw_linear_chirp"))
 		{
@@ -861,6 +908,10 @@ namespace radar
 		{
 			j["fmcw_mode"] = nlohmann::json::object();
 		}
+		else if (t.getMode() == OperationMode::SFCW_MODE)
+		{
+			j["sfcw_mode"] = nlohmann::json::object();
+		}
 		else
 		{
 			j["cw_mode"] = nlohmann::json::object();
@@ -889,6 +940,10 @@ namespace radar
 		else if (r.getMode() == OperationMode::FMCW_MODE)
 		{
 			j["fmcw_mode"] = receiver_fmcw_mode_to_json(r);
+		}
+		else if (r.getMode() == OperationMode::SFCW_MODE)
+		{
+			j["sfcw_mode"] = nlohmann::json::object();
 		}
 		else
 		{
@@ -1037,6 +1092,10 @@ namespace
 		else if (transmitter.getMode() == radar::OperationMode::FMCW_MODE)
 		{
 			monostatic_comp["fmcw_mode"] = receiver_fmcw_mode_to_json(receiver);
+		}
+		else if (transmitter.getMode() == radar::OperationMode::SFCW_MODE)
+		{
+			monostatic_comp["sfcw_mode"] = nlohmann::json::object();
 		}
 		else
 		{
@@ -1266,7 +1325,8 @@ namespace
 	{
 		return static_cast<std::size_t>(comp_json.contains("pulsed_mode")) +
 			static_cast<std::size_t>(comp_json.contains("fmcw_mode")) +
-			static_cast<std::size_t>(comp_json.contains("cw_mode"));
+			static_cast<std::size_t>(comp_json.contains("cw_mode")) +
+			static_cast<std::size_t>(comp_json.contains("sfcw_mode"));
 	}
 
 	/// Throws when a partial update or full component declares conflicting modes.
@@ -1275,7 +1335,8 @@ namespace
 		if (mode_block_count(comp_json) > 1)
 		{
 			throw std::runtime_error(error_context +
-									 " must have at most one of 'pulsed_mode', 'cw_mode', or 'fmcw_mode'.");
+									 " must have at most one of 'pulsed_mode', 'cw_mode', "
+									 "'fmcw_mode', or 'sfcw_mode'.");
 		}
 	}
 
@@ -1291,11 +1352,17 @@ namespace
 		{
 			return radar::OperationMode::FMCW_MODE;
 		}
+		if (comp_json.contains("sfcw_mode"))
+		{
+			return radar::OperationMode::SFCW_MODE;
+		}
 		if (comp_json.contains("cw_mode"))
 		{
 			return radar::OperationMode::CW_MODE;
 		}
-		throw std::runtime_error(error_context + " must have a 'pulsed_mode', 'cw_mode', or 'fmcw_mode' block.");
+		throw std::runtime_error(error_context +
+								 " must have a 'pulsed_mode', 'cw_mode', or 'fmcw_mode' block, or an 'sfcw_mode' "
+								 "block.");
 	}
 
 	/// Parses a transmitter component from JSON into the world.
@@ -1329,6 +1396,7 @@ namespace
 
 		radar::OperationMode const mode =
 			parse_mode(comp_json, "Transmitter component '" + comp_json.value("name", "Unnamed") + "'");
+		reject_non_empty_sfcw_mode(comp_json, "Transmitter component '" + comp_json.value("name", "Unnamed") + "'");
 		if (mode == radar::OperationMode::FMCW_MODE && comp_json.contains("fmcw_mode") &&
 			has_dechirp_fields(comp_json.at("fmcw_mode")))
 		{
@@ -1365,13 +1433,13 @@ namespace
 			}
 			auto schedule =
 				radar::processRawSchedule(raw, trans->getName(), mode == radar::OperationMode::PULSED_MODE, pri);
-			if (waveform->isFmcwFamily())
+			if (waveform->isFmcwFamily() || waveform->isSteppedFrequency())
 			{
 				validate_fmcw_schedule(schedule, *waveform, "Transmitter component '" + trans->getName() + "'");
 			}
 			trans->setSchedule(std::move(schedule));
 		}
-		else if (waveform->isFmcwFamily())
+		else if (waveform->isFmcwFamily() || waveform->isSteppedFrequency())
 		{
 			validate_fmcw_schedule(trans->getSchedule(), *waveform, "Transmitter component '" + trans->getName() + "'");
 		}
@@ -1404,6 +1472,7 @@ namespace
 
 		radar::OperationMode const mode =
 			parse_mode(comp_json, "Receiver component '" + comp_json.value("name", "Unnamed") + "'");
+		reject_non_empty_sfcw_mode(comp_json, "Receiver component '" + comp_json.value("name", "Unnamed") + "'");
 
 		const auto recv_id = parse_json_id(comp_json, "id", "Receiver");
 		auto recv =
@@ -1540,6 +1609,7 @@ namespace
 
 		radar::OperationMode const mode =
 			parse_mode(comp_json, "Monostatic component '" + comp_json.value("name", "Unnamed") + "'");
+		reject_non_empty_sfcw_mode(comp_json, "Monostatic component '" + comp_json.value("name", "Unnamed") + "'");
 
 		// Transmitter part
 		const auto tx_id = parse_json_id(comp_json, "tx_id", "Monostatic");
@@ -1599,7 +1669,7 @@ namespace
 			// Process once, apply to both
 			auto processed_schedule =
 				radar::processRawSchedule(raw, trans->getName(), mode == radar::OperationMode::PULSED_MODE, pri);
-			if (waveform->isFmcwFamily())
+			if (waveform->isFmcwFamily() || waveform->isSteppedFrequency())
 			{
 				validate_fmcw_schedule(processed_schedule, *waveform,
 									   "Monostatic component '" + comp_json.value("name", "Unnamed") + "'");
@@ -1608,7 +1678,7 @@ namespace
 			trans->setSchedule(processed_schedule);
 			recv->setSchedule(processed_schedule);
 		}
-		else if (waveform->isFmcwFamily())
+		else if (waveform->isFmcwFamily() || waveform->isSteppedFrequency())
 		{
 			validate_fmcw_schedule(trans->getSchedule(), *waveform,
 								   "Monostatic component '" + comp_json.value("name", "Unnamed") + "'");
@@ -1899,6 +1969,11 @@ namespace serial
 			}
 			tx.setMode(radar::OperationMode::FMCW_MODE);
 		}
+		else if (j.contains("sfcw_mode"))
+		{
+			reject_non_empty_sfcw_mode(j, "Transmitter '" + tx.getName() + "'");
+			tx.setMode(radar::OperationMode::SFCW_MODE);
+		}
 		else if (j.contains("cw_mode"))
 		{
 			tx.setMode(radar::OperationMode::CW_MODE);
@@ -1963,7 +2038,7 @@ namespace serial
 		}
 		validate_fmcw_waveform(*tx.getSignal(), "Waveform '" + tx.getSignal()->getName() + "'");
 		validate_waveform_mode_match(*tx.getSignal(), tx.getMode(), owner);
-		if (tx.getSignal()->isFmcwFamily())
+		if (tx.getSignal()->isFmcwFamily() || tx.getSignal()->isSteppedFrequency())
 		{
 			validate_fmcw_schedule(tx.getSchedule(), *tx.getSignal(), owner);
 		}
@@ -1980,7 +2055,7 @@ namespace serial
 		const bool pulsed = tx.getMode() == radar::OperationMode::PULSED_MODE;
 		const RealType pri = pulsed ? 1.0 / tx.getPrf() : 0.0;
 		auto schedule = radar::processRawSchedule(raw, tx.getName(), pulsed, pri);
-		if (tx.getSignal() != nullptr && tx.getSignal()->isFmcwFamily())
+		if (tx.getSignal() != nullptr && (tx.getSignal()->isFmcwFamily() || tx.getSignal()->isSteppedFrequency()))
 		{
 			validate_fmcw_schedule(schedule, *tx.getSignal(), owner);
 		}
@@ -2015,6 +2090,11 @@ namespace serial
 		else if (j.contains("fmcw_mode"))
 		{
 			rx.setMode(radar::OperationMode::FMCW_MODE);
+		}
+		else if (j.contains("sfcw_mode"))
+		{
+			reject_non_empty_sfcw_mode(j, "Receiver '" + rx.getName() + "'");
+			rx.setMode(radar::OperationMode::SFCW_MODE);
 		}
 		else if (j.contains("cw_mode"))
 		{
@@ -2169,7 +2249,7 @@ namespace serial
 		const bool pulsed = tx.getMode() == radar::OperationMode::PULSED_MODE;
 		const RealType pri = pulsed ? 1.0 / tx.getPrf() : 0.0;
 		auto processed_schedule = radar::processRawSchedule(raw, tx.getName(), pulsed, pri);
-		if (tx.getSignal() != nullptr && tx.getSignal()->isFmcwFamily())
+		if (tx.getSignal() != nullptr && (tx.getSignal()->isFmcwFamily() || tx.getSignal()->isSteppedFrequency()))
 		{
 			validate_fmcw_schedule(processed_schedule, *tx.getSignal(), "Monostatic '" + tx.getName() + "'");
 		}

--- a/packages/libfers/src/serial/vita49/vita49_context_builder.cpp
+++ b/packages/libfers/src/serial/vita49/vita49_context_builder.cpp
@@ -53,6 +53,10 @@ namespace serial::vita49
 		{
 			flags |= ContextFlagPulsedMetadataPresent;
 		}
+		if (request.stream.sfcw.present && modeAllowsMetadata(request.stream.mode, "sfcw"))
+		{
+			flags |= ContextFlagSfcwMetadataPresent;
+		}
 
 		return ContextPacket{
 			.stream_id = request.stream_id,
@@ -80,6 +84,7 @@ namespace serial::vita49
 			.pulsed = request.stream.pulsed,
 			.cw = request.stream.cw,
 			.fmcw = request.stream.fmcw,
+			.sfcw = request.stream.sfcw,
 		};
 	}
 }

--- a/packages/libfers/src/serial/vita49/vita49_serializer.cpp
+++ b/packages/libfers/src/serial/vita49/vita49_serializer.cpp
@@ -116,11 +116,36 @@ namespace serial::vita49
 					{"dechirp_reference_waveform_name", packet.fmcw.dechirp_reference_waveform_name}};
 		}
 
+		[[nodiscard]] nlohmann::json makeSfcwMetadataJson(const ContextPacket& packet)
+		{
+			nlohmann::json result = {{"present", packet.sfcw.present},
+									 {"waveform_id", packet.sfcw.waveform_id},
+									 {"waveform_name", packet.sfcw.waveform_name},
+									 {"carrier_hz", packet.sfcw.carrier_frequency},
+									 {"start_frequency_offset_hz", packet.sfcw.start_frequency_offset},
+									 {"step_size_hz", packet.sfcw.step_size},
+									 {"step_count", packet.sfcw.step_count},
+									 {"dwell_time_s", packet.sfcw.dwell_time},
+									 {"step_period_s", packet.sfcw.step_period},
+									 {"sweep_period_s", packet.sfcw.sweep_period},
+									 {"first_frequency_hz", packet.sfcw.first_frequency},
+									 {"last_frequency_hz", packet.sfcw.last_frequency},
+									 {"frequency_span_hz", packet.sfcw.frequency_span},
+									 {"effective_bandwidth_hz", packet.sfcw.effective_bandwidth}};
+			result["sweep_count"] = packet.sfcw.sweep_count.has_value() ? nlohmann::json(*packet.sfcw.sweep_count)
+																		: nlohmann::json(nullptr);
+			return result;
+		}
+
 		[[nodiscard]] nlohmann::json makeWaveformMetadataJson(const ContextPacket& packet)
 		{
 			if (packet.receiver_mode == "fmcw")
 			{
 				return {{"kind", "fmcw"}, {"metadata_ref", "fmcw"}};
+			}
+			if (packet.receiver_mode == "sfcw")
+			{
+				return {{"kind", "sfcw"}, {"metadata_ref", "sfcw"}};
 			}
 			if (packet.receiver_mode == "pulsed")
 			{
@@ -133,6 +158,10 @@ namespace serial::vita49
 			if (packet.fmcw.present)
 			{
 				return {{"kind", "fmcw"}, {"metadata_ref", "fmcw"}};
+			}
+			if (packet.sfcw.present)
+			{
+				return {{"kind", "sfcw"}, {"metadata_ref", "sfcw"}};
 			}
 			if (packet.pulsed.present)
 			{
@@ -147,7 +176,8 @@ namespace serial::vita49
 
 		[[nodiscard]] bool hasKnownReceiverMode(const ContextPacket& packet) noexcept
 		{
-			return packet.receiver_mode == "fmcw" || packet.receiver_mode == "pulsed" || packet.receiver_mode == "cw";
+			return packet.receiver_mode == "fmcw" || packet.receiver_mode == "sfcw" ||
+				packet.receiver_mode == "pulsed" || packet.receiver_mode == "cw";
 		}
 
 		[[nodiscard]] nlohmann::json makeContextMetadataJson(const ContextPacket& packet)
@@ -195,6 +225,10 @@ namespace serial::vita49
 			if (packet.receiver_mode == "fmcw" || (!known_mode && packet.fmcw.present))
 			{
 				metadata["fmcw"] = makeFmcwMetadataJson(packet);
+			}
+			if (packet.receiver_mode == "sfcw" || (!known_mode && packet.sfcw.present))
+			{
+				metadata["sfcw"] = makeSfcwMetadataJson(packet);
 			}
 			return metadata;
 		}

--- a/packages/libfers/src/serial/vita49/vita49_types.h
+++ b/packages/libfers/src/serial/vita49/vita49_types.h
@@ -93,6 +93,7 @@ namespace serial::vita49
 		ContextFlagFmcwMetadataPresent = 1u << 5u,
 		ContextFlagCwMetadataPresent = 1u << 6u,
 		ContextFlagPulsedMetadataPresent = 1u << 7u,
+		ContextFlagSfcwMetadataPresent = 1u << 8u,
 	};
 
 	struct Timestamp
@@ -136,6 +137,7 @@ namespace serial::vita49
 		core::ReceiverStreamDescriptor::PulsedContext pulsed;
 		core::ReceiverStreamDescriptor::CwContext cw;
 		core::ReceiverStreamDescriptor::FmcwContext fmcw;
+		core::ReceiverStreamDescriptor::SfcwContext sfcw;
 	};
 
 	struct SerializedPacket

--- a/packages/libfers/src/serial/xml_parser_utils.cpp
+++ b/packages/libfers/src/serial/xml_parser_utils.cpp
@@ -58,8 +58,8 @@ namespace serial::xml_parser_utils
 				if (selected_mode.has_value())
 				{
 					throw XmlException(owner +
-									   " must specify exactly one radar mode (<pulsed_mode>, <cw_mode>, or "
-									   "<fmcw_mode>).");
+									   " must specify exactly one radar mode (<pulsed_mode>, <cw_mode>, "
+									   "<fmcw_mode>, or <sfcw_mode>).");
 				}
 				selected_mode = mode;
 			};
@@ -67,12 +67,23 @@ namespace serial::xml_parser_utils
 			select_mode("pulsed_mode", radar::OperationMode::PULSED_MODE);
 			select_mode("cw_mode", radar::OperationMode::CW_MODE);
 			select_mode("fmcw_mode", radar::OperationMode::FMCW_MODE);
+			select_mode("sfcw_mode", radar::OperationMode::SFCW_MODE);
 			if (!selected_mode.has_value())
 			{
 				throw XmlException(owner +
-								   " must specify exactly one radar mode (<pulsed_mode>, <cw_mode>, or <fmcw_mode>).");
+								   " must specify exactly one radar mode (<pulsed_mode>, <cw_mode>, "
+								   "<fmcw_mode>, or <sfcw_mode>).");
 			}
 			return *selected_mode;
+		}
+
+		void reject_non_empty_sfcw_mode(const XmlElement& parent, const std::string& owner)
+		{
+			const XmlElement sfcw_mode = parent.childElement("sfcw_mode", 0);
+			if (sfcw_mode.isValid() && sfcw_mode.childElement("", 0).isValid())
+			{
+				throw XmlException(owner + " sfcw_mode must be empty.");
+			}
 		}
 
 		/// Returns true when an FMCW mode block carries receiver-side FMCW fields.
@@ -658,6 +669,38 @@ namespace serial::xml_parser_utils
 				name, power, carrier, ctx.parameters.end - ctx.parameters.start, std::move(cw_signal), id);
 			ctx.world->add(std::move(wave));
 		}
+		else if (const XmlElement sfcw_element = waveform.childElement("stepped_frequency", 0); sfcw_element.isValid())
+		{
+			const RealType start_frequency_offset = get_child_real_type(sfcw_element, "start_frequency_offset");
+			const RealType step_size = get_child_real_type(sfcw_element, "step_size");
+			const RealType raw_step_count = get_child_real_type(sfcw_element, "step_count");
+			if (raw_step_count <= 0.0 || std::floor(raw_step_count) != raw_step_count)
+			{
+				throw XmlException("Waveform '" + name + "' has an invalid step_count.");
+			}
+			const RealType dwell_time = get_child_real_type(sfcw_element, "dwell_time");
+			const RealType step_period = get_child_real_type(sfcw_element, "step_period");
+
+			std::optional<std::size_t> sweep_count;
+			if (const auto sweep_count_element = sfcw_element.childElement("sweep_count", 0);
+				sweep_count_element.isValid())
+			{
+				const RealType raw_count = get_child_real_type(sfcw_element, "sweep_count");
+				if (raw_count <= 0.0 || std::floor(raw_count) != raw_count)
+				{
+					throw XmlException("Waveform '" + name + "' has an invalid sweep_count.");
+				}
+				sweep_count = static_cast<std::size_t>(raw_count);
+			}
+
+			auto sfcw_signal = std::make_unique<fers_signal::SteppedFrequencySignal>(
+				start_frequency_offset, step_size, static_cast<std::size_t>(raw_step_count), dwell_time, step_period,
+				sweep_count);
+			auto wave = std::make_unique<fers_signal::RadarSignal>(name, power, carrier, sfcw_signal->getDwellTime(),
+																   std::move(sfcw_signal), id);
+			validate_fmcw_waveform(*wave, "Waveform '" + name + "'");
+			ctx.world->add(std::move(wave));
+		}
 		else if (const XmlElement fmcw_element = waveform.childElement("fmcw_linear_chirp", 0); fmcw_element.isValid())
 		{
 			const auto direction =
@@ -1062,7 +1105,7 @@ namespace serial::xml_parser_utils
 
 		RealType const pri = is_pulsed ? (1.0 / transmitter_obj->getPrf()) : 0.0;
 		auto schedule = parseSchedule(transmitter, name, is_pulsed, pri);
-		if (wave->isFmcwFamily())
+		if (wave->isFmcwFamily() || wave->isSteppedFrequency())
 		{
 			validate_fmcw_schedule(schedule, *wave, "Transmitter '" + name + "'");
 		}
@@ -1080,6 +1123,7 @@ namespace serial::xml_parser_utils
 	{
 		const std::string name = XmlElement::getSafeAttribute(transmitter, "name");
 		const radar::OperationMode mode = parse_mode_elements(transmitter, "Transmitter '" + name + "'");
+		reject_non_empty_sfcw_mode(transmitter, "Transmitter '" + name + "'");
 		if (const XmlElement fmcw_mode = transmitter.childElement("fmcw_mode", 0);
 			fmcw_mode.isValid() && has_dechirp_fields(fmcw_mode))
 		{
@@ -1181,6 +1225,7 @@ namespace serial::xml_parser_utils
 	{
 		const std::string name = XmlElement::getSafeAttribute(receiver, "name");
 		const radar::OperationMode mode = parse_mode_elements(receiver, "Receiver '" + name + "'");
+		reject_non_empty_sfcw_mode(receiver, "Receiver '" + name + "'");
 		return parseReceiverWithMode(receiver, platform, ctx, refs, mode);
 	}
 
@@ -1189,6 +1234,7 @@ namespace serial::xml_parser_utils
 	{
 		const std::string name = XmlElement::getSafeAttribute(monostatic, "name");
 		const radar::OperationMode monostatic_mode = parse_mode_elements(monostatic, "Monostatic '" + name + "'");
+		reject_non_empty_sfcw_mode(monostatic, "Monostatic '" + name + "'");
 		radar::Transmitter* trans = parseTransmitterWithMode(monostatic, platform, ctx, refs, monostatic_mode);
 		radar::Receiver* recv = parseReceiverWithMode(monostatic, platform, ctx, refs, monostatic_mode);
 		if (trans->getMode() != monostatic_mode || recv->getMode() != monostatic_mode)

--- a/packages/libfers/src/serial/xml_serializer_utils.cpp
+++ b/packages/libfers/src/serial/xml_serializer_utils.cpp
@@ -131,6 +131,19 @@ namespace serial::xml_serializer_utils
 				addChildWithNumber(fmcw_elem, "chirp_count", static_cast<RealType>(*fmcw->getChirpCount()));
 			}
 		}
+		else if (const auto* sfcw = waveform.getSteppedFrequencySignal(); sfcw != nullptr)
+		{
+			const XmlElement sfcw_elem = parent.addChild("stepped_frequency");
+			addChildWithNumber(sfcw_elem, "start_frequency_offset", sfcw->getStartFrequencyOffset());
+			addChildWithNumber(sfcw_elem, "step_size", sfcw->getStepSize());
+			addChildWithNumber(sfcw_elem, "step_count", static_cast<RealType>(sfcw->getStepCount()));
+			addChildWithNumber(sfcw_elem, "dwell_time", sfcw->getDwellTime());
+			addChildWithNumber(sfcw_elem, "step_period", sfcw->getStepPeriod());
+			if (sfcw->getSweepCount().has_value())
+			{
+				addChildWithNumber(sfcw_elem, "sweep_count", static_cast<RealType>(*sfcw->getSweepCount()));
+			}
+		}
 		else if (const auto* triangle = waveform.getFmcwTriangleSignal(); triangle != nullptr)
 		{
 			const XmlElement fmcw_elem = parent.addChild("fmcw_triangle");
@@ -333,6 +346,10 @@ namespace serial::xml_serializer_utils
 		{
 			(void)tx_elem.addChild("fmcw_mode");
 		}
+		else if (tx.getMode() == radar::OperationMode::SFCW_MODE)
+		{
+			(void)tx_elem.addChild("sfcw_mode");
+		}
 		else
 		{
 			(void)tx_elem.addChild("cw_mode");
@@ -397,6 +414,10 @@ namespace serial::xml_serializer_utils
 		{
 			serializeReceiverFmcwMode(rx, rx_elem.addChild("fmcw_mode"));
 		}
+		else if (rx.getMode() == radar::OperationMode::SFCW_MODE)
+		{
+			(void)rx_elem.addChild("sfcw_mode");
+		}
 		else
 		{
 			(void)rx_elem.addChild("cw_mode");
@@ -430,6 +451,10 @@ namespace serial::xml_serializer_utils
 		else if (tx.getMode() == radar::OperationMode::FMCW_MODE)
 		{
 			serializeReceiverFmcwMode(rx, mono_elem.addChild("fmcw_mode"));
+		}
+		else if (tx.getMode() == radar::OperationMode::SFCW_MODE)
+		{
+			(void)mono_elem.addChild("sfcw_mode");
 		}
 		else
 		{

--- a/packages/libfers/src/signal/radar_signal.cpp
+++ b/packages/libfers/src/signal/radar_signal.cpp
@@ -52,6 +52,98 @@ namespace fers_signal
 		return {};
 	}
 
+	SteppedFrequencySignal::SteppedFrequencySignal(const RealType start_frequency_offset, const RealType step_size,
+												   const std::size_t step_count, const RealType dwell_time,
+												   const RealType step_period, std::optional<std::size_t> sweep_count) :
+		_start_frequency_offset(start_frequency_offset), _step_size(step_size), _step_count(step_count),
+		_dwell_time(dwell_time), _step_period(step_period), _sweep_count(sweep_count)
+	{
+	}
+
+	RealType SteppedFrequencySignal::firstFrequency(const RealType carrier_frequency) const noexcept
+	{
+		return carrier_frequency + _start_frequency_offset;
+	}
+
+	RealType SteppedFrequencySignal::lastFrequency(const RealType carrier_frequency) const noexcept
+	{
+		if (_step_count == 0)
+		{
+			return firstFrequency(carrier_frequency);
+		}
+		return firstFrequency(carrier_frequency) + static_cast<RealType>(_step_count - 1U) * _step_size;
+	}
+
+	RealType SteppedFrequencySignal::frequencySpan() const noexcept
+	{
+		if (_step_count == 0)
+		{
+			return 0.0;
+		}
+		return std::abs(static_cast<RealType>(_step_count - 1U) * _step_size);
+	}
+
+	RealType SteppedFrequencySignal::effectiveBandwidth() const noexcept
+	{
+		return static_cast<RealType>(_step_count) * std::abs(_step_size);
+	}
+
+	std::optional<RealType> SteppedFrequencySignal::totalDuration() const noexcept
+	{
+		if (!_sweep_count.has_value())
+		{
+			return std::nullopt;
+		}
+		return static_cast<RealType>(*_sweep_count) * getSweepPeriod();
+	}
+
+	std::optional<SteppedFrequencySignal::StepState>
+	SteppedFrequencySignal::activeStepAt(const RealType time_since_segment_start,
+										 const RealType carrier_frequency) const noexcept
+	{
+		if (time_since_segment_start < 0.0 || _step_count == 0 || _step_period <= 0.0 || _dwell_time <= 0.0)
+		{
+			return std::nullopt;
+		}
+
+		const RealType sweep_period = getSweepPeriod();
+		const auto sweep_index = static_cast<std::size_t>(std::floor(time_since_segment_start / sweep_period));
+		if (_sweep_count.has_value() && sweep_index >= *_sweep_count)
+		{
+			return std::nullopt;
+		}
+
+		const RealType local_sweep_time = time_since_segment_start - static_cast<RealType>(sweep_index) * sweep_period;
+		const auto step_index = static_cast<std::size_t>(std::floor(local_sweep_time / _step_period));
+		if (step_index >= _step_count)
+		{
+			return std::nullopt;
+		}
+
+		const RealType step_start_time =
+			static_cast<RealType>(sweep_index) * sweep_period + static_cast<RealType>(step_index) * _step_period;
+		const RealType local_step_time = time_since_segment_start - step_start_time;
+		if (local_step_time < 0.0 || local_step_time >= _dwell_time)
+		{
+			return std::nullopt;
+		}
+
+		return StepState{.step_index = step_index,
+						 .sweep_index = sweep_index,
+						 .step_start_time = step_start_time,
+						 .dwell_end_time = step_start_time + _dwell_time,
+						 .step_end_time = step_start_time + _step_period,
+						 .rf_frequency =
+							 firstFrequency(carrier_frequency) + static_cast<RealType>(step_index) * _step_size};
+	}
+
+	std::vector<ComplexType> SteppedFrequencySignal::render(const std::vector<interp::InterpPoint>& /*points*/,
+															unsigned& size, const RealType /*fracWinDelay*/) const
+	{
+		size = 0;
+		return {};
+	}
+
 	FmcwChirpSignal::FmcwChirpSignal(const RealType chirp_bandwidth, const RealType chirp_duration,
 									 const RealType chirp_period, const RealType start_frequency_offset,
 									 std::optional<std::size_t> chirp_count, const FmcwChirpDirection direction) :
@@ -219,6 +311,11 @@ namespace fers_signal
 
 	bool RadarSignal::isFmcwFamily() const noexcept { return _signal->isFmcwFamily(); }
 
+	bool RadarSignal::isSteppedFrequency() const noexcept
+	{
+		return dynamic_cast<const SteppedFrequencySignal*>(_signal.get()) != nullptr;
+	}
+
 	const FmcwChirpSignal* RadarSignal::getFmcwChirpSignal() const noexcept
 	{
 		return dynamic_cast<const FmcwChirpSignal*>(_signal.get());
@@ -227,6 +324,11 @@ namespace fers_signal
 	const FmcwTriangleSignal* RadarSignal::getFmcwTriangleSignal() const noexcept
 	{
 		return dynamic_cast<const FmcwTriangleSignal*>(_signal.get());
+	}
+
+	const SteppedFrequencySignal* RadarSignal::getSteppedFrequencySignal() const noexcept
+	{
+		return dynamic_cast<const SteppedFrequencySignal*>(_signal.get());
 	}
 
 	void Signal::clear() noexcept

--- a/packages/libfers/src/signal/radar_signal.h
+++ b/packages/libfers/src/signal/radar_signal.h
@@ -247,11 +247,17 @@ namespace fers_signal
 		/// Returns true when this signal belongs to the FMCW waveform family.
 		[[nodiscard]] bool isFmcwFamily() const noexcept;
 
+		/// Returns true when this signal is a stepped-frequency CW waveform.
+		[[nodiscard]] bool isSteppedFrequency() const noexcept;
+
 		/// Gets the FMCW chirp implementation, if this signal owns one.
 		[[nodiscard]] const class FmcwChirpSignal* getFmcwChirpSignal() const noexcept;
 
 		/// Gets the FMCW triangle implementation, if this signal owns one.
 		[[nodiscard]] const class FmcwTriangleSignal* getFmcwTriangleSignal() const noexcept;
+
+		/// Gets the stepped-frequency implementation, if this signal owns one.
+		[[nodiscard]] const class SteppedFrequencySignal* getSteppedFrequencySignal() const noexcept;
 
 		/**
 		 * @brief Renders the radar signal.
@@ -301,6 +307,92 @@ namespace fers_signal
 		 */
 		std::vector<ComplexType> render(const std::vector<interp::InterpPoint>& points, unsigned& size,
 										RealType fracWinDelay) const override;
+	};
+
+	/// Stepped-frequency continuous-wave signal implementation.
+	class SteppedFrequencySignal final : public Signal
+	{
+	public:
+		/// Active SFCW dwell selected for one local waveform time.
+		struct StepState
+		{
+			std::size_t step_index = 0; ///< Zero-based step index inside a sweep.
+			std::size_t sweep_index = 0; ///< Zero-based sweep index.
+			RealType step_start_time = 0.0; ///< Local step period start time in seconds.
+			RealType dwell_end_time = 0.0; ///< Local active dwell end time in seconds.
+			RealType step_end_time = 0.0; ///< Local step period end time in seconds.
+			RealType rf_frequency = 0.0; ///< RF frequency for the active step in hertz.
+		};
+
+		/// Constructs a uniform stepped-frequency CW signal.
+		SteppedFrequencySignal(RealType start_frequency_offset, RealType step_size, std::size_t step_count,
+							   RealType dwell_time, RealType step_period,
+							   std::optional<std::size_t> sweep_count = std::nullopt);
+
+		~SteppedFrequencySignal() override = default;
+
+		SteppedFrequencySignal(const SteppedFrequencySignal&) noexcept = delete;
+
+		SteppedFrequencySignal& operator=(const SteppedFrequencySignal&) noexcept = delete;
+
+		SteppedFrequencySignal(SteppedFrequencySignal&&) noexcept = delete;
+
+		SteppedFrequencySignal& operator=(SteppedFrequencySignal&&) noexcept = delete;
+
+		/// Gets the first-step offset from carrier in hertz.
+		[[nodiscard]] RealType getStartFrequencyOffset() const noexcept { return _start_frequency_offset; }
+
+		/// Gets the uniform frequency step in hertz.
+		[[nodiscard]] RealType getStepSize() const noexcept { return _step_size; }
+
+		/// Gets the number of steps per sweep.
+		[[nodiscard]] std::size_t getStepCount() const noexcept { return _step_count; }
+
+		/// Gets active dwell time per step in seconds.
+		[[nodiscard]] RealType getDwellTime() const noexcept { return _dwell_time; }
+
+		/// Gets step repetition period in seconds.
+		[[nodiscard]] RealType getStepPeriod() const noexcept { return _step_period; }
+
+		/// Gets optional finite sweep count.
+		[[nodiscard]] const std::optional<std::size_t>& getSweepCount() const noexcept { return _sweep_count; }
+
+		/// Gets full sweep period in seconds.
+		[[nodiscard]] RealType getSweepPeriod() const noexcept
+		{
+			return static_cast<RealType>(_step_count) * _step_period;
+		}
+
+		/// Gets first-step RF frequency in hertz.
+		[[nodiscard]] RealType firstFrequency(RealType carrier_frequency) const noexcept;
+
+		/// Gets final-step RF frequency in hertz.
+		[[nodiscard]] RealType lastFrequency(RealType carrier_frequency) const noexcept;
+
+		/// Gets first-to-last absolute span in hertz.
+		[[nodiscard]] RealType frequencySpan() const noexcept;
+
+		/// Gets DFT-convention effective bandwidth in hertz.
+		[[nodiscard]] RealType effectiveBandwidth() const noexcept;
+
+		/// Gets finite waveform duration, if sweep_count is configured.
+		[[nodiscard]] std::optional<RealType> totalDuration() const noexcept;
+
+		/// Returns the active step for a time since the segment start.
+		[[nodiscard]] std::optional<StepState> activeStepAt(RealType time_since_segment_start,
+															RealType carrier_frequency) const noexcept;
+
+		/// Renders the signal data. For SFCW signals, this is a no-op.
+		std::vector<ComplexType> render(const std::vector<interp::InterpPoint>& points, unsigned& size,
+										RealType fracWinDelay) const override;
+
+	private:
+		RealType _start_frequency_offset{}; ///< First-step frequency offset relative to carrier in hertz.
+		RealType _step_size{}; ///< Uniform frequency step in hertz.
+		std::size_t _step_count{}; ///< Steps per sweep.
+		RealType _dwell_time{}; ///< Active dwell time per step in seconds.
+		RealType _step_period{}; ///< Step repetition period in seconds.
+		std::optional<std::size_t> _sweep_count; ///< Optional finite sweep count.
 	};
 
 	/// FMCW linear chirp signal implementation.

--- a/packages/libfers/src/simulation/channel_model.cpp
+++ b/packages/libfers/src/simulation/channel_model.cpp
@@ -108,6 +108,12 @@ namespace
 		RealType dist{}; ///< Distance between Source and Destination.
 	};
 
+	struct StreamingWaveformEvaluation
+	{
+		RealType phase = 0.0;
+		RealType rf_frequency = 0.0;
+	};
+
 	/**
 	 * @brief Computes the geometry (distance and direction) between two points.
 	 * @param p_from Starting position.
@@ -444,9 +450,10 @@ namespace
 		return true;
 	}
 
-	/// Computes streaming phase for CW or FMCW sources at a receiver time.
-	bool computeStreamingPhase(const core::ActiveStreamingSource& source, const RealType rx_time, const RealType tau,
-							   core::FmcwChirpBoundaryTracker* const chirp_tracker, RealType& phase_out)
+	/// Computes streaming waveform phase and active RF at a receiver time.
+	bool computeStreamingEvaluation(const core::ActiveStreamingSource& source, const RealType rx_time,
+									const RealType tau, core::FmcwChirpBoundaryTracker* const chirp_tracker,
+									StreamingWaveformEvaluation& eval)
 	{
 		if (source.carrier_freq <= 0.0)
 		{
@@ -461,23 +468,42 @@ namespace
 
 		if (source.kind == core::StreamingWaveformKind::FmcwLinear)
 		{
+			eval.rf_frequency = source.carrier_freq;
 			if (chirp_tracker == nullptr)
 			{
-				return computeLinearFmcwPhaseWithoutTracker(source, t_ret, tau, phase_out);
+				return computeLinearFmcwPhaseWithoutTracker(source, t_ret, tau, eval.phase);
 			}
-			return computeLinearFmcwPhaseWithTracker(source, t_ret, tau, *chirp_tracker, phase_out);
+			return computeLinearFmcwPhaseWithTracker(source, t_ret, tau, *chirp_tracker, eval.phase);
 		}
 
 		if (source.kind == core::StreamingWaveformKind::FmcwTriangle)
 		{
+			eval.rf_frequency = source.carrier_freq;
 			if (chirp_tracker == nullptr)
 			{
-				return computeTriangleFmcwPhaseWithoutTracker(source, t_ret, tau, phase_out);
+				return computeTriangleFmcwPhaseWithoutTracker(source, t_ret, tau, eval.phase);
 			}
-			return computeTriangleFmcwPhaseWithTracker(source, t_ret, tau, *chirp_tracker, phase_out);
+			return computeTriangleFmcwPhaseWithTracker(source, t_ret, tau, *chirp_tracker, eval.phase);
 		}
 
-		phase_out = -2.0 * PI * source.carrier_freq * tau;
+		if (source.kind == core::StreamingWaveformKind::Sfcw)
+		{
+			if (source.sfcw == nullptr)
+			{
+				return false;
+			}
+			const auto step = source.sfcw->activeStepAt(t_ret - source.segment_start, source.carrier_freq);
+			if (!step.has_value() || step->rf_frequency <= 0.0)
+			{
+				return false;
+			}
+			eval.rf_frequency = step->rf_frequency;
+			eval.phase = -2.0 * PI * step->rf_frequency * tau;
+			return true;
+		}
+
+		eval.rf_frequency = source.carrier_freq;
+		eval.phase = -2.0 * PI * source.carrier_freq * tau;
 		return true;
 	}
 
@@ -739,11 +765,12 @@ namespace simulation
 		}
 
 		const RealType tau = link.dist / params::c();
-		if (source.carrier_freq <= 0.0)
+		StreamingWaveformEvaluation eval;
+		if (!computeStreamingEvaluation(source, timeK, tau, chirp_tracker, eval))
 		{
 			return {0.0, 0.0};
 		}
-		const RealType lambda = params::c() / source.carrier_freq;
+		const RealType lambda = params::c() / eval.rf_frequency;
 
 		// Tx Gain: Direction Tx -> Rx
 		const RealType tx_gain = computeAntennaGain(trans, link.u_vec, timeK, lambda);
@@ -757,12 +784,7 @@ namespace simulation
 		const RealType amplitude = source.amplitude * std::sqrt(scaling_factor);
 
 		// Carrier Phase
-		RealType phase = 0.0;
-		if (!computeStreamingPhase(source, timeK, tau, chirp_tracker, phase))
-		{
-			return {0.0, 0.0};
-		}
-		ComplexType contribution = std::polar(amplitude, phase);
+		ComplexType contribution = std::polar(amplitude, eval.phase);
 
 		// Non-coherent Local Oscillator Effects
 		const RealType non_coherent_phase =
@@ -775,7 +797,13 @@ namespace simulation
 	bool calculateStreamingReferencePhase(const core::ActiveStreamingSource& source, const RealType timeK,
 										  core::FmcwChirpBoundaryTracker* const chirp_tracker, RealType& phase_out)
 	{
-		return computeStreamingPhase(source, timeK, 0.0, chirp_tracker, phase_out);
+		StreamingWaveformEvaluation eval;
+		if (!computeStreamingEvaluation(source, timeK, 0.0, chirp_tracker, eval))
+		{
+			return false;
+		}
+		phase_out = eval.phase;
+		return true;
 	}
 
 	ComplexType calculateReflectedPathContribution(const Transmitter* trans, const Receiver* recv, const Target* targ,
@@ -823,11 +851,12 @@ namespace simulation
 		}
 
 		const RealType tau = (link_tx_tgt.dist + link_tgt_rx.dist) / params::c();
-		if (source.carrier_freq <= 0.0)
+		StreamingWaveformEvaluation eval;
+		if (!computeStreamingEvaluation(source, timeK, tau, chirp_tracker, eval))
 		{
 			return {0.0, 0.0};
 		}
-		const RealType lambda = params::c() / source.carrier_freq;
+		const RealType lambda = params::c() / eval.rf_frequency;
 
 		// RCS Lookups: In (Tx->Tgt), Out (Rx->Tgt = - (Tgt->Rx))
 		SVec3 in_angle(link_tx_tgt.u_vec);
@@ -846,12 +875,7 @@ namespace simulation
 		// Include Signal Power
 		const RealType amplitude = source.amplitude * std::sqrt(scaling_factor);
 
-		RealType phase = 0.0;
-		if (!computeStreamingPhase(source, timeK, tau, chirp_tracker, phase))
-		{
-			return {0.0, 0.0};
-		}
-		ComplexType contribution = std::polar(amplitude, phase);
+		ComplexType contribution = std::polar(amplitude, eval.phase);
 
 		// Non-coherent Local Oscillator Effects
 		const RealType non_coherent_phase =

--- a/packages/libfers/tests/processing/test_finalizer.cpp
+++ b/packages/libfers/tests/processing/test_finalizer.cpp
@@ -134,6 +134,27 @@ namespace
 		}
 	};
 
+	struct SfcwTxFixture
+	{
+		radar::Platform platform;
+		std::unique_ptr<fers_signal::RadarSignal> wave;
+		radar::Transmitter transmitter;
+
+		SfcwTxFixture(const std::string& name, SimId tx_id, SimId waveform_id, RealType start_frequency_offset,
+					  RealType step_size, std::size_t step_count, RealType dwell_time, RealType step_period,
+					  std::optional<std::size_t> sweep_count) :
+			platform(name + "Platform"),
+			wave(std::make_unique<fers_signal::RadarSignal>(
+				name + "Wave", 1.0, 10.0e9, dwell_time,
+				std::make_unique<fers_signal::SteppedFrequencySignal>(start_frequency_offset, step_size, step_count,
+																	  dwell_time, step_period, sweep_count),
+				waveform_id)),
+			transmitter(&platform, name, radar::OperationMode::SFCW_MODE, tx_id)
+		{
+			transmitter.setSignal(wave.get());
+		}
+	};
+
 	std::unique_ptr<serial::Response>
 	makeFixedResponse(const radar::Transmitter* transmitter,
 					  std::vector<std::unique_ptr<fers_signal::RadarSignal>>& wave_store,
@@ -397,6 +418,44 @@ TEST_CASE("buildReceiverStreamDescriptor keeps CW metadata isolated from active 
 	REQUIRE_THAT(descriptor.cw.carrier_frequency, WithinAbs(5.0e9, 1e-6));
 }
 
+TEST_CASE("buildReceiverStreamDescriptor records SFCW waveform metadata", "[processing][finalizer][sfcw][vita49]")
+{
+	ParamGuard const guard;
+	params::setTime(0.0, 0.01);
+	params::setRate(10'000.0);
+	params::setOversampleRatio(1);
+
+	radar::Platform rx_platform("SfcwRxPlatform");
+	radar::Receiver receiver(&rx_platform, "SfcwRx", 62, radar::OperationMode::SFCW_MODE);
+	auto timing_owner = makeQuietTiming("sfcw_metadata_clk", 28, 9.6e9);
+	receiver.setTiming(timing_owner.timing);
+
+	SfcwTxFixture const source_fixture("DescriptorSfcwTx", 1201, 1202, -1.0e6, 2.0e5, 8, 1.0e-4, 2.0e-4,
+									   std::size_t{2});
+	const std::vector sources = {core::makeActiveSource(&source_fixture.transmitter, 0.0, params::endTime())};
+
+	const auto descriptor = processing::buildReceiverStreamDescriptor(&receiver, params::rate(), sources);
+
+	REQUIRE(descriptor.mode == "sfcw");
+	REQUIRE(descriptor.sfcw.present);
+	REQUIRE_FALSE(descriptor.fmcw.present);
+	REQUIRE_FALSE(descriptor.cw.present);
+	REQUIRE(descriptor.sfcw.waveform_id == 1202);
+	REQUIRE(descriptor.sfcw.step_count == 8u);
+	REQUIRE_THAT(descriptor.sfcw.start_frequency_offset, WithinAbs(-1.0e6, 1e-9));
+	REQUIRE_THAT(descriptor.sfcw.step_size, WithinAbs(2.0e5, 1e-9));
+	REQUIRE_THAT(descriptor.sfcw.dwell_time, WithinAbs(1.0e-4, 1e-12));
+	REQUIRE_THAT(descriptor.sfcw.step_period, WithinAbs(2.0e-4, 1e-12));
+	REQUIRE_THAT(descriptor.sfcw.sweep_period, WithinAbs(1.6e-3, 1e-12));
+	REQUIRE(descriptor.sfcw.sweep_count.has_value());
+	REQUIRE(descriptor.sfcw.sweep_count.value_or(0u) == 2u);
+	REQUIRE_THAT(descriptor.sfcw.first_frequency, WithinAbs(9.999e9, 1e-3));
+	REQUIRE_THAT(descriptor.sfcw.last_frequency, WithinAbs(10.0004e9, 1e-3));
+	REQUIRE_THAT(descriptor.sfcw.effective_bandwidth, WithinAbs(1.6e6, 1e-6));
+	REQUIRE_THAT(descriptor.sfcw.range_resolution, WithinAbs(params::c() / (2.0 * 1.6e6), 1e-9));
+	REQUIRE_THAT(descriptor.sfcw.unambiguous_range, WithinAbs(params::c() / (2.0 * 2.0e5), 1e-9));
+}
+
 TEST_CASE("buildStreamingOutputMetadata records FMCW source metadata for detached receivers",
 		  "[processing][finalizer][fmcw][metadata]")
 {
@@ -446,6 +505,60 @@ TEST_CASE("buildStreamingOutputMetadata records FMCW source metadata for detache
 	REQUIRE(streaming_segment.first_chirp_start_time.has_value());
 	REQUIRE_THAT(streaming_segment.first_chirp_start_time.value_or(1.0), WithinAbs(0.0, 1e-12));
 	REQUIRE(streaming_segment.emitted_chirp_count == std::optional<std::uint64_t>{4});
+}
+
+TEST_CASE("buildStreamingOutputMetadata records SFCW source metadata for detached receivers",
+		  "[processing][finalizer][sfcw][metadata]")
+{
+	ParamGuard const guard;
+	params::setTime(0.0, 0.01);
+	params::setRate(10'000.0);
+	params::setOversampleRatio(1);
+	params::setAdcBits(0);
+
+	const std::string receiver_name = uniqueName("sfcw_detached");
+	const auto out_dir = std::filesystem::temp_directory_path() / uniqueName("sfcw_detached_dir");
+	const auto output_path = resultPath(out_dir, receiver_name);
+
+	radar::Platform rx_platform("SfcwRxPlatform");
+	radar::Receiver receiver(&rx_platform, receiver_name, 58, radar::OperationMode::SFCW_MODE);
+	auto timing_owner = makeQuietTiming("sfcw_detached_clk", 24, 77.0);
+	receiver.setTiming(timing_owner.timing);
+	receiver.setNoiseTemperature(0.0);
+
+	SfcwTxFixture const source_fixture("DetachedSfcwTx", 1301, 1302, 0.0, 1.0e5, 4, 1.0e-4, 2.0e-4, std::size_t{2});
+	const auto source = core::makeActiveSource(&source_fixture.transmitter, 0.0, params::endTime());
+
+	const auto metadata =
+		processing::buildStreamingOutputMetadata(&receiver, output_path.string(), 20, {source}, params::rate());
+
+	REQUIRE(metadata.mode == "sfcw");
+	REQUIRE(metadata.sfcw.has_value());
+	REQUIRE(metadata.sfcw_sources.size() == 1u);
+	REQUIRE_FALSE(metadata.fmcw.has_value());
+
+	const auto& source_metadata = metadata.sfcw_sources.front();
+	REQUIRE(source_metadata.transmitter_id == 1301);
+	REQUIRE(source_metadata.transmitter_name == "DetachedSfcwTx");
+	REQUIRE(source_metadata.waveform_id == 1302);
+	REQUIRE(source_metadata.waveform_name == "DetachedSfcwTxWave");
+	REQUIRE_THAT(source_metadata.waveform.step_size, WithinAbs(1.0e5, 1e-9));
+	REQUIRE(source_metadata.waveform.step_count == 4u);
+	REQUIRE_THAT(source_metadata.waveform.dwell_time, WithinAbs(1.0e-4, 1e-12));
+	REQUIRE_THAT(source_metadata.waveform.step_period, WithinAbs(2.0e-4, 1e-12));
+	REQUIRE(source_metadata.waveform.sweep_count == std::optional<std::uint64_t>{2});
+	REQUIRE_THAT(source_metadata.waveform.effective_bandwidth, WithinAbs(4.0e5, 1e-9));
+	REQUIRE_THAT(source_metadata.waveform.range_resolution, WithinAbs(params::c() / (2.0 * 4.0e5), 1e-9));
+	REQUIRE_THAT(source_metadata.waveform.unambiguous_range, WithinAbs(params::c() / (2.0 * 1.0e5), 1e-9));
+	REQUIRE(source_metadata.segments.size() == 1u);
+	REQUIRE(source_metadata.segments.front().first_step_start_time.has_value());
+	REQUIRE_THAT(source_metadata.segments.front().first_step_start_time.value_or(1.0), WithinAbs(0.0, 1e-12));
+	REQUIRE(source_metadata.segments.front().emitted_step_count == std::optional<std::uint64_t>{8});
+
+	const auto& streaming_segment = metadata.streaming_segments.front();
+	REQUIRE(streaming_segment.first_sfcw_step_start_time.has_value());
+	REQUIRE_THAT(streaming_segment.first_sfcw_step_start_time.value_or(1.0), WithinAbs(0.0, 1e-12));
+	REQUIRE(streaming_segment.emitted_sfcw_step_count == std::optional<std::uint64_t>{8});
 }
 
 TEST_CASE("buildStreamingOutputMetadata writes IF-rate FMCW metadata", "[processing][finalizer][fmcw][if]")

--- a/packages/libfers/tests/serial/test_json_serializer.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer.cpp
@@ -416,6 +416,53 @@ TEST_CASE("JSON: FMCW triangle round trips", "[serial][json][fmcw]")
 	REQUIRE(reparsed_triangle_count.value_or(0u) == 3u);
 }
 
+TEST_CASE("JSON: SFCW waveform round trips", "[serial][json][sfcw]")
+{
+	ParamGuard const guard;
+	params::setRate(2.0e6);
+	params::setOversampleRatio(1);
+	params::setTime(0.0, 1.0);
+
+	json const wf_json = {{"id", 460},
+						  {"name", "Sfcw"},
+						  {"power", 125.0},
+						  {"carrier_frequency", 9.6e9},
+						  {"stepped_frequency",
+						   {{"start_frequency_offset", -1.0e6},
+							{"step_size", 2.0e5},
+							{"step_count", 16},
+							{"dwell_time", 1.0e-4},
+							{"step_period", 2.0e-4},
+							{"sweep_count", 5}}}};
+
+	auto wf = serial::parse_waveform_from_json(wf_json);
+	REQUIRE(wf != nullptr);
+	REQUIRE(wf->isSteppedFrequency());
+	REQUIRE_FALSE(wf->isFmcwFamily());
+	const auto* sfcw = wf->getSteppedFrequencySignal();
+	REQUIRE(sfcw != nullptr);
+	REQUIRE_THAT(sfcw->getStartFrequencyOffset(), WithinAbs(-1.0e6, 1e-9));
+	REQUIRE_THAT(sfcw->getStepSize(), WithinAbs(2.0e5, 1e-9));
+	REQUIRE(sfcw->getStepCount() == 16u);
+	REQUIRE_THAT(sfcw->getDwellTime(), WithinAbs(1.0e-4, 1e-12));
+	REQUIRE_THAT(sfcw->getStepPeriod(), WithinAbs(2.0e-4, 1e-12));
+	REQUIRE(sfcw->getSweepCount().has_value());
+	REQUIRE(sfcw->getSweepCount().value_or(0u) == 5u);
+
+	json serialized;
+	fers_signal::to_json(serialized, *wf);
+	REQUIRE(serialized.contains("stepped_frequency"));
+	REQUIRE_FALSE(serialized.contains("fmcw_linear_chirp"));
+	REQUIRE_FALSE(serialized.contains("fmcw_triangle"));
+	REQUIRE(serialized.at("stepped_frequency").at("step_count") == 16);
+	REQUIRE(serialized.at("stepped_frequency").at("sweep_count") == 5);
+
+	auto reparsed = serial::parse_waveform_from_json(serialized);
+	REQUIRE(reparsed != nullptr);
+	REQUIRE(reparsed->getSteppedFrequencySignal() != nullptr);
+	REQUIRE(reparsed->getSteppedFrequencySignal()->getSweepCount().value_or(0u) == 5u);
+}
+
 TEST_CASE("JSON: FMCW triangle rejects fractional triangle count", "[serial][json][fmcw]")
 {
 	ParamGuard const guard;

--- a/packages/libfers/tests/serial/test_vita49.cpp
+++ b/packages/libfers/tests/serial/test_vita49.cpp
@@ -586,6 +586,57 @@ TEST_CASE("VITA context metadata describes pulsed and CW waveform modes", "[seri
 	REQUIRE(cw_metadata.at("cw").at("power_w") == 25.0);
 }
 
+TEST_CASE("VITA context metadata describes SFCW waveform mode", "[serial][vita49][sfcw]")
+{
+	using namespace serial::vita49;
+
+	const core::ReceiverStreamDescriptor stream{.receiver_id = 7,
+												.receiver_name = "sfcw-rx",
+												.mode = "sfcw",
+												.sample_rate = 1.0e6,
+												.reference_frequency = 9.6e9,
+												.adc_bits = 12,
+												.coordinate = {},
+												.initial_platform_state = {},
+												.sfcw = {.present = true,
+														 .waveform_id = 101,
+														 .waveform_name = "sfcw",
+														 .carrier_frequency = 9.6e9,
+														 .power = 50.0,
+														 .start_frequency_offset = -1.0e6,
+														 .step_size = 2.0e5,
+														 .step_count = 8,
+														 .dwell_time = 1.0e-4,
+														 .step_period = 2.0e-4,
+														 .sweep_period = 1.6e-3,
+														 .sweep_count = 3,
+														 .first_frequency = 9.599e9,
+														 .last_frequency = 9.6004e9,
+														 .frequency_span = 1.4e6,
+														 .effective_bandwidth = 1.6e6}};
+	const auto context = Vita49ContextBuilder::build(ContextBuildRequest{.stream = stream,
+																		 .stream_id = 0x33333333u,
+																		 .simulation_name = "mixed",
+																		 .adc_fullscale = 1.0,
+																		 .timestamp = Timestamp{10u, 0u}});
+	const auto bytes = Vita49Serializer::serializeContext(context);
+	const auto metadata = nlohmann::json::parse(readAsciiMetadata(bytes, 92u));
+	const auto context_flags = metadata.at("receiver").at("context_flags").get<std::uint32_t>();
+
+	REQUIRE((context_flags & ContextFlagSfcwMetadataPresent) == ContextFlagSfcwMetadataPresent);
+	REQUIRE(metadata.at("waveform").at("kind") == "sfcw");
+	REQUIRE(metadata.at("waveform").at("metadata_ref") == "sfcw");
+	REQUIRE(metadata.at("sfcw").at("present").get<bool>());
+	REQUIRE(metadata.at("sfcw").at("waveform_id") == 101u);
+	REQUIRE(metadata.at("sfcw").at("step_count") == 8u);
+	REQUIRE(metadata.at("sfcw").at("step_size_hz") == 2.0e5);
+	REQUIRE(metadata.at("sfcw").at("dwell_time_s") == 1.0e-4);
+	REQUIRE(metadata.at("sfcw").at("step_period_s") == 2.0e-4);
+	REQUIRE(metadata.at("sfcw").at("sweep_period_s") == 1.6e-3);
+	REQUIRE(metadata.at("sfcw").at("sweep_count") == 3u);
+	REQUIRE(metadata.at("sfcw").at("effective_bandwidth_hz") == 1.6e6);
+}
+
 TEST_CASE("VITA context serializer rejects unsupported CIF0", "[serial][vita49]")
 {
 	using namespace serial::vita49;

--- a/packages/libfers/tests/serial/test_xml_parser_utils.cpp
+++ b/packages/libfers/tests/serial/test_xml_parser_utils.cpp
@@ -456,6 +456,53 @@ TEST_CASE("parseWaveform validates FMCW chirp schema constraints", "[serial][xml
 		REQUIRE(triangle->getTriangleCount().value_or(0u) == 4u);
 	}
 
+	SECTION("well-formed SFCW waveform")
+	{
+		auto doc = loadXml("<waveform name=\"sfcw_good\">"
+						   "  <power>12</power>"
+						   "  <carrier_frequency>2.4e9</carrier_frequency>"
+						   "  <stepped_frequency>"
+						   "    <start_frequency_offset>-1e6</start_frequency_offset>"
+						   "    <step_size>2e5</step_size>"
+						   "    <step_count>8</step_count>"
+						   "    <dwell_time>1e-4</dwell_time>"
+						   "    <step_period>2e-4</step_period>"
+						   "    <sweep_count>3</sweep_count>"
+						   "  </stepped_frequency>"
+						   "</waveform>");
+
+		serial::xml_parser_utils::parseWaveform(doc.getRootElement(), ctx);
+		REQUIRE(world.getWaveforms().size() == 1);
+		const auto* wave = world.getWaveforms().begin()->second.get();
+		const auto* sfcw = wave->getSteppedFrequencySignal();
+		REQUIRE(sfcw != nullptr);
+		REQUIRE(wave->isSteppedFrequency());
+		REQUIRE_THAT(wave->getLength(), WithinAbs(1.0e-4, 1.0e-12));
+		REQUIRE_THAT(sfcw->getStartFrequencyOffset(), WithinAbs(-1.0e6, 1e-6));
+		REQUIRE_THAT(sfcw->getStepSize(), WithinAbs(2.0e5, 1e-9));
+		REQUIRE(sfcw->getStepCount() == 8u);
+		REQUIRE(sfcw->getSweepCount().has_value());
+		REQUIRE(sfcw->getSweepCount().value_or(0u) == 3u);
+	}
+
+	SECTION("SFCW dwell longer than step period is rejected")
+	{
+		auto doc = loadXml("<waveform name=\"sfcw_bad_dwell\">"
+						   "  <power>10</power>"
+						   "  <carrier_frequency>2.4e9</carrier_frequency>"
+						   "  <stepped_frequency>"
+						   "    <start_frequency_offset>0</start_frequency_offset>"
+						   "    <step_size>1e5</step_size>"
+						   "    <step_count>4</step_count>"
+						   "    <dwell_time>2e-4</dwell_time>"
+						   "    <step_period>1e-4</step_period>"
+						   "  </stepped_frequency>"
+						   "</waveform>");
+
+		REQUIRE_THROWS_WITH(serial::xml_parser_utils::parseWaveform(doc.getRootElement(), ctx),
+							ContainsSubstring("SFCW dwell_time longer than step_period"));
+	}
+
 	SECTION("chirp period shorter than duration is rejected")
 	{
 		auto doc = loadXml("<waveform name=\"fmcw_bad_period\">"
@@ -885,6 +932,55 @@ TEST_CASE("parseTransmitter rejects FMCW waveform and mode mismatches", "[serial
 	REQUIRE_THROWS_WITH(
 		serial::xml_parser_utils::parseTransmitter(transmitter_dechirp_doc.getRootElement(), &platform, ctx, refs),
 		ContainsSubstring("must not contain dechirp configuration"));
+}
+
+TEST_CASE("parseTransmitter accepts native SFCW mode and rejects invalid SFCW blocks",
+		  "[serial][xml_parser_utils][sfcw]")
+{
+	ParamGuard const guard;
+	params::setRate(2.0e6);
+	params::setOversampleRatio(1);
+	params::setTime(0.0, 10.0);
+
+	core::World world;
+	std::mt19937 seeder(42);
+	serial::xml_parser_utils::ParserContext ctx;
+	ctx.world = &world;
+	ctx.master_seeder = &seeder;
+
+	auto sfcw_signal = std::make_unique<fers_signal::SteppedFrequencySignal>(0.0, 1.0e5, 4, 1.0e-4, 2.0e-4);
+	world.add(std::make_unique<fers_signal::RadarSignal>("sfcw_wave", 1.0, 1e9, 1.0e-4, std::move(sfcw_signal), 10));
+	world.add(std::make_unique<antenna::Isotropic>("a1", 20));
+	auto timing_proto = std::make_unique<timing::PrototypeTiming>("t1", 30);
+	timing_proto->setFrequency(1e6);
+	world.add(std::move(timing_proto));
+
+	std::unordered_map<std::string, SimId> const w_refs = {{"sfcw_wave", 10}};
+	std::unordered_map<std::string, SimId> const a_refs = {{"a1", 20}};
+	std::unordered_map<std::string, SimId> const t_refs = {{"t1", 30}};
+	serial::xml_parser_utils::ReferenceLookup const refs{&w_refs, &a_refs, &t_refs};
+	radar::Platform platform("plat");
+
+	auto sfcw_doc = loadXml("<transmitter name=\"tx_sfcw\" waveform=\"sfcw_wave\" antenna=\"a1\" timing=\"t1\">"
+							"  <sfcw_mode/>"
+							"</transmitter>");
+	auto* tx = serial::xml_parser_utils::parseTransmitter(sfcw_doc.getRootElement(), &platform, ctx, refs);
+	REQUIRE(tx->getMode() == radar::OperationMode::SFCW_MODE);
+	REQUIRE(tx->isStreamingMode());
+
+	auto mismatch_doc = loadXml("<transmitter name=\"tx_sfcw_bad\" waveform=\"sfcw_wave\" antenna=\"a1\" timing=\"t1\">"
+								"  <cw_mode/>"
+								"</transmitter>");
+	REQUIRE_THROWS_WITH(serial::xml_parser_utils::parseTransmitter(mismatch_doc.getRootElement(), &platform, ctx, refs),
+						ContainsSubstring("mode does not match waveform"));
+
+	auto non_empty_doc =
+		loadXml("<transmitter name=\"tx_sfcw_non_empty\" waveform=\"sfcw_wave\" antenna=\"a1\" timing=\"t1\">"
+				"  <sfcw_mode><dechirp_reference source=\"attached\"/></sfcw_mode>"
+				"</transmitter>");
+	REQUIRE_THROWS_WITH(
+		serial::xml_parser_utils::parseTransmitter(non_empty_doc.getRootElement(), &platform, ctx, refs),
+		ContainsSubstring("sfcw_mode must be empty"));
 }
 
 TEST_CASE("parseTransmitter validates FMCW schedule duration against chirp timing", "[serial][xml_parser_utils][fmcw]")

--- a/packages/libfers/tests/signal/test_radar_signal.cpp
+++ b/packages/libfers/tests/signal/test_radar_signal.cpp
@@ -113,6 +113,41 @@ TEST_CASE("FmcwTriangleSignal keeps phase continuous at leg and period boundarie
 	REQUIRE_FALSE(triangle.instantaneousBasebandPhase(4.0 * triangle.getTrianglePeriod()).has_value());
 }
 
+TEST_CASE("SteppedFrequencySignal selects active dwell steps and finite sweeps", "[signal][radar][sfcw]")
+{
+	fers_signal::SteppedFrequencySignal const sfcw(10.0, 2.0, 4, 0.25, 0.5, std::size_t{2});
+
+	REQUIRE_THAT(sfcw.firstFrequency(100.0), WithinAbs(110.0, 1e-12));
+	REQUIRE_THAT(sfcw.lastFrequency(100.0), WithinAbs(116.0, 1e-12));
+	REQUIRE_THAT(sfcw.frequencySpan(), WithinAbs(6.0, 1e-12));
+	REQUIRE_THAT(sfcw.effectiveBandwidth(), WithinAbs(8.0, 1e-12));
+	REQUIRE_THAT(sfcw.getSweepPeriod(), WithinAbs(2.0, 1e-12));
+	REQUIRE(sfcw.totalDuration().has_value());
+	REQUIRE_THAT(sfcw.totalDuration().value_or(0.0), WithinAbs(4.0, 1e-12));
+
+	const auto first = sfcw.activeStepAt(0.1, 100.0);
+	REQUIRE(first.has_value());
+	REQUIRE(first->sweep_index == 0u);
+	REQUIRE(first->step_index == 0u);
+	REQUIRE_THAT(first->rf_frequency, WithinAbs(110.0, 1e-12));
+	REQUIRE_THAT(first->step_start_time, WithinAbs(0.0, 1e-12));
+	REQUIRE_THAT(first->dwell_end_time, WithinAbs(0.25, 1e-12));
+
+	REQUIRE_FALSE(sfcw.activeStepAt(0.3, 100.0).has_value());
+
+	const auto second_sweep = sfcw.activeStepAt(2.55, 100.0);
+	REQUIRE(second_sweep.has_value());
+	REQUIRE(second_sweep->sweep_index == 1u);
+	REQUIRE(second_sweep->step_index == 1u);
+	REQUIRE_THAT(second_sweep->rf_frequency, WithinAbs(112.0, 1e-12));
+	REQUIRE_FALSE(sfcw.activeStepAt(4.0, 100.0).has_value());
+
+	fers_signal::SteppedFrequencySignal const descending(0.0, -5.0, 3, 0.1, 0.2);
+	REQUIRE_THAT(descending.lastFrequency(100.0), WithinAbs(90.0, 1e-12));
+	REQUIRE_THAT(descending.frequencySpan(), WithinAbs(10.0, 1e-12));
+	REQUIRE_FALSE(descending.totalDuration().has_value());
+}
+
 TEST_CASE("RadarSignal exposes metadata", "[signal][radar]")
 {
 	ParamGuard const guard;

--- a/packages/schema/fers-xml.dtd
+++ b/packages/schema/fers-xml.dtd
@@ -47,7 +47,7 @@
                 >
 
         <!-- Waveform definition -->
-        <!ELEMENT waveform (power, carrier_frequency, (pulsed_from_file | cw | fmcw_linear_chirp | fmcw_triangle))>
+        <!ELEMENT waveform (power, carrier_frequency, (pulsed_from_file | cw | fmcw_linear_chirp | fmcw_triangle | stepped_frequency))>
         <!ATTLIST waveform
                 name CDATA #REQUIRED>
 
@@ -64,10 +64,16 @@
         <!ELEMENT fmcw_linear_chirp (chirp_bandwidth, chirp_duration, chirp_period, start_frequency_offset?, chirp_count?)>
         <!ATTLIST fmcw_linear_chirp direction (up|down) #REQUIRED>
         <!ELEMENT fmcw_triangle (chirp_bandwidth, chirp_duration, start_frequency_offset?, triangle_count?)>
+        <!ELEMENT stepped_frequency (start_frequency_offset, step_size, step_count, dwell_time, step_period, sweep_count?)>
         <!ELEMENT chirp_bandwidth (#PCDATA)>
         <!ELEMENT chirp_duration (#PCDATA)>
         <!ELEMENT chirp_period (#PCDATA)>
         <!ELEMENT start_frequency_offset (#PCDATA)>
+        <!ELEMENT step_size (#PCDATA)>
+        <!ELEMENT step_count (#PCDATA)>
+        <!ELEMENT dwell_time (#PCDATA)>
+        <!ELEMENT step_period (#PCDATA)>
+        <!ELEMENT sweep_count (#PCDATA)>
         <!-- Per-schedule-segment maximum chirp count; each scheduled period may emit up to this many chirps. -->
         <!ELEMENT chirp_count (#PCDATA)>
         <!-- Per-schedule-segment maximum full triangle count; each scheduled period may emit up to this many triangles. -->
@@ -162,6 +168,7 @@
         <!ELEMENT cw_mode EMPTY>
         <!ELEMENT fmcw_mode (dechirp_reference?, if_sample_rate?, if_filter_bandwidth?, if_filter_transition_width?)>
         <!ATTLIST fmcw_mode dechirp_mode (none|physical|ideal) "none">
+        <!ELEMENT sfcw_mode EMPTY>
         <!ELEMENT dechirp_reference EMPTY>
         <!ATTLIST dechirp_reference
                 source (attached|transmitter|custom) #REQUIRED
@@ -180,7 +187,7 @@
                 >
 
         <!-- Monostatic radar installations -->
-        <!ELEMENT monostatic ((pulsed_mode | cw_mode | fmcw_mode), noise_temp?, schedule?)>
+        <!ELEMENT monostatic ((pulsed_mode | cw_mode | fmcw_mode | sfcw_mode), noise_temp?, schedule?)>
         <!ATTLIST monostatic
                 name CDATA #REQUIRED
                 antenna CDATA #REQUIRED
@@ -192,7 +199,7 @@
         <!ELEMENT noise_temp (#PCDATA)>
 
         <!-- Standalone Transmitter -->
-        <!ELEMENT transmitter ((pulsed_mode | cw_mode | fmcw_mode), schedule?)>
+        <!ELEMENT transmitter ((pulsed_mode | cw_mode | fmcw_mode | sfcw_mode), schedule?)>
         <!ATTLIST transmitter
                 name CDATA #REQUIRED
                 waveform CDATA #REQUIRED
@@ -200,7 +207,7 @@
                 timing CDATA #REQUIRED>
 
         <!-- Standalone Receiver -->
-        <!ELEMENT receiver ((pulsed_mode | cw_mode | fmcw_mode), noise_temp?, schedule?)>
+        <!ELEMENT receiver ((pulsed_mode | cw_mode | fmcw_mode | sfcw_mode), noise_temp?, schedule?)>
         <!ATTLIST receiver
                 name CDATA #REQUIRED
                 antenna CDATA #REQUIRED

--- a/packages/schema/fers-xml.xsd
+++ b/packages/schema/fers-xml.xsd
@@ -147,6 +147,18 @@
                             </xs:sequence>
                         </xs:complexType>
                     </xs:element>
+                    <xs:element name="stepped_frequency">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="start_frequency_offset" type="xs:string"/>
+                                <xs:element name="step_size" type="xs:string"/>
+                                <xs:element name="step_count" type="xs:string"/>
+                                <xs:element name="dwell_time" type="xs:string"/>
+                                <xs:element name="step_period" type="xs:string"/>
+                                <xs:element minOccurs="0" name="sweep_count" type="xs:string"/>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
                 </xs:choice>
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" use="required"/>
@@ -361,6 +373,9 @@
                         <xs:complexType/>
                     </xs:element>
                     <xs:element name="fmcw_mode" type="receiverFmcwModeType"/>
+                    <xs:element name="sfcw_mode">
+                        <xs:complexType/>
+                    </xs:element>
                 </xs:choice>
                 <xs:element minOccurs="0" name="noise_temp" type="xs:string"/>
                 <xs:element minOccurs="0" ref="schedule"/>
@@ -392,6 +407,9 @@
                     <xs:element name="fmcw_mode">
                         <xs:complexType/>
                     </xs:element>
+                    <xs:element name="sfcw_mode">
+                        <xs:complexType/>
+                    </xs:element>
                 </xs:choice>
                 <xs:element minOccurs="0" ref="schedule"/>
             </xs:sequence>
@@ -420,6 +438,9 @@
                         <xs:complexType/>
                     </xs:element>
                     <xs:element name="fmcw_mode" type="receiverFmcwModeType"/>
+                    <xs:element name="sfcw_mode">
+                        <xs:complexType/>
+                    </xs:element>
                 </xs:choice>
                 <xs:element minOccurs="0" name="noise_temp" type="xs:string"/>
                 <xs:element minOccurs="0" ref="schedule"/>


### PR DESCRIPTION
This pull request introduces native stepped-frequency continuous-wave (SFCW) radar support to FERS across the simulation core, scenario schema, CLI/runtime output metadata, VITA context metadata, UI authoring flow, examples, docs, and tests.

### Key Changes

**1. Native SFCW Simulation Support**
* Added a first-class stepped-frequency waveform model with RF step offsets, step size, step count, dwell time, step period, and optional finite sweep count.
* Added `SFCW_MODE` for transmitters, receivers, and monostatic radars.
* Extended streaming source setup so SFCW uses one transmitter/receiver stream instead of generated CW radars.
* Evaluated the active SFCW step from retarded transmit time and used the active RF frequency for phase, wavelength, antenna gain, and propagation-loss calculations.

**2. Scenario Schema, Parsing, and Validation**
* Added XML/DTD/XSD support for `<stepped_frequency>` and `<sfcw_mode/>`.
* Added JSON serialization and deserialization support for SFCW waveforms and radar modes.
* Extended waveform/mode compatibility and validation checks for step counts, dwell/period timing, nonzero step size, finite sweep counts, and positive RF steps.

**3. Output Metadata, HDF5, and VITA Context**
* Added SFCW metadata to output JSON and HDF5 attributes, including first/last RF frequency, frequency span, effective bandwidth, range resolution, unambiguous range, sweep count, and emitted step counts.
* Added SFCW source metadata and streaming segment step-count fields.
* Extended VITA 49 context metadata with SFCW waveform context and a dedicated metadata-present flag.

**4. FERS-UI Authoring and Display**
* Added SFCW waveform authoring fields, defaults, hydration, serialization, and schema validation.
* Added SFCW radar mode compatibility in component inspectors.
* Extended simulation output metadata display and VITA stream-mode handling for SFCW.
* Updated link visualization duty-cycle handling for stepped-frequency sweeps.

**5. Examples, Documentation, and Tests**
* Added `examples/sfcw_monostatic` with a runnable SFCW scenario and analysis script.
* Updated README and wiki documentation for SFCW XML, CLI usage, UI support, output metadata, VITA context metadata, and simulation pipeline behavior.
* Added focused C++ tests for signal timing, XML/JSON round trips, finalizer metadata, and VITA context metadata.
* Added UI tests for SFCW schema, serialization, inspector controls, and output metadata handling.

### Notes

This implements uniform stepped-frequency sweeps. Arbitrary frequency tables, masked step lists, per-step power settings, and built-in SFCW range-profile processing are intentionally left out of this MVP.
