### PR TITLE
fix(deps): update vcpkg baseline

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
     "name": "fers",
     "version-semver": "0.1.0",
-    "builtin-baseline": "f6735d5aa1537081e8d425372ea7e585b0ad65e8",
+    "builtin-baseline": "9942fb5f996ea431c5ed8fb8d2a53f31d08df62e",
     "dependencies": [
         "catch2",
         "geographiclib",


### PR DESCRIPTION
Update `builtin-baseline` in `vcpkg.json` to commit `9942fb5f996ea431c5ed8fb8d2a53f31d08df62e` which switches `libaec` port to github resolving setup/build errors on all platforms. See  https://github.com/microsoft/vcpkg/commit/9942fb5f996ea431c5ed8fb8d2a53f31d08df62e