### PR TITLE
feat(waveforms): add file-based CW and FMCW waveforms

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -45,7 +45,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
             - name: Install Linux dependencies
               if: runner.os == 'Linux'
@@ -54,11 +54,14 @@ jobs:
                   sudo apt-get install -y pkg-config build-essential
 
             - name: Get CMake
-              uses: lukka/get-cmake@latest
+              uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # latest
+              with:
+                  cmakeVersion: 4.4.2
+                  ninjaVersion: 1.13.2
 
             - name: Setup MSVC
               if: runner.os == 'Windows'
-              uses: ilammy/msvc-dev-cmd@v1
+              uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
               with:
                   arch: ${{ matrix.msvc_arch }}
 
@@ -78,7 +81,7 @@ jobs:
 
             - name: Setup ccache
               if: runner.os != 'Windows'
-              uses: hendrikmuhs/ccache-action@v1.2
+              uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
               with:
                   key: ${{ matrix.os }}-coverage
                   variant: ccache
@@ -108,7 +111,7 @@ jobs:
                   echo "VCPKG_KEEP_ENV_VARS=ACTIONS_CACHE_URL;ACTIONS_RUNTIME_TOKEN;CMAKE_C_COMPILER_LAUNCHER;CMAKE_CXX_COMPILER_LAUNCHER" >> "$GITHUB_ENV"
 
             - name: Cache vcpkg downloads
-              uses: actions/cache@v5
+              uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
               with:
                   path: ${{ github.workspace }}/.cache/vcpkg/downloads
                   key: ${{ runner.os }}-vcpkg-downloads-${{ hashFiles('vcpkg.json') }}
@@ -117,7 +120,7 @@ jobs:
 
             - name: Cache Windows vcpkg binary packages
               if: runner.os == 'Windows'
-              uses: actions/cache@v5
+              uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
               with:
                   path: ${{ github.workspace }}/.cache/vcpkg/binary-cache/${{ matrix.vcpkg_triplet }}
                   key: ${{ runner.os }}-vcpkg-binary-${{ matrix.vcpkg_triplet }}-${{ hashFiles('vcpkg.json') }}
@@ -125,7 +128,7 @@ jobs:
                       ${{ runner.os }}-vcpkg-binary-${{ matrix.vcpkg_triplet }}-
 
             - name: Setup vcpkg
-              uses: lukka/run-vcpkg@v11
+              uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11
               with:
                   vcpkgDirectory: ${{ github.workspace }}/vcpkg
                   vcpkgJsonGlob: 'vcpkg.json'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,12 +25,15 @@ concurrency:
 jobs:
     build:
         name: Build Documentation
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-            - uses: lukka/get-cmake@latest
+            - uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # latest
+              with:
+                  cmakeVersion: 4.4.2
+                  ninjaVersion: 1.13.2
 
             - name: Install build tools
               run: |
@@ -44,7 +47,7 @@ jobs:
               run: cmake --build --preset release --target doc
 
             - name: Upload artifact
-              uses: actions/upload-pages-artifact@v3
+              uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
               with:
                   path: './build/release/docs/html'
 
@@ -53,9 +56,9 @@ jobs:
         environment:
             name: github-pages
             url: ${{ steps.deployment.outputs.page_url }}
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         needs: build
         steps:
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v4
+              uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -23,16 +23,16 @@ jobs:
         timeout-minutes: 15
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
             - name: Setup Bun
-              uses: oven-sh/setup-bun@v2
+              uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
               with:
-                  bun-version: latest
+                  bun-version: 1.3.14
 
             - name: Cache Bun dependencies
               if: runner.os != 'Windows'
-              uses: actions/cache@v5
+              uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
               with:
                   path: ~/.bun/install/cache
                   key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
@@ -49,9 +49,9 @@ jobs:
               run: rustup show
 
             - name: Install cargo-about
-              uses: taiki-e/install-action@v2
+              uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f # v2
               with:
-                  tool: cargo-about
+                  tool: cargo-about@0.9.1
 
             - name: Check licenses are up to date
               run: |
@@ -93,7 +93,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
             - name: Install Linux dependencies
               if: runner.os == 'Linux'
@@ -102,11 +102,14 @@ jobs:
                   sudo apt-get install -y pkg-config build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev libwebkit2gtk-4.1-dev xdg-utils
 
             - name: Get CMake
-              uses: lukka/get-cmake@latest
+              uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # latest
+              with:
+                  cmakeVersion: 4.4.2
+                  ninjaVersion: 1.13.2
 
             - name: Setup MSVC
               if: runner.os == 'Windows'
-              uses: ilammy/msvc-dev-cmd@v1
+              uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
               with:
                   arch: ${{ matrix.msvc_arch }}
 
@@ -133,7 +136,7 @@ jobs:
 
             - name: Setup ccache
               if: runner.os != 'Windows'
-              uses: hendrikmuhs/ccache-action@v1.2
+              uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
               with:
                   key: ui-${{ matrix.os }}
                   variant: ccache
@@ -163,7 +166,7 @@ jobs:
                   echo "VCPKG_KEEP_ENV_VARS=ACTIONS_CACHE_URL;ACTIONS_RUNTIME_TOKEN;CMAKE_C_COMPILER_LAUNCHER;CMAKE_CXX_COMPILER_LAUNCHER" >> "$GITHUB_ENV"
 
             - name: Cache vcpkg downloads
-              uses: actions/cache@v5
+              uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
               with:
                   path: ${{ github.workspace }}/.cache/vcpkg/downloads
                   key: ${{ runner.os }}-vcpkg-downloads-${{ hashFiles('vcpkg.json') }}
@@ -172,7 +175,7 @@ jobs:
 
             - name: Cache Windows vcpkg binary packages
               if: runner.os == 'Windows'
-              uses: actions/cache@v5
+              uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
               with:
                   path: ${{ github.workspace }}/.cache/vcpkg/binary-cache/${{ matrix.vcpkg_triplet }}
                   key: ${{ runner.os }}-vcpkg-binary-${{ matrix.vcpkg_triplet }}-${{ hashFiles('vcpkg.json') }}
@@ -180,19 +183,19 @@ jobs:
                       ${{ runner.os }}-vcpkg-binary-${{ matrix.vcpkg_triplet }}-
 
             - name: Setup vcpkg
-              uses: lukka/run-vcpkg@v11
+              uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11
               with:
                   vcpkgDirectory: ${{ github.workspace }}/vcpkg
                   vcpkgJsonGlob: 'vcpkg.json'
                   doNotCache: true
 
             - name: Setup Bun
-              uses: oven-sh/setup-bun@v2
+              uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
               with:
-                  bun-version: latest
+                  bun-version: 1.3.14
 
             - name: Cache Bun dependencies
-              uses: actions/cache@v5
+              uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
               with:
                   path: ~/.bun/install/cache
                   key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
@@ -207,7 +210,7 @@ jobs:
               run: rustup target add ${{ matrix.rust_target }}
 
             - name: Rust Cache
-              uses: Swatinem/rust-cache@v2
+              uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
               with:
                   # Targets the specific workspace directory mapped in your .cargo/config.toml
                   workspaces: 'packages/fers-ui/src-tauri -> target'

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -19,13 +19,13 @@ concurrency:
 jobs:
     deploy:
         name: Deploy Wiki
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         env:
             WIKI_REPOSITORY: ${{ github.repository }}.wiki
             WIKI_TOKEN: ${{ secrets.WIKI_DEPLOY_TOKEN || github.token }}
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
             - name: Clone associated wiki repository
               run: |

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ semi-independent packages.
 - **Visual Scenario Builder:** An intuitive 3D interface to construct, configure, and visualize radar scenarios.
 - **Flexible System Modeling:** Simulate a wide range of radar systems, including monostatic, multistatic, pulsed,
   continuous wave (CW), native FMCW streaming, and native stepped-frequency continuous-wave (SFCW) modes.
+- **Sampled Waveform Input:** Load complex-baseband pulse waveforms from CSV or HDF5 and finite CW/FMCW waveforms
+  from the same HDF5 I/Q layout, while retaining generated CW tones and analytic FMCW chirps.
 - **Advanced Data Export:** Output simulation data in HDF5 format for analysis.
 - **Geographic Visualization:** Generate KML files from scenarios for accurate visualization in tools like Google Earth.
 - **Modern Documentation:** A continuously updated and

--- a/docs/wiki/FERS-UI.md
+++ b/docs/wiki/FERS-UI.md
@@ -154,7 +154,7 @@ Waveform editing supports:
 - Generated FMCW linear and triangular chirps.
 - SFCW stepped-frequency sweeps.
 
-For FMCW waveforms, the UI warns or blocks when settings violate major FMCW constraints, such as chirp period shorter than chirp duration or a baseband sweep edge too close to the effective sample-rate limit `<rate> * <oversample>`.
+For generated FMCW waveforms, the UI warns or blocks when settings violate major FMCW constraints, such as chirp period shorter than chirp duration or a baseband sweep edge too close to the effective sample-rate limit `<rate> * <oversample>`. File-backed FMCW validates its HDF5 filename but does not apply analytic chirp constraints that cannot be inferred from arbitrary samples.
 
 For SFCW waveforms, the UI validates step count, step size, dwell time, step period, optional sweep count, and whether the generated RF steps remain positive.
 
@@ -234,7 +234,7 @@ For FMCW receivers and monostatic radars, the UI supports:
 
 IF settings are valid only when dechirping is enabled. If dechirping is enabled without an IF sample rate, FERS writes legacy full-rate IF output at `<rate> * <oversample>`. If an IF sample rate is provided, it is receiver-local and must be no higher than `<rate> * <oversample>`.
 
-The UI blocks simulations and KML generation when it detects invalid FMCW settings that would fail later.
+The UI blocks simulations and KML generation when it detects invalid generated-FMCW settings or an invalid file-backed FMCW filename that would fail later.
 
 ### SFCW Receiver Settings
 

--- a/docs/wiki/FERS-UI.md
+++ b/docs/wiki/FERS-UI.md
@@ -149,10 +149,9 @@ If you change the rotation angle unit after entering rotation values, the UI ask
 
 Waveform editing supports:
 
-- Pulse file waveforms from `.csv` or `.h5`.
-- CW waveforms.
-- FMCW linear chirps.
-- FMCW triangular chirps.
+- Pulse file waveforms from `.csv` or `.h5`; CW and FMCW file waveforms use the same pulsed HDF5 I/Q layout and are listed first as the primary authoring choices.
+- Generated CW tones.
+- Generated FMCW linear and triangular chirps.
 - SFCW stepped-frequency sweeps.
 
 For FMCW waveforms, the UI warns or blocks when settings violate major FMCW constraints, such as chirp period shorter than chirp duration or a baseband sweep edge too close to the effective sample-rate limit `<rate> * <oversample>`.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -8,9 +8,9 @@ FERS is useful when you need to study how radar waveforms, platform motion, timi
 
 FERS can model:
 
-- Pulsed radar using complex baseband waveform files.
-- Continuous-wave radar.
-- FMCW linear chirps and triangular chirps.
+- Pulsed radar using complex-baseband waveform files.
+- Continuous-wave radar using finite HDF5 I/Q waveforms or generated tones.
+- FMCW radar using finite HDF5 I/Q waveforms or generated linear and triangular chirps.
 - Stepped-frequency continuous-wave radar.
 - Monostatic radars, where the transmitter and receiver are attached to the same platform.
 - Bistatic or multistatic layouts, where transmitters, receivers, and targets are on separate moving platforms.

--- a/docs/wiki/Simulation-Pipelines.md
+++ b/docs/wiki/Simulation-Pipelines.md
@@ -152,20 +152,23 @@ Pulsed output is written as one I/Q dataset pair per receiver window.
 
 ## CW Streaming Pipeline
 
-CW output is continuous over the receiver's active intervals.
+CW output is streamed over the receiver's active intervals. `<cw_from_file>` supplies a finite complex envelope sampled
+at `<rate>`; each active transmitter segment starts at the first HDF5 sample and stops at the file end without wrapping.
+Generated `<cw/>` remains a continuous unit-envelope tone.
 
 ```mermaid
 flowchart TD
-    A[CW waveform] --> B[Active transmitter interval]
+    A[CW HDF5 waveform or generated tone] --> B[Active transmitter interval]
     B --> C[For each receiver sample]
-    C --> D[Update platform geometry]
-    D --> E[Calculate direct path if enabled]
-    D --> F[Calculate target reflections]
-    E --> G[Sum received complex sample]
-    F --> G
-    G --> H[Apply timing effects and noise]
-    H --> I[Normalize and optional ADC quantization]
-    I --> J[Write I_data and Q_data]
+    C --> D[Evaluate file envelope or generated tone at retarded transmit time]
+    D --> E[Update platform geometry]
+    E --> F[Calculate direct path if enabled]
+    E --> G[Calculate target reflections]
+    F --> H[Sum received complex sample]
+    G --> H
+    H --> I[Apply timing effects and noise]
+    I --> J[Normalize and optional ADC quantization]
+    J --> K[Write I_data and Q_data]
 ```
 
 Important CW settings:
@@ -173,6 +176,8 @@ Important CW settings:
 | Setting | Effect |
 | --- | --- |
 | `<rate>` | Output sample rate. |
+| `<cw_from_file>` | Finite HDF5 complex envelope; no implicit repetition. |
+| `<cw/>` | Generated continuous tone. |
 | Schedules | Active transmit and receive intervals. |
 | Antenna patterns and platform rotation | Directional gain over time. |
 | `nodirect` | Removes direct transmitter-to-receiver path. |
@@ -184,7 +189,7 @@ Use `dechirp_mode="none"` when you want FERS to write the received FMCW signal a
 
 ```mermaid
 flowchart TD
-    A[FMCW chirp waveform] --> B[Active transmitter interval]
+    A[FMCW HDF5 waveform or generated chirp] --> B[Active transmitter interval]
     B --> C[Generate received raw baseband samples]
     C --> D[Apply delays, Doppler, gain, RCS, and path loss]
     D --> E[Sum direct and reflected paths]
@@ -200,14 +205,17 @@ Use this mode when:
 - You are testing a custom processing chain.
 - You want to compare FERS output with another FMCW processor.
 
+For `<fmcw_from_file>`, raw output preserves the supplied finite complex envelope after propagation. FERS does not infer
+an analytic chirp bandwidth, direction, period, or repetition from the samples.
+
 ## FMCW Pipeline With Built-In Dechirp
 
 Use `dechirp_mode="physical"` or `dechirp_mode="ideal"` when you want FERS to write IF output directly.
 
 ```mermaid
 flowchart TD
-    A[FMCW chirp waveform] --> B[Received raw baseband sample]
-    C[Dechirp reference] --> D[Mix received signal with reference]
+    A[FMCW HDF5 waveform or generated chirp] --> B[Received raw baseband sample]
+    C[Matching complex dechirp reference] --> D[Mix received signal with reference]
     B --> D
     D --> E[Low-pass IF filtering when if_sample_rate is configured]
     E --> F[Resample to receiver-local if_sample_rate when configured]
@@ -216,6 +224,9 @@ flowchart TD
 ```
 
 If `if_sample_rate` is omitted, dechirped FMCW is written as legacy full-rate IF output at `<rate> * <oversample>`.
+
+For `<fmcw_from_file>`, the dechirp reference uses the same finite complex samples, including their amplitude and phase
+modulation. Reference playback ends at the file boundary and does not synthesize chirp repetition.
 
 Reference choices:
 

--- a/docs/wiki/Using-FERS.md
+++ b/docs/wiki/Using-FERS.md
@@ -28,7 +28,7 @@ A scenario describes the radar scene, not the analysis you want to run afterward
 At a high level it contains:
 
 - Global settings, such as start time, end time, sample rate, and KML/geospatial reference settings.
-- Waveforms, such as pulsed waveform files, CW tones, or FMCW chirps.
+- Waveforms, including pulsed files, finite HDF5-backed CW/FMCW signals, generated CW tones, and generated FMCW chirps.
 - Timing sources, which model oscillator frequency, phase, and noise behavior.
 - Antennas, which determine gain as a function of direction.
 - Platforms, which move through the scene.
@@ -46,7 +46,8 @@ The complete XML reference is in [[XML Schema Reference]].
 | FMCW | You want chirp-based ranging or range-Doppler analysis. | Prefer `<fmcw_from_file>`; generated `<fmcw_linear_chirp>` and `<fmcw_triangle>` remain available. Use `<fmcw_mode>` and optional dechirp settings. |
 | SFCW | You want stepped narrowband RF dwells that synthesize a wider range profile without one wide baseband waveform. | `<stepped_frequency>`, `<sfcw_mode/>`, step size/count, dwell time, and step period. |
 
-The waveform type and radar mode must match. For example, a `<cw/>` waveform must be used with `<cw_mode/>`.
+The waveform type and radar mode must match. For example, `<cw_from_file>` and `<cw/>` use `<cw_mode/>`, while
+`<fmcw_from_file>`, `<fmcw_linear_chirp>`, and `<fmcw_triangle>` use `<fmcw_mode>`.
 
 ## Monostatic And Bistatic Layouts
 
@@ -87,7 +88,7 @@ I_data
 Q_data
 ```
 
-For FMCW with dechirping enabled, these datasets contain the dechirped IF output. Without dechirping, they contain the received complex baseband signal. SFCW output is raw streaming complex baseband; the HDF5 metadata records the step timing and RF frequencies needed for downstream range-profile reconstruction.
+For FMCW with dechirping enabled, these datasets contain the dechirped IF output. Without dechirping, they contain the received complex baseband signal. File-backed CW/FMCW sources stop after their final HDF5 sample and do not wrap implicitly. File-backed FMCW metadata reports sampled duration and count instead of inferred analytic chirp parameters. SFCW output is raw streaming complex baseband; the HDF5 metadata records the step timing and RF frequencies needed for downstream range-profile reconstruction.
 
 ## Reconstruct Physical I/Q Values
 
@@ -128,7 +129,7 @@ The most important rates are:
 | `<oversample>` | Internal oversampling multiplier. FMCW aliasing checks and legacy full-rate dechirped IF output use `<rate> * <oversample>`. |
 | `<if_sample_rate>` | Optional receiver-local FMCW IF output rate after dechirping and resampling. |
 
-Use a high enough `<rate>` and `<oversample>` to represent the signal bandwidth you expect. For FMCW, the waveform definition must also satisfy the baseband sweep-edge checks described in [[XML Schema Reference]]. For SFCW, `<rate>` must be high enough to capture the dwell intervals you want to analyze; the wide effective bandwidth comes from RF step metadata, not a wide instantaneous baseband waveform.
+Use a high enough `<rate>` and `<oversample>` to represent the signal bandwidth you expect. Generated FMCW waveforms must also satisfy the baseband sweep-edge checks described in [[XML Schema Reference]]. For file-backed CW/FMCW, `<rate>` is the HDF5 sample rate; FERS does not infer bandwidth, sweep direction, or repetition from the samples. For SFCW, `<rate>` must be high enough to capture the dwell intervals you want to analyze; the wide effective bandwidth comes from RF step metadata, not a wide instantaneous baseband waveform.
 
 ## Validation
 
@@ -172,7 +173,9 @@ If KML generation fails, `fers-cli` exits with a nonzero status and logs the rea
 | Scenario loads but does not run | A referenced waveform, antenna, timing source, or platform object name is wrong. |
 | Output is all zeros | Receiver schedule/window may miss the return, antenna pointing may be wrong, target may be outside the simulated time span, or path loss may make the signal very small. |
 | Pulsed range looks offset | Check `window_skip`, `window_length`, waveform sample rate, and speed of propagation `c`. |
-| FMCW run fails validation | Check chirp bandwidth, chirp duration, chirp period, count fields, `start_frequency_offset`, `<rate>`, `<oversample>`, and IF-chain settings. |
+| Generated FMCW run fails validation | Check chirp bandwidth, chirp duration, chirp period, count fields, `start_frequency_offset`, `<rate>`, `<oversample>`, and IF-chain settings. |
+| CW/FMCW file waveform fails to load | Use an HDF5 `.h5` file with equal-length one-dimensional `/I/value` and `/Q/value` datasets; CSV is supported only for pulsed file waveforms. |
+| File-backed CW/FMCW output stops early | File playback is finite and does not wrap; provide enough samples for the active transmitter interval or schedule another active segment to restart playback. |
 | SFCW run fails validation | Check `step_size`, `step_count`, `dwell_time`, `step_period`, `sweep_count`, and that every RF step remains positive. |
 | KML looks wrong geographically | Check KML/geospatial `<origin>`, `<coordinatesystem>`, UTM zone, and hemisphere. |
 

--- a/docs/wiki/Using-FERS.md
+++ b/docs/wiki/Using-FERS.md
@@ -42,8 +42,8 @@ The complete XML reference is in [[XML Schema Reference]].
 | Mode | Use when | Scenario pieces |
 | --- | --- | --- |
 | Pulsed | You have a pulse waveform and want range-gated receiver windows. | `<pulsed_from_file>`, `<pulsed_mode>`, `prf`, `window_skip`, `window_length`. |
-| CW | You want continuous-wave Doppler-style output. | `<cw/>`, `<cw_mode/>`. |
-| FMCW | You want chirp-based ranging or range-Doppler analysis. | `<fmcw_linear_chirp>` or `<fmcw_triangle>`, `<fmcw_mode>`, optional dechirp settings. |
+| CW | You want continuous-wave Doppler-style output. | Prefer `<cw_from_file>`; `<cw/>` generates a simple tone. Use `<cw_mode/>`. |
+| FMCW | You want chirp-based ranging or range-Doppler analysis. | Prefer `<fmcw_from_file>`; generated `<fmcw_linear_chirp>` and `<fmcw_triangle>` remain available. Use `<fmcw_mode>` and optional dechirp settings. |
 | SFCW | You want stepped narrowband RF dwells that synthesize a wider range profile without one wide baseband waveform. | `<stepped_frequency>`, `<sfcw_mode/>`, step size/count, dwell time, and step period. |
 
 The waveform type and radar mode must match. For example, a `<cw/>` waveform must be used with `<cw_mode/>`.

--- a/docs/wiki/VITA49-Streaming-Implementation.md
+++ b/docs/wiki/VITA49-Streaming-Implementation.md
@@ -400,6 +400,10 @@ The serializer follows the receiver mode when stale mode blocks are present. For
 - `dechirp_reference_waveform_id`
 - `dechirp_reference_waveform_name`
 
+For file-backed FMCW, `waveform_shape` is `file`. Analytic chirp fields are not inferred from the HDF5 samples. The
+current VITA context profile does not include the HDF5 `sampled_duration` and `sampled_count` fields available in normal
+FERS output metadata.
+
 ### SFCW Metadata
 
 `sfcw` contains:

--- a/docs/wiki/VITA49-Streaming-Implementation.md
+++ b/docs/wiki/VITA49-Streaming-Implementation.md
@@ -377,6 +377,11 @@ The serializer follows the receiver mode when stale mode blocks are present. For
 - `carrier_hz`
 - `power_w`
 
+For an attached CW receiver, these fields describe the attached transmitter's waveform. For a detached bistatic CW
+receiver, FERS binds them when the active source inventory contains one logical generated or file-backed CW source;
+repeated schedule segments from that same source are treated as one. If multiple distinct CW sources are active, the
+scalar CW context remains unbound rather than selecting an arbitrary transmitter.
+
 ### FMCW Metadata
 
 `fmcw` contains:

--- a/docs/wiki/XML-Schema-Reference.md
+++ b/docs/wiki/XML-Schema-Reference.md
@@ -145,6 +145,8 @@ Required children:
 Then choose exactly one waveform type:
 
 - `<pulsed_from_file>`.
+- `<cw_from_file>`.
+- `<fmcw_from_file>`.
 - `<cw/>`.
 - `<fmcw_linear_chirp>`.
 - `<fmcw_triangle>`.
@@ -173,9 +175,22 @@ Supported file types:
 
 The file contains complex baseband samples. Do not include the RF carrier in the file; use `<carrier_frequency>` for that.
 
+### `<cw_from_file>` and `<fmcw_from_file>`
+
+File input is the primary way to define CW and FMCW waveforms. Parameter-generated `<cw/>`, `<fmcw_linear_chirp>`, and `<fmcw_triangle>` remain available as convenient alternatives.
+
+```xml
+<cw_from_file filename="recorded_cw.h5"/>
+<fmcw_from_file filename="sampled_fmcw.h5"/>
+```
+
+Both elements use the same HDF5 layout and path resolution as pulsed HDF5 input: one-dimensional real samples in `/I/value` and imaginary samples in `/Q/value`. The scenario `<rate>` supplies the sample rate. The file is a finite complex-baseband timeline; it starts at the beginning of an active transmitter segment and stops after its last sample without implicit wrapping. `<power>` scales the complex sample envelope.
+
+FMCW dechirp references use the same finite complex samples. A file-backed FMCW waveform therefore may contain an arbitrary sampled sweep or phase/amplitude modulation; FERS does not infer analytic chirp bandwidth, direction, or repetition from the file.
+
 ### `<cw/>`
 
-Use this for continuous-wave simulation.
+Use this to generate a simple continuous tone without a file.
 
 ```xml
 <cw/>

--- a/packages/fers-cli/README.md
+++ b/packages/fers-cli/README.md
@@ -13,7 +13,7 @@ terminal and to maintain backward compatibility with the original FERS workflow.
 - Full access to all core `libfers` simulation capabilities.
 - Parses command-line arguments for simulation control.
 - Loads scenarios from FERS XML files.
-- Runs pulsed, CW, FMCW, and SFCW scenarios using the same XML workflow.
+- Runs pulsed, CW, FMCW, and SFCW scenarios using the same XML workflow, including HDF5-backed CW/FMCW waveforms.
 - Displays real-time simulation progress in the console.
 - Automatically outputs results to the scenario's directory by default.
 - Generates KML files for scenario visualization.

--- a/packages/fers-ui/README.md
+++ b/packages/fers-ui/README.md
@@ -14,6 +14,7 @@
 - **Hierarchical Scene Tree:** An intuitive tree view for all simulation elements, enabling easy selection, parenting, and organization of complex scenarios.
 - **Integrated Simulation Runner:** A focused workspace to configure global simulation parameters, trigger the FERS core engine, and monitor progress.
 - **FERS XML Import/Export:** Generate a valid FERS XML configuration file directly from the visual scenario, or load an existing one to begin editing.
+- **Waveform Authoring:** Configure HDF5-backed CW/FMCW waveforms as the primary authoring choices, with generated CW tones and analytic FMCW chirps retained as alternatives.
 
 ## Technology Stack
 

--- a/packages/fers-ui/src/components/LinkVisualizer.tsx
+++ b/packages/fers-ui/src/components/LinkVisualizer.tsx
@@ -407,7 +407,8 @@ export default function LinkVisualizer() {
                 }
 
                 const dutyCycle =
-                    waveform.waveformType === 'fmcw_triangle'
+                    waveform.waveformType === 'fmcw_triangle' ||
+                    waveform.waveformType === 'fmcw_from_file'
                         ? 1
                         : waveform.waveformType === 'fmcw_linear_chirp' &&
                             waveform.chirp_period > 0

--- a/packages/fers-ui/src/components/inspectors/InspectorControls.test.ts
+++ b/packages/fers-ui/src/components/inspectors/InspectorControls.test.ts
@@ -96,14 +96,42 @@ describe('InspectorControls blur resolution', () => {
 });
 
 describe('Waveform inspector authoring options', () => {
-    test('offers pulse file, CW, and FMCW waveform types', () => {
+    test('offers file waveform types first and generated alternatives after them', () => {
         expect(WAVEFORM_TYPE_OPTIONS).toEqual([
             { value: 'pulsed_from_file', label: 'Pulse File' },
-            { value: 'cw', label: 'CW' },
-            { value: 'fmcw_linear_chirp', label: 'FMCW Linear Chirp' },
-            { value: 'fmcw_triangle', label: 'FMCW Triangle' },
+            { value: 'cw_from_file', label: 'CW File' },
+            { value: 'fmcw_from_file', label: 'FMCW File' },
+            { value: 'cw', label: 'CW Tone (Generated)' },
+            {
+                value: 'fmcw_linear_chirp',
+                label: 'FMCW Linear Chirp (Generated)',
+            },
+            { value: 'fmcw_triangle', label: 'FMCW Triangle (Generated)' },
             { value: 'stepped_frequency', label: 'SFCW' },
         ]);
+    });
+
+    test('creates file waveform defaults and shows only the file field', () => {
+        for (const waveformType of [
+            'cw_from_file',
+            'fmcw_from_file',
+        ] as const) {
+            const waveform = createWaveformForType(
+                {
+                    id: 'file',
+                    type: 'Waveform',
+                    name: 'File waveform',
+                    waveformType: 'cw',
+                    power: 10,
+                    carrier_frequency: 1e9,
+                },
+                waveformType
+            );
+            expect(waveform).toMatchObject({ waveformType, filename: '' });
+            expect(getVisibleWaveformFieldLabels(waveformType)).toEqual([
+                'Waveform File (.h5)',
+            ]);
+        }
     });
 
     test('creates FMCW defaults while preserving common waveform fields', () => {
@@ -248,6 +276,8 @@ describe('Platform component inspector waveform compatibility', () => {
         { id: '3', name: 'Chirp', waveformType: 'fmcw_linear_chirp' },
         { id: '4', name: 'Triangle', waveformType: 'fmcw_triangle' },
         { id: '5', name: 'Steps', waveformType: 'stepped_frequency' },
+        { id: '6', name: 'CW File', waveformType: 'cw_from_file' },
+        { id: '7', name: 'FMCW File', waveformType: 'fmcw_from_file' },
     ];
 
     test('offers FMCW radar mode and hides pulsed-only fields for FMCW/CW', () => {
@@ -272,10 +302,14 @@ describe('Platform component inspector waveform compatibility', () => {
         expect(getCompatibleWaveforms(waveforms, 'pulsed')).toEqual([
             waveforms[0],
         ]);
-        expect(getCompatibleWaveforms(waveforms, 'cw')).toEqual([waveforms[1]]);
+        expect(getCompatibleWaveforms(waveforms, 'cw')).toEqual([
+            waveforms[1],
+            waveforms[5],
+        ]);
         expect(getCompatibleWaveforms(waveforms, 'fmcw')).toEqual([
             waveforms[2],
             waveforms[3],
+            waveforms[6],
         ]);
         expect(getCompatibleWaveforms(waveforms, 'sfcw')).toEqual([
             waveforms[4],
@@ -410,6 +444,15 @@ describe('Platform component inspector waveform compatibility', () => {
                 start_frequency_offset: 0,
                 chirp_count: null,
             },
+            {
+                id: '3',
+                type: 'Waveform' as const,
+                name: 'FMCW File LO',
+                waveformType: 'fmcw_from_file' as const,
+                power: 1,
+                carrier_frequency: 1,
+                filename: 'fmcw.h5',
+            },
         ];
         const platforms = [
             {
@@ -462,7 +505,10 @@ describe('Platform component inspector waveform compatibility', () => {
             },
         ];
 
-        expect(getFmcwWaveformNames(fullWaveforms)).toEqual(['FMCW LO']);
+        expect(getFmcwWaveformNames(fullWaveforms)).toEqual([
+            'FMCW LO',
+            'FMCW File LO',
+        ]);
         expect(getFmcwEmitterNames(platforms, fullWaveforms)).toEqual([
             'FMCW TX',
         ]);

--- a/packages/fers-ui/src/components/inspectors/PlatformComponentInspector.tsx
+++ b/packages/fers-ui/src/components/inspectors/PlatformComponentInspector.tsx
@@ -69,8 +69,8 @@ export const RADAR_MODE_OPTIONS: ReadonlyArray<{
 
 const WAVEFORM_TYPE_BY_RADAR_TYPE: Record<RadarType, string[]> = {
     pulsed: ['pulsed_from_file'],
-    cw: ['cw'],
-    fmcw: ['fmcw_linear_chirp', 'fmcw_triangle'],
+    cw: ['cw_from_file', 'cw'],
+    fmcw: ['fmcw_from_file', 'fmcw_linear_chirp', 'fmcw_triangle'],
     sfcw: ['stepped_frequency'],
 };
 

--- a/packages/fers-ui/src/components/inspectors/WaveformInspector.tsx
+++ b/packages/fers-ui/src/components/inspectors/WaveformInspector.tsx
@@ -16,6 +16,8 @@ import { BufferedTextField, FileInput, NumberField } from './InspectorControls';
 
 export type WaveformType =
     | 'pulsed_from_file'
+    | 'cw_from_file'
+    | 'fmcw_from_file'
     | 'cw'
     | 'fmcw_linear_chirp'
     | 'fmcw_triangle'
@@ -59,9 +61,11 @@ export const WAVEFORM_TYPE_OPTIONS: ReadonlyArray<{
     label: string;
 }> = [
     { value: 'pulsed_from_file', label: 'Pulse File' },
-    { value: 'cw', label: 'CW' },
-    { value: 'fmcw_linear_chirp', label: 'FMCW Linear Chirp' },
-    { value: 'fmcw_triangle', label: 'FMCW Triangle' },
+    { value: 'cw_from_file', label: 'CW File' },
+    { value: 'fmcw_from_file', label: 'FMCW File' },
+    { value: 'cw', label: 'CW Tone (Generated)' },
+    { value: 'fmcw_linear_chirp', label: 'FMCW Linear Chirp (Generated)' },
+    { value: 'fmcw_triangle', label: 'FMCW Triangle (Generated)' },
     { value: 'stepped_frequency', label: 'SFCW' },
 ];
 
@@ -101,7 +105,11 @@ export function createWaveformForType(
         waveformType,
     };
 
-    if (waveformType === 'pulsed_from_file') {
+    if (
+        waveformType === 'pulsed_from_file' ||
+        waveformType === 'cw_from_file' ||
+        waveformType === 'fmcw_from_file'
+    ) {
         return {
             ...nextWaveform,
             filename:
@@ -186,6 +194,9 @@ export function getVisibleWaveformFieldLabels(
 ): string[] {
     if (waveformType === 'pulsed_from_file') {
         return ['Waveform File (.csv, .h5)'];
+    }
+    if (waveformType === 'cw_from_file' || waveformType === 'fmcw_from_file') {
+        return ['Waveform File (.h5)'];
     }
 
     if (waveformType === 'fmcw_linear_chirp') {
@@ -311,13 +322,25 @@ export function WaveformInspector({ item }: WaveformInspectorProps) {
                     {issue.message}
                 </Alert>
             ))}
-            {waveform.waveformType === 'pulsed_from_file' && (
+            {(waveform.waveformType === 'pulsed_from_file' ||
+                waveform.waveformType === 'cw_from_file' ||
+                waveform.waveformType === 'fmcw_from_file') && (
                 <FileInput
-                    label="Waveform File (.csv, .h5)"
+                    label={
+                        waveform.waveformType === 'pulsed_from_file'
+                            ? 'Waveform File (.csv, .h5)'
+                            : 'Waveform File (.h5)'
+                    }
                     value={waveform.filename}
                     onChange={(v) => handleChange('filename', v)}
                     filters={[
-                        { name: 'Waveform', extensions: ['csv', 'h5'] },
+                        {
+                            name: 'Waveform',
+                            extensions:
+                                waveform.waveformType === 'pulsed_from_file'
+                                    ? ['csv', 'h5']
+                                    : ['h5'],
+                        },
                         { name: 'All Files', extensions: ['*'] },
                     ]}
                 />

--- a/packages/fers-ui/src/stores/scenarioSchema.ts
+++ b/packages/fers-ui/src/stores/scenarioSchema.ts
@@ -71,6 +71,26 @@ export const WaveformSchema = z
                 .min(1, 'A filename is required for this waveform type.'),
         }),
         BaseWaveformSchema.extend({
+            waveformType: z.literal('cw_from_file'),
+            filename: z
+                .string()
+                .min(1, 'A filename is required for this waveform type.')
+                .regex(
+                    /\.h5$/i,
+                    'CW file waveforms require an HDF5 (.h5) file.'
+                ),
+        }),
+        BaseWaveformSchema.extend({
+            waveformType: z.literal('fmcw_from_file'),
+            filename: z
+                .string()
+                .min(1, 'A filename is required for this waveform type.')
+                .regex(
+                    /\.h5$/i,
+                    'FMCW file waveforms require an HDF5 (.h5) file.'
+                ),
+        }),
+        BaseWaveformSchema.extend({
             waveformType: z.literal('cw'),
         }),
         BaseWaveformSchema.extend({

--- a/packages/fers-ui/src/stores/scenarioStore/defaults.ts
+++ b/packages/fers-ui/src/stores/scenarioStore/defaults.ts
@@ -49,6 +49,12 @@ export function createWaveformForType(
     waveformType: 'cw'
 ): WaveformDefaults<'cw'>;
 export function createWaveformForType(
+    waveformType: 'cw_from_file'
+): WaveformDefaults<'cw_from_file'>;
+export function createWaveformForType(
+    waveformType: 'fmcw_from_file'
+): WaveformDefaults<'fmcw_from_file'>;
+export function createWaveformForType(
     waveformType: 'fmcw_linear_chirp'
 ): WaveformDefaults<'fmcw_linear_chirp'>;
 export function createWaveformForType(
@@ -68,6 +74,8 @@ export function createWaveformForType(
 
     switch (waveformType) {
         case 'pulsed_from_file':
+        case 'cw_from_file':
+        case 'fmcw_from_file':
             return {
                 ...common,
                 waveformType,

--- a/packages/fers-ui/src/stores/scenarioStore/fmcwModeConfig.ts
+++ b/packages/fers-ui/src/stores/scenarioStore/fmcwModeConfig.ts
@@ -48,6 +48,7 @@ const DECHIRP_REFERENCE_SOURCES = new Set<DechirpReferenceSource>([
 ]);
 
 export const FMCW_WAVEFORM_TYPES = [
+    'fmcw_from_file',
     'fmcw_linear_chirp',
     'fmcw_triangle',
 ] as const;

--- a/packages/fers-ui/src/stores/scenarioStore/fmcwValidation.test.ts
+++ b/packages/fers-ui/src/stores/scenarioStore/fmcwValidation.test.ts
@@ -71,6 +71,20 @@ const makeScenario = (waveform: Waveform): ScenarioData => ({
 });
 
 describe('FMCW validation', () => {
+    test('accepts file-backed FMCW without applying analytic chirp constraints', () => {
+        const waveform: Waveform = {
+            ...createWaveformForType('fmcw_from_file'),
+            id: 'file-fmcw',
+            name: 'File FMCW',
+            filename: 'fmcw.h5',
+        };
+
+        expect(validateFmcwWaveform(waveform, defaultGlobalParameters)).toEqual(
+            []
+        );
+        expect(validateFmcwScenario(makeScenario(waveform))).toEqual([]);
+    });
+
     test('matches backend baseband and RF sweep checks', () => {
         const aliasIssues = validateFmcwWaveform(
             makeLinearWaveform({ chirp_bandwidth: 20e3 }),

--- a/packages/fers-ui/src/stores/scenarioStore/fmcwValidation.ts
+++ b/packages/fers-ui/src/stores/scenarioStore/fmcwValidation.ts
@@ -26,7 +26,7 @@ export type FmcwValidationIssue = {
     field?: string;
 };
 
-type FmcwWaveform = Extract<
+type AnalyticFmcwWaveform = Extract<
     Waveform,
     { waveformType: 'fmcw_linear_chirp' | 'fmcw_triangle' }
 >;
@@ -45,11 +45,14 @@ const IF_CHAIN_FIELD_KEYS = [
     'if_filter_transition_width',
 ] as const;
 
-const isFmcwWaveform = (
+const isAnalyticFmcwWaveform = (
     waveform: Waveform | undefined
-): waveform is FmcwWaveform =>
+): waveform is AnalyticFmcwWaveform =>
     waveform?.waveformType === 'fmcw_linear_chirp' ||
     waveform?.waveformType === 'fmcw_triangle';
+
+const isFmcwWaveform = (waveform: Waveform | undefined): boolean =>
+    isFmcwWaveformType(waveform?.waveformType);
 
 const isSfcwWaveform = (
     waveform: Waveform | undefined
@@ -156,7 +159,7 @@ export function validateFmcwWaveform(
         return issues;
     }
 
-    if (!isFmcwWaveform(waveform)) {
+    if (!isAnalyticFmcwWaveform(waveform)) {
         return [];
     }
 
@@ -226,7 +229,7 @@ export function validateFmcwWaveform(
 
 function validateFmcwEmitterSchedule(
     component: FmcwEmitterComponent,
-    waveform: FmcwWaveform,
+    waveform: AnalyticFmcwWaveform,
     globalParameters: GlobalParameters
 ): FmcwValidationIssue[] {
     const issues: FmcwValidationIssue[] = [];
@@ -663,13 +666,15 @@ export function validateFmcwScenario(
                 continue;
             }
 
-            issues.push(
-                ...validateFmcwEmitterSchedule(
-                    component,
-                    waveform,
-                    scenario.globalParameters
-                )
-            );
+            if (isAnalyticFmcwWaveform(waveform)) {
+                issues.push(
+                    ...validateFmcwEmitterSchedule(
+                        component,
+                        waveform,
+                        scenario.globalParameters
+                    )
+                );
+            }
         }
     }
 

--- a/packages/fers-ui/src/stores/scenarioStore/hydration.test.ts
+++ b/packages/fers-ui/src/stores/scenarioStore/hydration.test.ts
@@ -145,6 +145,45 @@ describe('buildHydratedScenarioState', () => {
 });
 
 describe('parseScenarioData FMCW hydration', () => {
+    test('hydrates CW and FMCW file waveform variants', () => {
+        const scenario = parseScenarioData({
+            name: 'File waveforms',
+            parameters: {},
+            waveforms: [
+                {
+                    id: 11,
+                    name: 'CW File',
+                    power: 1,
+                    carrier_frequency: 1e9,
+                    cw_from_file: { filename: 'cw.h5' },
+                },
+                {
+                    id: 12,
+                    name: 'FMCW File',
+                    power: 2,
+                    carrier_frequency: 2e9,
+                    fmcw_from_file: { filename: 'fmcw.h5' },
+                },
+            ],
+            timings: [],
+            antennas: [],
+            platforms: [],
+        });
+
+        expect(scenario?.waveforms).toEqual([
+            expect.objectContaining({
+                id: '11',
+                waveformType: 'cw_from_file',
+                filename: 'cw.h5',
+            }),
+            expect.objectContaining({
+                id: '12',
+                waveformType: 'fmcw_from_file',
+                filename: 'fmcw.h5',
+            }),
+        ]);
+    });
+
     test('hydrates FMCW waveform and component mode from backend data', () => {
         const scenario = parseScenarioData({
             name: 'FMCW Scenario',

--- a/packages/fers-ui/src/stores/scenarioStore/hydration.ts
+++ b/packages/fers-ui/src/stores/scenarioStore/hydration.ts
@@ -101,6 +101,12 @@ interface BackendWaveform {
     pulsed_from_file?: {
         filename: string;
     };
+    cw_from_file?: {
+        filename: string;
+    };
+    fmcw_from_file?: {
+        filename: string;
+    };
     fmcw_linear_chirp?: {
         direction: 'up' | 'down';
         chirp_bandwidth: number;
@@ -310,7 +316,13 @@ export function parseScenarioData(backendData: unknown): ScenarioData | null {
                 carrier_frequency: w.carrier_frequency,
             };
             let waveform: Waveform;
-            if (w.fmcw_linear_chirp) {
+            if (w.fmcw_from_file) {
+                waveform = {
+                    ...commonWaveform,
+                    waveformType: 'fmcw_from_file',
+                    filename: w.fmcw_from_file.filename ?? '',
+                };
+            } else if (w.fmcw_linear_chirp) {
                 waveform = {
                     ...commonWaveform,
                     waveformType: 'fmcw_linear_chirp',
@@ -343,6 +355,12 @@ export function parseScenarioData(backendData: unknown): ScenarioData | null {
                     dwell_time: w.stepped_frequency.dwell_time,
                     step_period: w.stepped_frequency.step_period,
                     sweep_count: w.stepped_frequency.sweep_count ?? null,
+                };
+            } else if (w.cw_from_file) {
+                waveform = {
+                    ...commonWaveform,
+                    waveformType: 'cw_from_file',
+                    filename: w.cw_from_file.filename ?? '',
                 };
             } else if (w.cw) {
                 waveform = {

--- a/packages/fers-ui/src/stores/scenarioStore/serializers.test.ts
+++ b/packages/fers-ui/src/stores/scenarioStore/serializers.test.ts
@@ -164,6 +164,38 @@ describe('FMCW schema', () => {
     });
 });
 
+describe('file waveform schema', () => {
+    test('requires a non-empty filename for CW and FMCW file variants', () => {
+        const waveforms = [
+            {
+                ...createWaveformForType('cw_from_file'),
+                id: '11',
+                name: 'CW File',
+            },
+            {
+                ...createWaveformForType('fmcw_from_file'),
+                id: '12',
+                name: 'FMCW File',
+            },
+        ];
+        for (const waveform of waveforms) {
+            expect(WaveformSchema.safeParse(waveform).success).toBe(false);
+            expect(
+                WaveformSchema.safeParse({
+                    ...waveform,
+                    filename: `${waveform.waveformType}.h5`,
+                }).success
+            ).toBe(true);
+            expect(
+                WaveformSchema.safeParse({
+                    ...waveform,
+                    filename: `${waveform.waveformType}.csv`,
+                }).success
+            ).toBe(false);
+        }
+    });
+});
+
 describe('SFCW schema', () => {
     const validWaveform: Extract<
         Waveform,
@@ -214,6 +246,28 @@ describe('SFCW schema', () => {
 });
 
 describe('serializeWaveform', () => {
+    test('serializes CW and FMCW file waveform payloads', () => {
+        const cw: Waveform = {
+            ...createWaveformForType('cw_from_file'),
+            id: 'file-cw',
+            name: 'CW File',
+            filename: 'waveforms/cw.h5',
+        };
+        const fmcw: Waveform = {
+            ...createWaveformForType('fmcw_from_file'),
+            id: 'file-fmcw',
+            name: 'FMCW File',
+            filename: 'waveforms/fmcw.h5',
+        };
+
+        expect(serializeWaveform(cw)).toMatchObject({
+            cw_from_file: { filename: 'waveforms/cw.h5' },
+        });
+        expect(serializeWaveform(fmcw)).toMatchObject({
+            fmcw_from_file: { filename: 'waveforms/fmcw.h5' },
+        });
+    });
+
     test('serializes FMCW waveform payload and omits unset optional fields', () => {
         const waveform: Waveform = {
             ...createWaveformForType('fmcw_linear_chirp'),

--- a/packages/fers-ui/src/stores/scenarioStore/serializers.ts
+++ b/packages/fers-ui/src/stores/scenarioStore/serializers.ts
@@ -209,6 +209,10 @@ export const serializeWaveform = (w: Waveform) => {
                 return { cw: {} };
             case 'pulsed_from_file':
                 return { pulsed_from_file: { filename: w.filename } };
+            case 'cw_from_file':
+                return { cw_from_file: { filename: w.filename } };
+            case 'fmcw_from_file':
+                return { fmcw_from_file: { filename: w.filename } };
             case 'fmcw_linear_chirp':
                 return {
                     fmcw_linear_chirp: {

--- a/packages/fers-ui/src/stores/simulationProgressStore.test.ts
+++ b/packages/fers-ui/src/stores/simulationProgressStore.test.ts
@@ -19,6 +19,49 @@ const baseMetadata = {
 } satisfies Omit<SimulationOutputMetadata, 'files'>;
 
 describe('simulation output metadata', () => {
+    test('keeps file-backed FMCW waveform metadata', () => {
+        const metadata: SimulationOutputMetadata = {
+            ...baseMetadata,
+            files: [
+                {
+                    receiver_id: 1,
+                    receiver_name: 'File FMCW Rx',
+                    mode: 'fmcw',
+                    path: '/tmp/fers/file-fmcw.h5',
+                    sampling_rate: 1e6,
+                    total_samples: 4,
+                    sample_start: 0,
+                    sample_end_exclusive: 4,
+                    pulse_count: 0,
+                    min_pulse_length_samples: 0,
+                    max_pulse_length_samples: 0,
+                    uniform_pulse_length: true,
+                    chunks: [],
+                    streaming_segments: [],
+                    fmcw: {
+                        waveform_shape: 'file',
+                        chirp_bandwidth: 0,
+                        chirp_duration: 0,
+                        chirp_rate: 0,
+                        start_frequency_offset: 0,
+                        sampled_duration: 250e-6,
+                        sampled_count: 8,
+                    },
+                    fmcw_sources: [],
+                    sfcw_sources: [],
+                },
+            ],
+        };
+
+        expect(
+            normalizeSimulationOutputMetadata(metadata).files[0].fmcw
+        ).toMatchObject({
+            waveform_shape: 'file',
+            sampled_duration: 250e-6,
+            sampled_count: 8,
+        });
+    });
+
     test('keeps FMCW metadata and streaming segments', () => {
         const metadata: SimulationOutputMetadata = {
             ...baseMetadata,

--- a/packages/fers-ui/src/stores/simulationProgressStore.ts
+++ b/packages/fers-ui/src/stores/simulationProgressStore.ts
@@ -46,7 +46,7 @@ export type SimulationOutputStreamingSegmentMetadata = {
 };
 
 export type SimulationOutputFmcwMetadata = {
-    waveform_shape?: 'linear' | 'triangle';
+    waveform_shape?: 'linear' | 'triangle' | 'file';
     chirp_bandwidth: number;
     chirp_duration: number;
     chirp_rate: number;
@@ -57,6 +57,8 @@ export type SimulationOutputFmcwMetadata = {
     chirp_count?: number;
     triangle_period?: number;
     triangle_count?: number;
+    sampled_duration?: number;
+    sampled_count?: number;
 };
 
 export type SimulationOutputFmcwSourceSegmentMetadata = {

--- a/packages/fers-ui/src/views/SimulationView.tsx
+++ b/packages/fers-ui/src/views/SimulationView.tsx
@@ -421,6 +421,10 @@ export const SimulationView = React.memo(function SimulationView() {
             )}, T_tri=${formatMetric(fmcw.triangle_period ?? 0)}`;
         }
 
+        if (fmcw.waveform_shape === 'file') {
+            return `file, duration=${formatMetric(fmcw.sampled_duration ?? 0)}, samples=${fmcw.sampled_count ?? 0}`;
+        }
+
         return `${fmcw.chirp_direction ?? 'up'}, B=${formatMetric(
             fmcw.chirp_bandwidth
         )}, T_c=${formatMetric(

--- a/packages/libfers/README.md
+++ b/packages/libfers/README.md
@@ -16,6 +16,8 @@ including the official `fers-cli` and `fers-ui` applications.
 - **Signal-Level Modeling:** Creation of radar signal returns, including Doppler and phase modeling.
 - **System Simulation:** Support for monostatic, multistatic, continuous wave (CW), pulsed, and native FMCW streaming
   radar systems.
+- **Waveform Sources:** Finite HDF5 complex-I/Q input for CW and FMCW, CSV/HDF5 pulse input, and generated CW/FMCW
+  alternatives.
 - **Data Export:** Advanced data export in HDF5, CSV, and XML formats.
 - **Geographic Visualization:** Generate KML files from scenarios.
 - **Performance:** A unified event-driven architecture for efficient simulation of both pulsed and continuous-wave scenarios, with a global thread pool for parallelizing tasks.

--- a/packages/libfers/src/core/output_metadata.cpp
+++ b/packages/libfers/src/core/output_metadata.cpp
@@ -80,6 +80,17 @@ namespace core
 					result["chirp_count"] = *fmcw.chirp_count;
 				}
 			}
+			else if (fmcw.waveform_shape == "file")
+			{
+				if (fmcw.sampled_duration.has_value())
+				{
+					result["sampled_duration"] = *fmcw.sampled_duration;
+				}
+				if (fmcw.sampled_count.has_value())
+				{
+					result["sampled_count"] = *fmcw.sampled_count;
+				}
+			}
 			else if (fmcw.waveform_shape == "triangle")
 			{
 				if (fmcw.triangle_period.has_value())

--- a/packages/libfers/src/core/output_metadata.h
+++ b/packages/libfers/src/core/output_metadata.h
@@ -50,7 +50,7 @@ namespace core
 	/// FMCW waveform metadata captured for a streaming output file.
 	struct FmcwMetadata
 	{
-		std::string waveform_shape = "linear"; ///< FMCW waveform shape token: linear or triangle.
+		std::string waveform_shape = "linear"; ///< FMCW waveform shape token: linear, triangle, or file.
 		RealType chirp_bandwidth = 0.0; ///< Chirp bandwidth in hertz.
 		RealType chirp_duration = 0.0; ///< Active chirp duration in seconds.
 		RealType chirp_period = 0.0; ///< Chirp repetition period in seconds.
@@ -61,6 +61,8 @@ namespace core
 		std::optional<std::uint64_t> chirp_count = std::nullopt; ///< Optional finite chirp count.
 		std::optional<RealType> triangle_period = std::nullopt; ///< Full triangle period in seconds.
 		std::optional<std::uint64_t> triangle_count = std::nullopt; ///< Optional finite triangle count.
+		std::optional<RealType> sampled_duration = std::nullopt; ///< Finite file-backed waveform duration in seconds.
+		std::optional<std::uint64_t> sampled_count = std::nullopt; ///< Native samples in a file-backed waveform.
 	};
 
 	/// Metadata for one active FMCW transmitter schedule segment.

--- a/packages/libfers/src/core/sim_threading.cpp
+++ b/packages/libfers/src/core/sim_threading.cpp
@@ -1555,7 +1555,7 @@ namespace core
 	std::optional<ComplexType> SimulationEngine::calculateDechirpMixer(Receiver* rx, const RealType t_step,
 																	   ReceiverTrackerCache& tracker_cache) const
 	{
-		RealType reference_phase = 0.0;
+		ComplexType reference_sample{0.0, 0.0};
 		const auto& dechirp_sources = rx->getDechirpSources();
 		if (tracker_cache.dechirp_reference.size() < dechirp_sources.size())
 		{
@@ -1579,8 +1579,8 @@ namespace core
 		{
 			const auto& reference_source = dechirp_sources[source_index];
 			if (t_step >= reference_source.segment_start && t_step < reference_source.segment_end &&
-				simulation::calculateStreamingReferencePhase(
-					reference_source, t_step, &tracker_cache.dechirp_reference[source_index], reference_phase))
+				simulation::calculateStreamingReferenceSample(
+					reference_source, t_step, &tracker_cache.dechirp_reference[source_index], reference_sample))
 			{
 				reference_active = true;
 			}
@@ -1596,7 +1596,7 @@ namespace core
 		{
 			receiver_phase = _cw_phase_noise_lookup->sample(rx->getTiming().get(), t_step);
 		}
-		return std::polar(1.0, reference_phase + receiver_phase);
+		return reference_sample * std::polar(1.0, receiver_phase);
 	}
 
 	ComplexType SimulationEngine::calculateStreamingSample(Receiver* rx, const RealType t_step,

--- a/packages/libfers/src/core/simulation_state.cpp
+++ b/packages/libfers/src/core/simulation_state.cpp
@@ -243,6 +243,16 @@ namespace core
 				source.segment_end = segment_start + static_cast<RealType>(emitted_triangles) * source.triangle_period;
 				return;
 			}
+
+			if (const auto* const file = signal->getFileSignal();
+				file != nullptr && file->getKind() != fers_signal::FileWaveformKind::Pulsed)
+			{
+				source.file = file;
+				source.file_duration = signal->getLength();
+				source.is_fmcw = file->getKind() == fers_signal::FileWaveformKind::Fmcw;
+				source.kind = source.is_fmcw ? StreamingWaveformKind::FileFmcw : StreamingWaveformKind::FileCw;
+				source.segment_end = std::min(source.segment_end, segment_start + source.file_duration);
+			}
 		}
 	}
 

--- a/packages/libfers/src/core/simulation_state.h
+++ b/packages/libfers/src/core/simulation_state.h
@@ -23,6 +23,7 @@ namespace fers_signal
 {
 	class FmcwChirpSignal;
 	class FmcwTriangleSignal;
+	class FileSignal;
 	class RadarSignal;
 	class SteppedFrequencySignal;
 }
@@ -35,6 +36,8 @@ namespace core
 		Cw,
 		FmcwLinear,
 		FmcwTriangle,
+		FileCw,
+		FileFmcw,
 		Sfcw
 	};
 
@@ -53,6 +56,7 @@ namespace core
 
 		const fers_signal::FmcwChirpSignal* fmcw = nullptr; ///< Stable pointer to the linear FMCW waveform, if any.
 		const fers_signal::FmcwTriangleSignal* triangle = nullptr; ///< Stable pointer to the triangle waveform, if any.
+		const fers_signal::FileSignal* file = nullptr; ///< Stable pointer to the finite sampled waveform, if any.
 		const fers_signal::SteppedFrequencySignal* sfcw =
 			nullptr; ///< Stable pointer to the stepped-frequency waveform, if any.
 		RealType chirp_duration = 0.0; ///< Cached FMCW chirp duration in seconds.
@@ -71,6 +75,7 @@ namespace core
 		RealType mod_phi_tri = 0.0; ///< Triangle period phase increment modulo 2*pi.
 		RealType triangle_period = 0.0; ///< Cached full triangle period in seconds.
 		std::optional<std::size_t> triangle_count; ///< Optional finite triangle count for the segment.
+		RealType file_duration = 0.0; ///< Duration of the finite file waveform in seconds.
 
 		RealType sfcw_step_size = 0.0; ///< Cached SFCW frequency step in hertz.
 		std::size_t sfcw_step_count = 0; ///< Cached SFCW steps per sweep.

--- a/packages/libfers/src/processing/finalizer.cpp
+++ b/packages/libfers/src/processing/finalizer.cpp
@@ -682,6 +682,46 @@ namespace processing
 			return receiver == nullptr ? nullptr : dynamic_cast<const radar::Transmitter*>(receiver->getAttached());
 		}
 
+		[[nodiscard]] bool isCwContextSource(const core::ActiveStreamingSource& source) noexcept
+		{
+			return source.transmitter != nullptr &&
+				(source.kind == core::StreamingWaveformKind::Cw || source.kind == core::StreamingWaveformKind::FileCw);
+		}
+
+		/// Returns the sole logical CW source represented by the active segments.
+		/// Repeated schedule segments from the same transmitter/waveform remain one
+		/// source; multiple distinct CW sources are intentionally left unbound because
+		/// the scalar VITA CW context cannot describe their superposition faithfully.
+		[[nodiscard]] const radar::Transmitter*
+		uniqueCwContextTransmitter(const std::span<const core::ActiveStreamingSource> streaming_sources)
+		{
+			const radar::Transmitter* candidate = nullptr;
+			const fers_signal::RadarSignal* candidate_signal = nullptr;
+			for (const auto& source : streaming_sources)
+			{
+				if (!isCwContextSource(source))
+				{
+					continue;
+				}
+				const auto* signal = source.transmitter->getSignal();
+				if (signal == nullptr)
+				{
+					continue;
+				}
+				if (candidate == nullptr)
+				{
+					candidate = source.transmitter;
+					candidate_signal = signal;
+					continue;
+				}
+				if (candidate != source.transmitter || candidate_signal != signal)
+				{
+					return nullptr;
+				}
+			}
+			return candidate;
+		}
+
 		void populateWaveformIdentity(core::ReceiverStreamDescriptor::PulsedContext& context,
 									  const fers_signal::RadarSignal* signal)
 		{
@@ -773,7 +813,9 @@ namespace processing
 			return context;
 		}
 
-		[[nodiscard]] core::ReceiverStreamDescriptor::CwContext buildCwContext(const radar::Receiver* receiver)
+		[[nodiscard]] core::ReceiverStreamDescriptor::CwContext
+		buildCwContext(const radar::Receiver* receiver,
+					   const std::span<const core::ActiveStreamingSource> streaming_sources)
 		{
 			core::ReceiverStreamDescriptor::CwContext context;
 			if (receiver == nullptr || receiver->getMode() != radar::OperationMode::CW_MODE)
@@ -782,7 +824,12 @@ namespace processing
 			}
 
 			context.present = true;
-			if (const auto* transmitter = attachedTransmitter(receiver); transmitter != nullptr)
+			const auto* transmitter = attachedTransmitter(receiver);
+			if (transmitter == nullptr || transmitter->getSignal() == nullptr)
+			{
+				transmitter = uniqueCwContextTransmitter(streaming_sources);
+			}
+			if (transmitter != nullptr)
 			{
 				populateWaveformIdentity(context, transmitter->getSignal());
 			}
@@ -890,7 +937,7 @@ namespace processing
 												  .coordinate = buildCoordinateContext(),
 												  .initial_platform_state = buildInitialPlatformState(receiver),
 												  .pulsed = buildPulsedContext(receiver),
-												  .cw = buildCwContext(receiver),
+												  .cw = buildCwContext(receiver, streaming_sources),
 												  .fmcw = buildFmcwContext(receiver, streaming_sources),
 												  .sfcw = buildSfcwContext(receiver, streaming_sources)};
 		if (const auto timing = receiver->getTiming(); timing)

--- a/packages/libfers/src/processing/finalizer.cpp
+++ b/packages/libfers/src/processing/finalizer.cpp
@@ -36,6 +36,15 @@ namespace processing
 		/// Converts a cached streaming source to reusable FMCW waveform metadata.
 		core::FmcwMetadata buildFmcwMetadata(const core::ActiveStreamingSource& source)
 		{
+			if (source.kind == core::StreamingWaveformKind::FileFmcw)
+			{
+				return core::FmcwMetadata{.waveform_shape = "file",
+										  .sampled_duration = source.file_duration,
+										  .sampled_count = source.file != nullptr
+											  ? std::optional<std::uint64_t>(static_cast<std::uint64_t>(
+													std::llround(source.file_duration * params::rate())))
+											  : std::nullopt};
+			}
 			if (source.kind == core::StreamingWaveformKind::FmcwTriangle)
 			{
 				return core::FmcwMetadata{
@@ -98,6 +107,10 @@ namespace processing
 			const RealType active_start = std::max(params::startTime(), source.segment_start);
 			const RealType active_end = std::min(params::endTime(), source.segment_end);
 			core::FmcwSourceSegmentMetadata segment{.start_time = source.segment_start, .end_time = source.segment_end};
+			if (source.kind == core::StreamingWaveformKind::FileFmcw)
+			{
+				return segment;
+			}
 			if (source.kind == core::StreamingWaveformKind::FmcwTriangle)
 			{
 				segment.first_triangle_start_time = core::firstFmcwTriangleStart(source, active_start, active_end);

--- a/packages/libfers/src/serial/hdf5_handler.cpp
+++ b/packages/libfers/src/serial/hdf5_handler.cpp
@@ -121,6 +121,11 @@ namespace serial
 					createOptionalUnsignedAttribute(file, prefix + "chirp_count", waveform.chirp_count);
 				}
 			}
+			else if (waveform.waveform_shape == "file")
+			{
+				createOptionalAttribute(file, prefix + "sampled_duration", waveform.sampled_duration);
+				createOptionalUnsignedAttribute(file, prefix + "sampled_count", waveform.sampled_count);
+			}
 			else if (waveform.waveform_shape == "triangle" && waveform.triangle_period.has_value())
 			{
 				file.createAttribute(prefix + "triangle_period", *waveform.triangle_period);

--- a/packages/libfers/src/serial/json_serializer.cpp
+++ b/packages/libfers/src/serial/json_serializer.cpp
@@ -613,7 +613,28 @@ namespace fers_signal
 						   {"name", rs.getName()},
 						   {"power", rs.getPower()},
 						   {"carrier_frequency", rs.getCarrier()}};
-		if (dynamic_cast<const CwSignal*>(rs.getSignal()) != nullptr)
+		if (const auto* file = rs.getFileSignal(); file != nullptr)
+		{
+			std::string_view key = "pulsed_from_file";
+			if (file->getKind() == FileWaveformKind::Cw)
+			{
+				key = "cw_from_file";
+			}
+			else if (file->getKind() == FileWaveformKind::Fmcw)
+			{
+				key = "fmcw_from_file";
+			}
+			if (const auto& filename = rs.getFilename(); filename.has_value())
+			{
+				j[key] = {{"filename", *filename}};
+			}
+			else
+			{
+				throw std::logic_error("Attempted to serialize a file-based waveform named '" + rs.getName() +
+									   "' without a source filename.");
+			}
+		}
+		else if (dynamic_cast<const CwSignal*>(rs.getSignal()) != nullptr)
 		{
 			j["cw"] = nlohmann::json::object();
 		}
@@ -769,6 +790,26 @@ namespace fers_signal
 				return; // rs remains nullptr
 			}
 			rs = serial::loadWaveformFromFile(name, filename, power, carrier, id);
+		}
+		else if (j.contains("cw_from_file"))
+		{
+			const auto filename = j.at("cw_from_file").value("filename", "");
+			if (filename.empty())
+			{
+				LOG(logging::Level::WARNING, "Skipping load of file-based waveform '{}': filename is empty.", name);
+				return;
+			}
+			rs = serial::loadWaveformFromFile(name, filename, power, carrier, id, FileWaveformKind::Cw);
+		}
+		else if (j.contains("fmcw_from_file"))
+		{
+			const auto filename = j.at("fmcw_from_file").value("filename", "");
+			if (filename.empty())
+			{
+				LOG(logging::Level::WARNING, "Skipping load of file-based waveform '{}': filename is empty.", name);
+				return;
+			}
+			rs = serial::loadWaveformFromFile(name, filename, power, carrier, id, FileWaveformKind::Fmcw);
 		}
 		else
 		{

--- a/packages/libfers/src/serial/waveform_factory.cpp
+++ b/packages/libfers/src/serial/waveform_factory.cpp
@@ -30,14 +30,19 @@
 #include "hdf5_handler.h"
 #include "signal/radar_signal.h"
 
+using fers_signal::FileSignal;
+using fers_signal::FileWaveformKind;
 using fers_signal::RadarSignal;
-using fers_signal::Signal;
 
 namespace
 {
 	/// Converts a sample count to unsigned after validating the supported range.
 	[[nodiscard]] unsigned checked_sample_count(const std::size_t sample_count, const std::string_view source)
 	{
+		if (sample_count == 0)
+		{
+			throw std::runtime_error(std::format("Waveform '{}' contains no samples.", source));
+		}
 		if (sample_count > static_cast<std::size_t>(std::numeric_limits<unsigned>::max()))
 		{
 			throw std::runtime_error(std::format("Waveform '{}' has too many samples to load into Signal.", source));
@@ -74,13 +79,14 @@ namespace
 	 */
 	std::unique_ptr<RadarSignal> loadWaveformFromHdf5File(const std::string& name,
 														  const std::filesystem::path& filepath, const RealType power,
-														  const RealType carrierFreq, const SimId id)
+														  const RealType carrierFreq, const SimId id,
+														  const FileWaveformKind kind)
 	{
 		std::vector<ComplexType> data;
 		serial::readPulseData(filepath.string(), data);
 		const unsigned sample_count = checked_sample_count(data.size(), filepath.string());
 
-		auto signal = std::make_unique<Signal>();
+		auto signal = std::make_unique<FileSignal>(kind);
 		signal->load(data, sample_count, params::rate());
 		return std::make_unique<RadarSignal>(
 			name, power, carrierFreq, static_cast<RealType>(sample_count) / params::rate(), std::move(signal), id);
@@ -98,7 +104,7 @@ namespace
 	 */
 	std::unique_ptr<RadarSignal> loadWaveformFromCsvFile(const std::string& name, const std::filesystem::path& filepath,
 														 const RealType power, const RealType carrierFreq,
-														 const SimId id)
+														 const SimId id, const FileWaveformKind kind)
 	{
 		std::ifstream ifile(filepath);
 		if (!ifile)
@@ -121,6 +127,10 @@ namespace
 		}
 
 		const unsigned length = parse_csv_sample_count(rlength, filepath);
+		if (length == 0)
+		{
+			throw std::runtime_error("Waveform file '" + filepath.string() + "' contains no samples.");
+		}
 		std::vector<ComplexType> data(length);
 
 		// Read the file data
@@ -134,7 +144,7 @@ namespace
 			throw std::runtime_error("Could not read full waveform from file '" + filepath.string() + "'");
 		}
 
-		auto signal = std::make_unique<Signal>();
+		auto signal = std::make_unique<FileSignal>(kind);
 		signal->load(data, length, rate);
 		return std::make_unique<RadarSignal>(name, power, carrierFreq, rlength / rate, std::move(signal), id);
 	}
@@ -155,20 +165,27 @@ namespace
 namespace serial
 {
 	std::unique_ptr<RadarSignal> loadWaveformFromFile(const std::string& name, const std::string& filename,
-													  const RealType power, const RealType carrierFreq, const SimId id)
+													  const RealType power, const RealType carrierFreq, const SimId id,
+													  const FileWaveformKind kind)
 	{
 		const std::filesystem::path filepath = filename;
 		const auto extension = filepath.extension().string();
+		if (kind != FileWaveformKind::Pulsed && !hasExtension(extension, ".h5"))
+		{
+			throw std::runtime_error("File-backed CW and FMCW waveforms require the pulsed-compatible HDF5 (.h5) "
+									 "format: " +
+									 filename);
+		}
 
 		if (hasExtension(extension, ".csv"))
 		{
-			auto wave = loadWaveformFromCsvFile(name, filepath, power, carrierFreq, id);
+			auto wave = loadWaveformFromCsvFile(name, filepath, power, carrierFreq, id, kind);
 			wave->setFilename(filename);
 			return wave;
 		}
 		if (hasExtension(extension, ".h5"))
 		{
-			auto wave = loadWaveformFromHdf5File(name, filepath, power, carrierFreq, id);
+			auto wave = loadWaveformFromHdf5File(name, filepath, power, carrierFreq, id, kind);
 			wave->setFilename(filename);
 			return wave;
 		}

--- a/packages/libfers/src/serial/waveform_factory.h
+++ b/packages/libfers/src/serial/waveform_factory.h
@@ -17,11 +17,7 @@
 
 #include "core/config.h"
 #include "core/sim_id.h"
-
-namespace fers_signal
-{
-	class RadarSignal;
-}
+#include "signal/radar_signal.h"
 
 namespace serial
 {
@@ -32,11 +28,13 @@ namespace serial
 	 * @param filename The path to the file containing the waveform data.
 	 * @param power The power of the radar signal in the waveform.
 	 * @param carrierFreq The carrier frequency of the radar signal.
+	 * @param id Optional explicit waveform identifier.
+	 * @param kind Radar mode assigned to the loaded samples.
 	 * @return A unique pointer to a RadarSignal object loaded with the waveform data.
 	 * @throws std::runtime_error If the file cannot be opened or the file format is unrecognized.
 	 */
-	[[nodiscard]] std::unique_ptr<fers_signal::RadarSignal> loadWaveformFromFile(const std::string& name,
-																				 const std::string& filename,
-																				 RealType power, RealType carrierFreq,
-																				 const SimId id = 0);
+	[[nodiscard]] std::unique_ptr<fers_signal::RadarSignal>
+	loadWaveformFromFile(const std::string& name, const std::string& filename, RealType power, RealType carrierFreq,
+						 const SimId id = 0,
+						 fers_signal::FileWaveformKind kind = fers_signal::FileWaveformKind::Pulsed);
 }

--- a/packages/libfers/src/serial/xml_parser_utils.cpp
+++ b/packages/libfers/src/serial/xml_parser_utils.cpp
@@ -648,19 +648,31 @@ namespace serial::xml_parser_utils
 		const auto power = get_child_real_type(waveform, "power");
 		const auto carrier = get_child_real_type(waveform, "carrier_frequency");
 
-		if (const XmlElement pulsed_file = waveform.childElement("pulsed_from_file", 0); pulsed_file.isValid())
+		auto load_file_waveform = [&](const XmlElement& file_element, const fers_signal::FileWaveformKind kind)
 		{
-			const std::string filename_str = XmlElement::getSafeAttribute(pulsed_file, "filename");
-			fs::path pulse_path(filename_str);
+			const std::string filename_str = XmlElement::getSafeAttribute(file_element, "filename");
+			fs::path waveform_path(filename_str);
 
-			if (!fs::exists(pulse_path))
+			if (!fs::exists(waveform_path))
 			{
-				pulse_path = ctx.base_dir / filename_str;
+				waveform_path = ctx.base_dir / filename_str;
 			}
 
-			// Defer to dependency-injected file loader
-			auto wave = ctx.loaders.loadWaveform(name, pulse_path, power, carrier, id);
+			auto wave = ctx.loaders.loadWaveform(name, waveform_path, power, carrier, id, kind);
 			ctx.world->add(std::move(wave));
+		};
+
+		if (const XmlElement pulsed_file = waveform.childElement("pulsed_from_file", 0); pulsed_file.isValid())
+		{
+			load_file_waveform(pulsed_file, fers_signal::FileWaveformKind::Pulsed);
+		}
+		else if (const XmlElement cw_file = waveform.childElement("cw_from_file", 0); cw_file.isValid())
+		{
+			load_file_waveform(cw_file, fers_signal::FileWaveformKind::Cw);
+		}
+		else if (const XmlElement fmcw_file = waveform.childElement("fmcw_from_file", 0); fmcw_file.isValid())
+		{
+			load_file_waveform(fmcw_file, fers_signal::FileWaveformKind::Fmcw);
 		}
 		else if (waveform.childElement("cw", 0).isValid())
 		{
@@ -1549,9 +1561,9 @@ namespace serial::xml_parser_utils
 
 	AssetLoaders createDefaultAssetLoaders()
 	{
-		return {.loadWaveform = [](const std::string& name, const fs::path& pulse_path, RealType power,
-								   RealType carrierFreq, SimId id)
-				{ return serial::loadWaveformFromFile(name, pulse_path.string(), power, carrierFreq, id); },
+		return {.loadWaveform = [](const std::string& name, const fs::path& waveform_path, RealType power,
+								   RealType carrierFreq, SimId id, const fers_signal::FileWaveformKind kind)
+				{ return serial::loadWaveformFromFile(name, waveform_path.string(), power, carrierFreq, id, kind); },
 				.loadXmlAntenna = [](const std::string& name, const std::string& filename, SimId id)
 				{ return std::make_unique<antenna::XmlAntenna>(name, filename, id); },
 				.loadH5Antenna = [](const std::string& name, const std::string& filename, SimId id)

--- a/packages/libfers/src/serial/xml_parser_utils.h
+++ b/packages/libfers/src/serial/xml_parser_utils.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <memory>
@@ -37,6 +38,7 @@ namespace antenna
 }
 namespace fers_signal
 {
+	enum class FileWaveformKind : std::uint8_t;
 	class RadarSignal;
 }
 namespace timing
@@ -82,10 +84,10 @@ namespace serial::xml_parser_utils
 	 */
 	struct AssetLoaders
 	{
-		/// Hook to load a pulsed waveform from an external file.
-		std::function<std::unique_ptr<fers_signal::RadarSignal>(const std::string& name,
-																const std::filesystem::path& pulse_path, RealType power,
-																RealType carrierFreq, SimId id)>
+		/// Hook to load a mode-tagged waveform from an external file.
+		std::function<std::unique_ptr<fers_signal::RadarSignal>(
+			const std::string& name, const std::filesystem::path& waveform_path, RealType power, RealType carrierFreq,
+			SimId id, fers_signal::FileWaveformKind kind)>
 			loadWaveform;
 
 		/// Hook to load an antenna pattern defined in a legacy XML format.

--- a/packages/libfers/src/serial/xml_serializer_utils.cpp
+++ b/packages/libfers/src/serial/xml_serializer_utils.cpp
@@ -110,7 +110,21 @@ namespace serial::xml_serializer_utils
 		addChildWithNumber(parent, "power", waveform.getPower());
 		addChildWithNumber(parent, "carrier_frequency", waveform.getCarrier());
 
-		if (dynamic_cast<const fers_signal::CwSignal*>(waveform.getSignal()) != nullptr)
+		if (const auto* file = waveform.getFileSignal(); file != nullptr)
+		{
+			std::string_view element_name = "pulsed_from_file";
+			if (file->getKind() == fers_signal::FileWaveformKind::Cw)
+			{
+				element_name = "cw_from_file";
+			}
+			else if (file->getKind() == fers_signal::FileWaveformKind::Fmcw)
+			{
+				element_name = "fmcw_from_file";
+			}
+			const XmlElement file_element = parent.addChild(element_name);
+			file_element.setAttribute("filename", waveform.getFilename().value_or(""));
+		}
+		else if (dynamic_cast<const fers_signal::CwSignal*>(waveform.getSignal()) != nullptr)
 		{
 			(void)parent.addChild("cw"); // Empty element
 		}
@@ -161,8 +175,7 @@ namespace serial::xml_serializer_utils
 		else
 		{
 			const XmlElement pulsed_file = parent.addChild("pulsed_from_file");
-			const auto& filename = waveform.getFilename();
-			pulsed_file.setAttribute("filename", filename.value_or(""));
+			pulsed_file.setAttribute("filename", waveform.getFilename().value_or(""));
 		}
 	}
 

--- a/packages/libfers/src/signal/radar_signal.cpp
+++ b/packages/libfers/src/signal/radar_signal.cpp
@@ -297,7 +297,15 @@ namespace fers_signal
 		return data;
 	}
 
-	bool RadarSignal::isCw() const noexcept { return dynamic_cast<const CwSignal*>(_signal.get()) != nullptr; }
+	bool RadarSignal::isCw() const noexcept
+	{
+		if (dynamic_cast<const CwSignal*>(_signal.get()) != nullptr)
+		{
+			return true;
+		}
+		const auto* file = getFileSignal();
+		return file != nullptr && file->getKind() == FileWaveformKind::Cw;
+	}
 
 	bool RadarSignal::isFmcwChirp() const noexcept
 	{
@@ -331,6 +339,11 @@ namespace fers_signal
 		return dynamic_cast<const SteppedFrequencySignal*>(_signal.get());
 	}
 
+	const FileSignal* RadarSignal::getFileSignal() const noexcept
+	{
+		return dynamic_cast<const FileSignal*>(_signal.get());
+	}
+
 	void Signal::clear() noexcept
 	{
 		_size = 0;
@@ -358,6 +371,32 @@ namespace fers_signal
 		{
 			upsample(inData, samples, _data);
 		}
+	}
+
+	ComplexType Signal::sampleAt(const RealType time_since_start) const noexcept
+	{
+		if (_data.empty() || _rate <= 0.0 || !std::isfinite(time_since_start) || time_since_start < 0.0 ||
+			time_since_start >= static_cast<RealType>(_size) / _rate)
+		{
+			return {0.0, 0.0};
+		}
+
+		const RealType position = time_since_start * _rate;
+		const auto center = static_cast<long long>(std::floor(position));
+		const RealType fraction = position - std::floor(position);
+		const auto& filter = interp::InterpFilter::getInstance().getFilter(fraction);
+		const auto filter_length = static_cast<long long>(filter.size());
+		const auto sample_count = static_cast<long long>(_data.size());
+		ComplexType value{0.0, 0.0};
+		for (long long tap = 0; tap < filter_length; ++tap)
+		{
+			const long long sample_index = center + tap - filter_length / 2;
+			if (sample_index >= 0 && sample_index < sample_count)
+			{
+				value += _data[static_cast<std::size_t>(sample_index)] * filter[static_cast<std::size_t>(tap)];
+			}
+		}
+		return value;
 	}
 
 	std::vector<ComplexType> Signal::render(const std::vector<interp::InterpPoint>& points, unsigned& size,

--- a/packages/libfers/src/signal/radar_signal.h
+++ b/packages/libfers/src/signal/radar_signal.h
@@ -39,6 +39,14 @@ namespace fers_signal
 		Down ///< Instantaneous baseband frequency decreases over the chirp.
 	};
 
+	/// Simulation mode assigned to samples loaded from a waveform file.
+	enum class FileWaveformKind : std::uint8_t
+	{
+		Pulsed,
+		Cw,
+		Fmcw
+	};
+
 	/// Converts a chirp direction to the schema token.
 	[[nodiscard]] std::string_view fmcwChirpDirectionToken(FmcwChirpDirection direction) noexcept;
 
@@ -107,6 +115,10 @@ namespace fers_signal
 
 		/// Returns true when this signal belongs to the FMCW waveform family.
 		[[nodiscard]] virtual bool isFmcwFamily() const noexcept { return false; }
+
+		/// Samples the finite stored complex envelope using the render interpolation filter.
+		/// Times outside [0, duration) return zero; file-backed signals never wrap implicitly.
+		[[nodiscard]] ComplexType sampleAt(RealType time_since_start) const noexcept;
 
 	private:
 		std::vector<ComplexType> _data; ///< The complex signal data.
@@ -259,6 +271,9 @@ namespace fers_signal
 		/// Gets the stepped-frequency implementation, if this signal owns one.
 		[[nodiscard]] const class SteppedFrequencySignal* getSteppedFrequencySignal() const noexcept;
 
+		/// Gets the file-backed signal implementation, if this signal owns one.
+		[[nodiscard]] const class FileSignal* getFileSignal() const noexcept;
+
 		/**
 		 * @brief Renders the radar signal.
 		 *
@@ -283,6 +298,26 @@ namespace fers_signal
 		RealType _length; ///< The length of the radar signal.
 		std::unique_ptr<Signal> _signal; ///< The `Signal` object containing the radar signal data.
 		std::optional<std::string> _filename; ///< The original filename for file-based signals.
+	};
+
+	/// File-backed sampled waveform with explicit radar-mode identity.
+	class FileSignal final : public Signal
+	{
+	public:
+		explicit FileSignal(FileWaveformKind kind) : _kind(kind) {}
+
+		~FileSignal() override = default;
+
+		FileSignal(const FileSignal&) = delete;
+		FileSignal& operator=(const FileSignal&) = delete;
+		FileSignal(FileSignal&&) = delete;
+		FileSignal& operator=(FileSignal&&) = delete;
+
+		[[nodiscard]] FileWaveformKind getKind() const noexcept { return _kind; }
+		[[nodiscard]] bool isFmcwFamily() const noexcept override { return _kind == FileWaveformKind::Fmcw; }
+
+	private:
+		FileWaveformKind _kind;
 	};
 
 	/// Continuous-wave signal implementation.

--- a/packages/libfers/src/simulation/channel_model.cpp
+++ b/packages/libfers/src/simulation/channel_model.cpp
@@ -112,6 +112,7 @@ namespace
 	{
 		RealType phase = 0.0;
 		RealType rf_frequency = 0.0;
+		ComplexType envelope{1.0, 0.0};
 	};
 
 	/**
@@ -502,6 +503,18 @@ namespace
 			return true;
 		}
 
+		if (source.kind == core::StreamingWaveformKind::FileCw || source.kind == core::StreamingWaveformKind::FileFmcw)
+		{
+			if (source.file == nullptr || source.file_duration <= 0.0)
+			{
+				return false;
+			}
+			eval.rf_frequency = source.carrier_freq;
+			eval.phase = -2.0 * PI * source.carrier_freq * tau;
+			eval.envelope = source.file->sampleAt(t_ret - source.segment_start);
+			return true;
+		}
+
 		eval.rf_frequency = source.carrier_freq;
 		eval.phase = -2.0 * PI * source.carrier_freq * tau;
 		return true;
@@ -784,7 +797,7 @@ namespace simulation
 		const RealType amplitude = source.amplitude * std::sqrt(scaling_factor);
 
 		// Carrier Phase
-		ComplexType contribution = std::polar(amplitude, eval.phase);
+		ComplexType contribution = amplitude * eval.envelope * std::polar(1.0, eval.phase);
 
 		// Non-coherent Local Oscillator Effects
 		const RealType non_coherent_phase =
@@ -803,6 +816,22 @@ namespace simulation
 			return false;
 		}
 		phase_out = eval.phase;
+		if (std::abs(eval.envelope) > 0.0)
+		{
+			phase_out += std::arg(eval.envelope);
+		}
+		return true;
+	}
+
+	bool calculateStreamingReferenceSample(const core::ActiveStreamingSource& source, const RealType timeK,
+										   core::FmcwChirpBoundaryTracker* const chirp_tracker, ComplexType& sample_out)
+	{
+		StreamingWaveformEvaluation eval;
+		if (!computeStreamingEvaluation(source, timeK, 0.0, chirp_tracker, eval))
+		{
+			return false;
+		}
+		sample_out = eval.envelope * std::polar(1.0, eval.phase);
 		return true;
 	}
 
@@ -875,7 +904,7 @@ namespace simulation
 		// Include Signal Power
 		const RealType amplitude = source.amplitude * std::sqrt(scaling_factor);
 
-		ComplexType contribution = std::polar(amplitude, eval.phase);
+		ComplexType contribution = amplitude * eval.envelope * std::polar(1.0, eval.phase);
 
 		// Non-coherent Local Oscillator Effects
 		const RealType non_coherent_phase =

--- a/packages/libfers/src/simulation/channel_model.h
+++ b/packages/libfers/src/simulation/channel_model.h
@@ -203,6 +203,11 @@ namespace simulation
 														core::FmcwChirpBoundaryTracker* chirp_tracker,
 														RealType& phase_out);
 
+	/// Evaluates the complete complex reference envelope, including file-backed amplitude modulation.
+	[[nodiscard]] bool calculateStreamingReferenceSample(const core::ActiveStreamingSource& source, RealType timeK,
+														 core::FmcwChirpBoundaryTracker* chirp_tracker,
+														 ComplexType& sample_out);
+
 	/**
 	 * @brief Calculates the complex envelope contribution for a reflected path (Tx -> Tgt -> Rx) at a specific time.
 	 * This function is used for Continuous Wave (CW) simulations.

--- a/packages/libfers/tests/api/test_api_runtime.cpp
+++ b/packages/libfers/tests/api/test_api_runtime.cpp
@@ -1,12 +1,17 @@
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <chrono>
+#include <complex>
 #include <filesystem>
+#include <highfive/highfive.hpp>
 #include <libfers/api.h>
 #include <limits>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <vector>
 
 #include "api_test_helpers.h"
@@ -19,6 +24,32 @@ namespace
 	std::string uniqueLogMessage(const std::string& prefix)
 	{
 		return prefix + "_" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+	}
+
+	void replaceAll(std::string& value, const std::string_view needle, const std::string_view replacement)
+	{
+		std::size_t position = 0;
+		while ((position = value.find(needle, position)) != std::string::npos)
+		{
+			value.replace(position, needle.size(), replacement);
+			position += replacement.size();
+		}
+	}
+
+	void writeHdf5IqWaveform(const std::filesystem::path& path, const std::vector<ComplexType>& samples)
+	{
+		std::vector<RealType> i_values;
+		std::vector<RealType> q_values;
+		i_values.reserve(samples.size());
+		q_values.reserve(samples.size());
+		for (const auto& sample : samples)
+		{
+			i_values.push_back(sample.real());
+			q_values.push_back(sample.imag());
+		}
+		HighFive::File file(path.string(), HighFive::File::Overwrite);
+		file.createGroup("/I").createDataSet<RealType>("value", HighFive::DataSpace::From(i_values)).write(i_values);
+		file.createGroup("/Q").createDataSet<RealType>("value", HighFive::DataSpace::From(q_values)).write(q_values);
 	}
 
 	struct CallbackState
@@ -470,6 +501,93 @@ TEST_CASE("API run simulation accepts a minimal valid scenario", "[api][runtime]
 	REQUIRE(metadata_json.get() != nullptr);
 	const auto metadata = api_test::json::parse(metadata_json.str());
 	CHECK_FALSE(metadata.contains("vita49"));
+}
+
+TEST_CASE("API runs pulsed-compatible HDF5 CW and FMCW scenarios end to end", "[api][runtime][file-waveform][hdf5]")
+{
+	api_test::ParamGuard const guard;
+	const auto temp_dir = api_test::uniqueTempPath("api_file_waveform_e2e");
+	std::filesystem::create_directories(temp_dir);
+	api_test::ScopedPath const temp_guard(temp_dir);
+	const auto waveform_path = temp_dir / "sampled_iq.h5";
+	std::vector<ComplexType> input_samples;
+	input_samples.reserve(64);
+	for (std::size_t index = 0; index < 64; ++index)
+	{
+		const RealType magnitude = 0.25 + 0.75 * static_cast<RealType>(index) / 63.0;
+		const RealType phase = 0.007 * static_cast<RealType>(index * index);
+		input_samples.push_back(std::polar(magnitude, phase));
+	}
+	writeHdf5IqWaveform(waveform_path, input_samples);
+
+	for (const auto& [element, mode, receiver_name] :
+		 std::array<std::tuple<std::string_view, std::string_view, std::string_view>, 2>{
+			 std::tuple{"cw_from_file", "cw_mode", "file_cw_rx"},
+			 std::tuple{"fmcw_from_file", "fmcw_mode", "file_fmcw_rx"}})
+	{
+		api_test::clearLastError();
+		api_test::Context const context;
+		REQUIRE(fers_set_output_directory(context.get(), temp_dir.string().c_str()) == 0);
+		std::string xml = api_test::previewScenarioXml(std::string(receiver_name));
+		replaceAll(xml, "<endtime>0.1</endtime>", "<endtime>0.002</endtime>");
+		replaceAll(xml, "<rate>1000000</rate>", "<rate>32000</rate>");
+		replaceAll(xml, "<cw/>", "<" + std::string(element) + " filename=\"" + waveform_path.string() + "\"/>");
+		if (mode == "cw_mode")
+		{
+			replaceAll(xml, "<cw_mode/>", "<cw_mode/>");
+		}
+		else
+		{
+			const auto transmitter_mode = xml.find("<cw_mode/>");
+			REQUIRE(transmitter_mode != std::string::npos);
+			xml.replace(transmitter_mode, std::string_view("<cw_mode/>").size(), "<fmcw_mode/>");
+			const auto receiver_mode = xml.find("<cw_mode/>");
+			REQUIRE(receiver_mode != std::string::npos);
+			xml.replace(receiver_mode, std::string_view("<cw_mode/>").size(),
+						"<fmcw_mode dechirp_mode=\"physical\"><dechirp_reference source=\"custom\" "
+						"waveform_name=\"api_preview_wave\"/></fmcw_mode>");
+		}
+		replaceAll(xml, "api_preview_rx", receiver_name);
+		replaceAll(xml, "<noise_temp>290</noise_temp>", "<noise_temp>0</noise_temp>");
+
+		REQUIRE(fers_load_scenario_from_xml_string(context.get(), xml.c_str(), 0) == 0);
+		REQUIRE(fers_run_simulation(context.get(), nullptr, nullptr) == 0);
+		const auto output_path = temp_dir / (std::string(receiver_name) + "_results.h5");
+		REQUIRE(std::filesystem::exists(output_path));
+		HighFive::File const output(output_path.string(), HighFive::File::ReadOnly);
+		std::vector<RealType> i_samples;
+		std::vector<RealType> q_samples;
+		output.getDataSet("I_data").read(i_samples);
+		output.getDataSet("Q_data").read(q_samples);
+		REQUIRE(i_samples.size() == 64u);
+		REQUIRE(q_samples.size() == i_samples.size());
+		RealType minimum_power = std::numeric_limits<RealType>::max();
+		RealType maximum_power = 0.0;
+		for (std::size_t index = 0; index < i_samples.size(); ++index)
+		{
+			const RealType power = i_samples[index] * i_samples[index] + q_samples[index] * q_samples[index];
+			minimum_power = std::min(minimum_power, power);
+			maximum_power = std::max(maximum_power, power);
+		}
+		REQUIRE(maximum_power > 0.0);
+		REQUIRE(maximum_power > minimum_power * 2.0);
+		api_test::ApiString const metadata_json(fers_get_last_output_metadata_json(context.get()));
+		const auto metadata = api_test::json::parse(metadata_json.str());
+		REQUIRE(metadata.at("files").size() == 1u);
+		REQUIRE(metadata.at("files").front().at("total_samples").get<std::uint64_t>() > 0u);
+		if (element == "fmcw_from_file")
+		{
+			REQUIRE(metadata.at("files").front().at("fmcw_sources").size() == 1u);
+			const auto& source = metadata.at("files").front().at("fmcw_sources").front();
+			REQUIRE(source.at("waveform_shape") == "file");
+			REQUIRE(source.at("sampled_duration") == 64.0 / 32000.0);
+			REQUIRE(source.at("sampled_count") == 64u);
+			REQUIRE_FALSE(source.contains("chirp_period"));
+			REQUIRE_FALSE(source.at("segments").front().contains("emitted_chirp_count"));
+			REQUIRE(metadata.at("files").front().at("fmcw_dechirp_mode") == "physical");
+			REQUIRE(metadata.at("files").front().at("fmcw_dechirp_reference_source") == "custom");
+		}
+	}
 }
 
 TEST_CASE("VITA49 metadata section records runtime output config", "[api][runtime][vita49]")

--- a/packages/libfers/tests/core/test_logging.cpp
+++ b/packages/libfers/tests/core/test_logging.cpp
@@ -68,7 +68,7 @@ TEST_CASE("getLevelString maps levels", "[core][logging]")
 	REQUIRE(logging::getLevelString(logging::Level::FATAL) == "FATAL");
 	REQUIRE(logging::getLevelString(logging::Level::OFF) == "OFF");
 
-	const auto unknown = static_cast<logging::Level>(-1);
+	const auto unknown = static_cast<logging::Level>(255);
 	REQUIRE(logging::getLevelString(unknown) == "UNKNOWN");
 }
 

--- a/packages/libfers/tests/core/test_sim_events.cpp
+++ b/packages/libfers/tests/core/test_sim_events.cpp
@@ -30,6 +30,6 @@ TEST_CASE("EventType toString covers all values", "[core][events]")
 	REQUIRE(core::toString(core::EventType::RX_STREAMING_START) == "RxStreamingStart");
 	REQUIRE(core::toString(core::EventType::RX_STREAMING_END) == "RxStreamingEnd");
 
-	const auto unknown = static_cast<core::EventType>(-1);
+	const auto unknown = static_cast<core::EventType>(255);
 	REQUIRE(core::toString(unknown) == "UnknownEvent");
 }

--- a/packages/libfers/tests/math/test_path.cpp
+++ b/packages/libfers/tests/math/test_path.cpp
@@ -43,7 +43,7 @@ TEST_CASE("Path: Error Handling and Edge Cases", "[math][path]")
 
 	SECTION("Invalid Interpolation Type Fallback")
 	{
-		Path p_invalid(static_cast<Path::InterpType>(999));
+		Path p_invalid(static_cast<Path::InterpType>(255));
 		p_invalid.addCoord({Vec3(0, 0, 0), 0.0});
 		p_invalid.finalize();
 		Vec3 const v = p_invalid.getVelocity(0.0);

--- a/packages/libfers/tests/math/test_rotation_path.cpp
+++ b/packages/libfers/tests/math/test_rotation_path.cpp
@@ -18,7 +18,7 @@ TEST_CASE("RotationPath: State Management and Errors", "[math][rotation_path]")
 	rp.addCoord(RotationCoord(0.0, 0.0, 0.0));
 	REQUIRE_THROWS_AS(rp.getPosition(0.0), PathException);
 
-	RotationPath rp_invalid(static_cast<RotationPath::InterpType>(999));
+	RotationPath rp_invalid(static_cast<RotationPath::InterpType>(255));
 	rp_invalid.addCoord(RotationCoord(0.0, 0.0, 0.0));
 	rp_invalid.finalize();
 	REQUIRE_THROWS_AS(rp_invalid.getPosition(0.0), PathException);

--- a/packages/libfers/tests/processing/test_finalizer.cpp
+++ b/packages/libfers/tests/processing/test_finalizer.cpp
@@ -418,6 +418,108 @@ TEST_CASE("buildReceiverStreamDescriptor keeps CW metadata isolated from active 
 	REQUIRE_THAT(descriptor.cw.carrier_frequency, WithinAbs(5.0e9, 1e-6));
 }
 
+TEST_CASE("buildReceiverStreamDescriptor binds a sole detached file-CW source",
+		  "[processing][finalizer][cw][file][vita49]")
+{
+	ParamGuard const guard;
+	params::setTime(0.0, 180.0);
+	params::setRate(204'800.0);
+	params::setOversampleRatio(1);
+
+	radar::Platform rx_platform("DetachedFileCwRxPlatform");
+	radar::Receiver receiver(&rx_platform, "DetachedFileCwRx", 63, radar::OperationMode::CW_MODE);
+	auto timing_owner = makeQuietTiming("detached_file_cw_clk", 29, 204'800.0);
+	receiver.setTiming(timing_owner.timing);
+
+	radar::Platform tx_platform("DetachedFileCwTxPlatform");
+	auto waveform = std::make_unique<fers_signal::RadarSignal>(
+		"TxWaveform", 16'400.0, 89.0e6, 180.0,
+		std::make_unique<fers_signal::FileSignal>(fers_signal::FileWaveformKind::Cw), 1302);
+	radar::Transmitter transmitter(&tx_platform, "DetachedFileCwTx", radar::OperationMode::CW_MODE, 1301);
+	transmitter.setSignal(waveform.get());
+	const std::vector sources = {core::makeActiveSource(&transmitter, 0.0, 90.0),
+								 core::makeActiveSource(&transmitter, 90.0, params::endTime())};
+
+	const auto descriptor = processing::buildReceiverStreamDescriptor(&receiver, params::rate(), sources);
+
+	REQUIRE(descriptor.mode == "cw");
+	REQUIRE(descriptor.cw.present);
+	REQUIRE(descriptor.cw.waveform_id == 1302);
+	REQUIRE(descriptor.cw.waveform_name == "TxWaveform");
+	REQUIRE_THAT(descriptor.cw.carrier_frequency, WithinAbs(89.0e6, 1e-6));
+	REQUIRE_THAT(descriptor.cw.power, WithinAbs(16'400.0, 1e-12));
+}
+
+TEST_CASE("buildReceiverStreamDescriptor preserves attached CW source precedence",
+		  "[processing][finalizer][cw][vita49]")
+{
+	ParamGuard const guard;
+	params::setTime(0.0, 1.0);
+	params::setRate(1'000.0);
+	params::setOversampleRatio(1);
+
+	radar::Platform rx_platform("AttachedCwRxPlatform");
+	radar::Receiver receiver(&rx_platform, "AttachedCwRx", 64, radar::OperationMode::CW_MODE);
+	auto timing_owner = makeQuietTiming("attached_cw_clk", 30, 1'000.0);
+	receiver.setTiming(timing_owner.timing);
+
+	radar::Platform attached_platform("AttachedCwTxPlatform");
+	auto attached_waveform = std::make_unique<fers_signal::RadarSignal>(
+		"AttachedCwWave", 25.0, 5.0e9, 1.0, std::make_unique<fers_signal::CwSignal>(), 1402);
+	radar::Transmitter attached(&attached_platform, "AttachedCwTx", radar::OperationMode::CW_MODE, 1401);
+	attached.setSignal(attached_waveform.get());
+	receiver.setAttached(&attached);
+
+	radar::Platform detached_platform("OtherCwTxPlatform");
+	auto detached_waveform = std::make_unique<fers_signal::RadarSignal>(
+		"OtherCwWave", 100.0, 9.0e9, 1.0, std::make_unique<fers_signal::CwSignal>(), 1502);
+	radar::Transmitter detached(&detached_platform, "OtherCwTx", radar::OperationMode::CW_MODE, 1501);
+	detached.setSignal(detached_waveform.get());
+	const std::vector sources = {core::makeActiveSource(&detached, 0.0, params::endTime())};
+
+	const auto descriptor = processing::buildReceiverStreamDescriptor(&receiver, params::rate(), sources);
+
+	REQUIRE(descriptor.cw.waveform_id == 1402);
+	REQUIRE(descriptor.cw.waveform_name == "AttachedCwWave");
+	REQUIRE_THAT(descriptor.cw.carrier_frequency, WithinAbs(5.0e9, 1e-6));
+	REQUIRE_THAT(descriptor.cw.power, WithinAbs(25.0, 1e-12));
+}
+
+TEST_CASE("buildReceiverStreamDescriptor leaves ambiguous detached CW sources unbound",
+		  "[processing][finalizer][cw][vita49]")
+{
+	ParamGuard const guard;
+	params::setTime(0.0, 1.0);
+	params::setRate(2'000.0);
+	params::setOversampleRatio(1);
+
+	radar::Platform rx_platform("AmbiguousCwRxPlatform");
+	radar::Receiver receiver(&rx_platform, "AmbiguousCwRx", 65, radar::OperationMode::CW_MODE);
+	auto timing_owner = makeQuietTiming("ambiguous_cw_clk", 31, 2'000.0);
+	receiver.setTiming(timing_owner.timing);
+
+	radar::Platform first_platform("FirstCwTxPlatform");
+	auto first_waveform = std::make_unique<fers_signal::RadarSignal>("FirstCwWave", 1.0, 1.0e9, 1.0,
+																	 std::make_unique<fers_signal::CwSignal>(), 1602);
+	radar::Transmitter first(&first_platform, "FirstCwTx", radar::OperationMode::CW_MODE, 1601);
+	first.setSignal(first_waveform.get());
+	radar::Platform second_platform("SecondCwTxPlatform");
+	auto second_waveform = std::make_unique<fers_signal::RadarSignal>("SecondCwWave", 2.0, 2.0e9, 1.0,
+																	  std::make_unique<fers_signal::CwSignal>(), 1702);
+	radar::Transmitter second(&second_platform, "SecondCwTx", radar::OperationMode::CW_MODE, 1701);
+	second.setSignal(second_waveform.get());
+	const std::vector sources = {core::makeActiveSource(&first, 0.0, params::endTime()),
+								 core::makeActiveSource(&second, 0.0, params::endTime())};
+
+	const auto descriptor = processing::buildReceiverStreamDescriptor(&receiver, params::rate(), sources);
+
+	REQUIRE(descriptor.cw.present);
+	REQUIRE(descriptor.cw.waveform_id == 0);
+	REQUIRE(descriptor.cw.waveform_name.empty());
+	REQUIRE_THAT(descriptor.cw.carrier_frequency, WithinAbs(2'000.0, 1e-12));
+	REQUIRE_THAT(descriptor.cw.power, WithinAbs(0.0, 1e-12));
+}
+
 TEST_CASE("buildReceiverStreamDescriptor records SFCW waveform metadata", "[processing][finalizer][sfcw][vita49]")
 {
 	ParamGuard const guard;

--- a/packages/libfers/tests/serial/test_hdf5_handler.cpp
+++ b/packages/libfers/tests/serial/test_hdf5_handler.cpp
@@ -252,6 +252,37 @@ TEST_CASE("Output metadata uses per-file sampling rates when outputs differ", "[
 	REQUIRE(json.at("files").at(1).at("sampling_rate") == 4'000.0);
 }
 
+TEST_CASE("HDF5 writer preserves finite file FMCW sample metadata", "[serial][hdf5][file-waveform]")
+{
+	const std::string path = tempFilePath(uniqueFileName("file_fmcw_metadata"));
+	removeIfExists(path);
+	core::OutputFileMetadata metadata{
+		.receiver_id = 9,
+		.receiver_name = "FileFmcwRx",
+		.mode = "fmcw",
+		.path = path,
+		.fmcw = core::FmcwMetadata{.waveform_shape = "file", .sampled_duration = 0.00025, .sampled_count = 8}};
+	{
+		HighFive::File file(path, HighFive::File::Overwrite);
+		std::scoped_lock const lock(serial::hdf5_global_mutex);
+		serial::writeOutputFileMetadataAttributes(file, metadata);
+	}
+	{
+		HighFive::File const file(path, HighFive::File::ReadOnly);
+		std::string shape;
+		RealType duration = 0.0;
+		std::uint64_t sample_count = 0;
+		file.getAttribute("fmcw_waveform_shape").read(shape);
+		file.getAttribute("fmcw_sampled_duration").read(duration);
+		file.getAttribute("fmcw_sampled_count").read(sample_count);
+		REQUIRE(shape == "file");
+		REQUIRE_THAT(duration, WithinAbs(0.00025, 1e-15));
+		REQUIRE(sample_count == 8u);
+		REQUIRE_FALSE(file.hasAttribute("fmcw_chirp_period"));
+	}
+	removeIfExists(path);
+}
+
 TEST_CASE("HDF5 writer exposes FMCW segment metadata without cw_segments JSON alias", "[serial][hdf5]")
 {
 	const std::string path = tempFilePath(uniqueFileName("fmcw_metadata"));

--- a/packages/libfers/tests/serial/test_json_serializer.cpp
+++ b/packages/libfers/tests/serial/test_json_serializer.cpp
@@ -1,15 +1,21 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // Copyright (c) 2025-present FERS Contributors (see AUTHORS.md).
 
+#include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <highfive/highfive.hpp>
 #include <iostream>
 #include <nlohmann/json.hpp>
 #include <random>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "antenna/antenna_factory.h"
 #include "core/logging.h"
@@ -87,6 +93,34 @@ namespace
 		params::setOversampleRatio(1);
 		params::setTime(0.0, 1.0);
 	}
+
+	class TemporaryWaveformHdf5
+	{
+	public:
+		TemporaryWaveformHdf5()
+		{
+			path = std::filesystem::temp_directory_path() /
+				("fers_json_file_waveform_" +
+				 std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) + ".h5");
+			HighFive::File file(path.string(), HighFive::File::Overwrite);
+			const std::vector<RealType> i_values{1.0, 0.0, -1.0, 0.0};
+			const std::vector<RealType> q_values{0.0, 1.0, 0.0, -1.0};
+			file.createGroup("/I")
+				.createDataSet<RealType>("value", HighFive::DataSpace::From(i_values))
+				.write(i_values);
+			file.createGroup("/Q")
+				.createDataSet<RealType>("value", HighFive::DataSpace::From(q_values))
+				.write(q_values);
+		}
+		~TemporaryWaveformHdf5()
+		{
+			std::error_code ec;
+			std::filesystem::remove(path, ec);
+		}
+		TemporaryWaveformHdf5(const TemporaryWaveformHdf5&) = delete;
+		TemporaryWaveformHdf5& operator=(const TemporaryWaveformHdf5&) = delete;
+		std::filesystem::path path;
+	};
 
 	[[nodiscard]] json linearChirpJson(const std::string_view direction)
 	{
@@ -373,6 +407,33 @@ TEST_CASE("JSON: FMCW linear chirp direction round trips", "[serial][json][fmcw]
 	for (const auto* const direction : {"up", "down"})
 	{
 		requireLinearChirpDirectionRoundTrip(direction);
+	}
+}
+
+TEST_CASE("JSON: CW and FMCW file waveforms round trip", "[serial][json][file]")
+{
+	ParamGuard const guard;
+	params::setOversampleRatio(1);
+	params::setRate(8.0);
+	TemporaryWaveformHdf5 const file;
+
+	for (const auto& [key, kind] : std::array<std::pair<std::string, fers_signal::FileWaveformKind>, 2>{
+			 std::pair{"cw_from_file", fers_signal::FileWaveformKind::Cw},
+			 std::pair{"fmcw_from_file", fers_signal::FileWaveformKind::Fmcw}})
+	{
+		const json input = {{"id", 459},
+							{"name", key},
+							{"power", 2.0},
+							{"carrier_frequency", 10.0},
+							{key, {{"filename", file.path.string()}}}};
+		auto waveform = serial::parse_waveform_from_json(input);
+		REQUIRE(waveform->getFileSignal() != nullptr);
+		REQUIRE(waveform->getFileSignal()->getKind() == kind);
+
+		json output;
+		fers_signal::to_json(output, *waveform);
+		REQUIRE(output.at(key).at("filename") == file.path.string());
+		REQUIRE_FALSE(output.contains(kind == fers_signal::FileWaveformKind::Cw ? "fmcw_from_file" : "cw_from_file"));
 	}
 }
 

--- a/packages/libfers/tests/serial/test_waveform_factory.cpp
+++ b/packages/libfers/tests/serial/test_waveform_factory.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <chrono>
 #include <complex>
 #include <filesystem>
@@ -15,6 +16,7 @@
 #include "serial/waveform_factory.h"
 #include "signal/radar_signal.h"
 
+using Catch::Matchers::ContainsSubstring;
 using Catch::Matchers::WithinAbs;
 
 namespace
@@ -118,6 +120,54 @@ TEST_CASE("Waveform factory loads CSV waveform metadata", "[serial][waveform_fac
 	REQUIRE_THAT(waveform->getRate(), WithinAbs(csvRate * params::oversampleRatio(), 1e-12));
 	REQUIRE_THAT(waveform->getLength(), WithinAbs(static_cast<RealType>(samples.size()) / csvRate, 1e-12));
 
+	removeIfExists(path);
+}
+
+TEST_CASE("Waveform factory assigns CW and FMCW identity to pulsed-compatible HDF5 samples",
+		  "[serial][waveform_factory][hdf5]")
+{
+	ParamGuard const guard;
+	params::params.reset();
+	params::setOversampleRatio(1);
+	params::setRate(8.0);
+	const std::filesystem::path path = tempFilePath(uniqueFileName("waveform_factory_kind", ".h5"));
+	removeIfExists(path);
+	writeHdf5Waveform(path, {ComplexType(1.0, 0.0), ComplexType(0.0, 1.0)});
+
+	const auto cw = serial::loadWaveformFromFile("cw", path.string(), 1.0, 10.0, 1, fers_signal::FileWaveformKind::Cw);
+	const auto fmcw =
+		serial::loadWaveformFromFile("fmcw", path.string(), 1.0, 10.0, 2, fers_signal::FileWaveformKind::Fmcw);
+
+	REQUIRE(cw->isCw());
+	REQUIRE(cw->getFileSignal()->getKind() == fers_signal::FileWaveformKind::Cw);
+	REQUIRE(fmcw->isFmcwFamily());
+	REQUIRE(fmcw->getFileSignal()->getKind() == fers_signal::FileWaveformKind::Fmcw);
+	removeIfExists(path);
+}
+
+TEST_CASE("CW and FMCW file loading rejects legacy CSV input", "[serial][waveform_factory][hdf5]")
+{
+	const std::filesystem::path path = tempFilePath(uniqueFileName("waveform_factory_mode_csv", ".csv"));
+	removeIfExists(path);
+	writeCsvWaveform(path, 8.0, {ComplexType(1.0, 0.0)});
+
+	REQUIRE_THROWS_WITH(
+		serial::loadWaveformFromFile("cw", path.string(), 1.0, 10.0, 1, fers_signal::FileWaveformKind::Cw),
+		ContainsSubstring("require the pulsed-compatible HDF5"));
+	REQUIRE_THROWS_WITH(
+		serial::loadWaveformFromFile("fmcw", path.string(), 1.0, 10.0, 2, fers_signal::FileWaveformKind::Fmcw),
+		ContainsSubstring("require the pulsed-compatible HDF5"));
+
+	removeIfExists(path);
+}
+
+TEST_CASE("Waveform factory rejects empty file waveforms", "[serial][waveform_factory]")
+{
+	const std::filesystem::path path = tempFilePath(uniqueFileName("waveform_factory_empty", ".csv"));
+	removeIfExists(path);
+	writeCsvWaveform(path, 8.0, {});
+
+	REQUIRE_THROWS_AS(serial::loadWaveformFromFile("empty", path.string(), 1.0, 10.0), std::runtime_error);
 	removeIfExists(path);
 }
 

--- a/packages/libfers/tests/serial/test_xml_parser.cpp
+++ b/packages/libfers/tests/serial/test_xml_parser.cpp
@@ -1,8 +1,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <highfive/highfive.hpp>
 #include <string>
+#include <vector>
 
 #include "core/parameters.h"
 #include "core/world.h"
@@ -61,6 +64,15 @@ namespace
 		std::ofstream out(path);
 		out << content;
 		return path;
+	}
+
+	void writeHdf5Waveform(const std::filesystem::path& path)
+	{
+		HighFive::File file(path.string(), HighFive::File::Overwrite);
+		const std::vector<RealType> i_values{1.0, 0.0, -1.0, 0.0};
+		const std::vector<RealType> q_values{0.0, 1.0, 0.0, -1.0};
+		file.createGroup("/I").createDataSet<RealType>("value", HighFive::DataSpace::From(i_values)).write(i_values);
+		file.createGroup("/Q").createDataSet<RealType>("value", HighFive::DataSpace::From(q_values)).write(q_values);
 	}
 }
 
@@ -140,6 +152,38 @@ TEST_CASE("parseSimulation handles file loading and includes", "[serial][xml_par
 
 	std::filesystem::remove(include_path);
 	std::filesystem::remove(main_path);
+}
+
+TEST_CASE("parseSimulation resolves relative CW and FMCW HDF5 waveform files",
+		  "[serial][xml_parser][file-waveform][hdf5]")
+{
+	ParamGuard const guard;
+	const auto directory = std::filesystem::temp_directory_path() /
+		("fers_relative_file_waveforms_" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+	std::filesystem::create_directories(directory);
+	const auto hdf5_path = directory / "sampled_iq.h5";
+	const auto scenario_path = directory / "scenario.fersxml";
+	writeHdf5Waveform(hdf5_path);
+	{
+		std::ofstream scenario(scenario_path);
+		scenario << R"(<?xml version="1.0" encoding="UTF-8"?>
+<simulation name="RelativeFileWaveforms">
+  <parameters><starttime>0</starttime><endtime>1</endtime><rate>8</rate></parameters>
+  <waveform name="FileCw"><power>1</power><carrier_frequency>100</carrier_frequency><cw_from_file filename="sampled_iq.h5"/></waveform>
+  <waveform name="FileFmcw"><power>1</power><carrier_frequency>100</carrier_frequency><fmcw_from_file filename="sampled_iq.h5"/></waveform>
+</simulation>)";
+	}
+
+	core::World world;
+	std::mt19937 seeder(42);
+	REQUIRE_NOTHROW(serial::parseSimulation(scenario_path.string(), &world, true, seeder));
+	REQUIRE(world.getWaveforms().size() == 2u);
+	REQUIRE(world.findWaveformByName("FileCw")->isCw());
+	REQUIRE(world.findWaveformByName("FileFmcw")->isFmcwFamily());
+	REQUIRE(world.findWaveformByName("FileCw")->getFilename() == hdf5_path.string());
+	REQUIRE(world.findWaveformByName("FileFmcw")->getFilename() == hdf5_path.string());
+	std::error_code ec;
+	std::filesystem::remove_all(directory, ec);
 }
 
 TEST_CASE("parseSimulation throws on missing file", "[serial][xml_parser]")

--- a/packages/libfers/tests/serial/test_xml_parser_utils.cpp
+++ b/packages/libfers/tests/serial/test_xml_parser_utils.cpp
@@ -70,10 +70,10 @@ namespace
 	serial::xml_parser_utils::AssetLoaders createMockLoaders()
 	{
 		serial::xml_parser_utils::AssetLoaders loaders;
-		loaders.loadWaveform =
-			[](const std::string& name, const std::filesystem::path&, RealType power, RealType carrierFreq, SimId id)
+		loaders.loadWaveform = [](const std::string& name, const std::filesystem::path&, RealType power,
+								  RealType carrierFreq, SimId id, const fers_signal::FileWaveformKind kind)
 		{
-			auto sig = std::make_unique<fers_signal::CwSignal>();
+			auto sig = std::make_unique<fers_signal::FileSignal>(kind);
 			return std::make_unique<fers_signal::RadarSignal>(name, power, carrierFreq, 1.0, std::move(sig), id);
 		};
 		loaders.loadXmlAntenna = [](const std::string& name, const std::string&, SimId id)
@@ -356,6 +356,28 @@ TEST_CASE("parseWaveform handles CW and delegates file loading", "[serial][xml_p
 		serial::xml_parser_utils::parseWaveform(doc.getRootElement(), ctx);
 		REQUIRE(world.getWaveforms().size() == 1);
 		REQUIRE(world.getWaveforms().begin()->second->getName() == "p1");
+	}
+
+	SECTION("CW from file")
+	{
+		auto doc = loadXml("<waveform name=\"cw-file\"><power>5</power><carrier_frequency>2e9</carrier_frequency>"
+						   "<cw_from_file filename=\"dummy.h5\"/></waveform>");
+		serial::xml_parser_utils::parseWaveform(doc.getRootElement(), ctx);
+		const auto* wave = world.getWaveforms().begin()->second.get();
+		REQUIRE(wave->isCw());
+		REQUIRE(wave->getFileSignal() != nullptr);
+		REQUIRE(wave->getFileSignal()->getKind() == fers_signal::FileWaveformKind::Cw);
+	}
+
+	SECTION("FMCW from file")
+	{
+		auto doc = loadXml("<waveform name=\"fmcw-file\"><power>5</power><carrier_frequency>2e9</carrier_frequency>"
+						   "<fmcw_from_file filename=\"dummy.h5\"/></waveform>");
+		serial::xml_parser_utils::parseWaveform(doc.getRootElement(), ctx);
+		const auto* wave = world.getWaveforms().begin()->second.get();
+		REQUIRE(wave->isFmcwFamily());
+		REQUIRE(wave->getFileSignal() != nullptr);
+		REQUIRE(wave->getFileSignal()->getKind() == fers_signal::FileWaveformKind::Fmcw);
 	}
 }
 

--- a/packages/libfers/tests/serial/test_xml_serializer.cpp
+++ b/packages/libfers/tests/serial/test_xml_serializer.cpp
@@ -399,7 +399,7 @@ TEST_CASE("serializeRotation translates internal math to compass correctly", "[s
 
 	SECTION("Default/Unknown")
 	{
-		rot.setInterp(static_cast<math::RotationPath::InterpType>(999));
+		rot.setInterp(static_cast<math::RotationPath::InterpType>(255));
 		serial::xml_serializer_utils::serializeRotation(rot, root);
 		std::string s = dumpElement(root);
 		REQUIRE_THAT(s, ContainsSubstring("<rotationpath/>"));

--- a/packages/libfers/tests/serial/test_xml_serializer.cpp
+++ b/packages/libfers/tests/serial/test_xml_serializer.cpp
@@ -172,6 +172,24 @@ TEST_CASE("serializeWaveform processes CW and Pulsed correctly", "[serial][xml_s
 		std::string s = dumpElement(root);
 		REQUIRE_THAT(s, ContainsSubstring("<pulsed_from_file filename=\"\"/>"));
 	}
+
+	SECTION("CW file")
+	{
+		auto sig = std::make_unique<fers_signal::FileSignal>(fers_signal::FileWaveformKind::Cw);
+		fers_signal::RadarSignal wave("cw-file", 20.0, 2e9, 1.0, std::move(sig));
+		wave.setFilename("cw.h5");
+		serial::xml_serializer_utils::serializeWaveform(wave, root);
+		REQUIRE_THAT(dumpElement(root), ContainsSubstring("<cw_from_file filename=\"cw.h5\"/>"));
+	}
+
+	SECTION("FMCW file")
+	{
+		auto sig = std::make_unique<fers_signal::FileSignal>(fers_signal::FileWaveformKind::Fmcw);
+		fers_signal::RadarSignal wave("fmcw-file", 20.0, 2e9, 1.0, std::move(sig));
+		wave.setFilename("fmcw.h5");
+		serial::xml_serializer_utils::serializeWaveform(wave, root);
+		REQUIRE_THAT(dumpElement(root), ContainsSubstring("<fmcw_from_file filename=\"fmcw.h5\"/>"));
+	}
 }
 
 TEST_CASE("serializeWaveform round trips FMCW linear chirp direction", "[serial][xml_serializer][fmcw]")

--- a/packages/libfers/tests/signal/test_radar_signal.cpp
+++ b/packages/libfers/tests/signal/test_radar_signal.cpp
@@ -55,6 +55,53 @@ TEST_CASE("CwSignal render returns empty data", "[signal][radar][cw]")
 	REQUIRE(size == 0);
 }
 
+TEST_CASE("FileSignal preserves radar-mode identity", "[signal][radar][file]")
+{
+	auto cw_signal = std::make_unique<fers_signal::FileSignal>(fers_signal::FileWaveformKind::Cw);
+	cw_signal->load(std::vector<ComplexType>{{1.0, 0.0}}, 1, 8.0);
+	fers_signal::RadarSignal const cw("cw-file", 1.0, 10.0, 0.125, std::move(cw_signal), 1);
+
+	auto fmcw_signal = std::make_unique<fers_signal::FileSignal>(fers_signal::FileWaveformKind::Fmcw);
+	fmcw_signal->load(std::vector<ComplexType>{{1.0, 0.0}}, 1, 8.0);
+	fers_signal::RadarSignal const fmcw("fmcw-file", 1.0, 10.0, 0.125, std::move(fmcw_signal), 2);
+
+	REQUIRE(cw.isCw());
+	REQUIRE_FALSE(cw.isFmcwFamily());
+	REQUIRE(cw.getFileSignal()->getKind() == fers_signal::FileWaveformKind::Cw);
+	REQUIRE_FALSE(fmcw.isCw());
+	REQUIRE(fmcw.isFmcwFamily());
+	REQUIRE(fmcw.getFileSignal()->getKind() == fers_signal::FileWaveformKind::Fmcw);
+}
+
+TEST_CASE("FileSignal interpolates a finite complex envelope without wrapping", "[signal][radar][file][hdf5]")
+{
+	ParamGuard const guard;
+	params::setOversampleRatio(1);
+	constexpr RealType rate = 32.0;
+	constexpr unsigned sample_count = 64;
+	std::vector<ComplexType> samples(sample_count);
+	for (unsigned i = 0; i < sample_count; ++i)
+	{
+		const RealType phase = 2.0 * PI * 3.0 * static_cast<RealType>(i) / rate;
+		samples[i] = {std::cos(phase), std::sin(phase)};
+	}
+
+	fers_signal::FileSignal signal(fers_signal::FileWaveformKind::Fmcw);
+	signal.load(samples, sample_count, rate);
+	const RealType duration = static_cast<RealType>(sample_count) / rate;
+	const RealType sample_time = 0.3125;
+	const auto first = signal.sampleAt(sample_time);
+	const auto at_end = signal.sampleAt(duration);
+	const auto after_end = signal.sampleAt(sample_time + duration);
+	const auto negative = signal.sampleAt(-sample_time);
+
+	REQUIRE_THAT(std::abs(first), WithinAbs(1.0, 1e-6));
+	REQUIRE_THAT(std::arg(first), WithinAbs(std::remainder(2.0 * PI * 3.0 * sample_time, 2.0 * PI), 1e-6));
+	REQUIRE((at_end == ComplexType{0.0, 0.0}));
+	REQUIRE((after_end == ComplexType{0.0, 0.0}));
+	REQUIRE((negative == ComplexType{0.0, 0.0}));
+}
+
 TEST_CASE("RadarSignal requires a signal", "[signal][radar]")
 {
 	REQUIRE_THROWS_AS(fers_signal::RadarSignal("test", 1.0, 1.0, 1.0, std::unique_ptr<fers_signal::Signal>{}, 0),

--- a/packages/libfers/tests/simulation/test_channel_model_direct.cpp
+++ b/packages/libfers/tests/simulation/test_channel_model_direct.cpp
@@ -526,6 +526,95 @@ TEST_CASE("CW streaming direct path gates schedules by retarded transmit time", 
 			0.0);
 }
 
+TEST_CASE("File streaming reference follows finite HDF5-style samples for CW and FMCW",
+		  "[simulation][channel_model][direct][file][hdf5]")
+{
+	ParamGuard const guard;
+	params::params.reset();
+	params::setOversampleRatio(1);
+	constexpr RealType rate = 32.0;
+	constexpr unsigned sample_count = 64;
+	constexpr RealType baseband_frequency = 3.0;
+	constexpr RealType carrier = 5.0;
+	std::vector<ComplexType> samples(sample_count);
+	for (unsigned i = 0; i < sample_count; ++i)
+	{
+		const RealType phase = 2.0 * PI * baseband_frequency * static_cast<RealType>(i) / rate;
+		samples[i] = {std::cos(phase), std::sin(phase)};
+	}
+
+	for (const auto kind : {fers_signal::FileWaveformKind::Cw, fers_signal::FileWaveformKind::Fmcw})
+	{
+		auto signal = std::make_unique<fers_signal::FileSignal>(kind);
+		signal->load(samples, sample_count, rate);
+		fers_signal::RadarSignal const waveform("file", 4.0, carrier, 2.0, std::move(signal));
+		const auto source = core::makeActiveSourceFromWaveform(&waveform, 0.25, 5.0);
+		const RealType local_time = 0.3125;
+		ComplexType first{};
+		ComplexType after_end{};
+		REQUIRE(simulation::calculateStreamingReferenceSample(source, 0.25 + local_time, nullptr, first));
+		REQUIRE_FALSE(
+			simulation::calculateStreamingReferenceSample(source, 0.25 + local_time + 2.0, nullptr, after_end));
+		const RealType expected_phase = 2.0 * PI * baseband_frequency * local_time;
+		const ComplexType expected = std::polar(1.0, expected_phase);
+		REQUIRE_THAT(first.real(), WithinAbs(expected.real(), 1e-6));
+		REQUIRE_THAT(first.imag(), WithinAbs(expected.imag(), 1e-6));
+		REQUIRE((after_end == ComplexType{0.0, 0.0}));
+		REQUIRE_THAT(source.segment_end, WithinAbs(2.25, 1e-12));
+	}
+}
+
+TEST_CASE("File CW direct path samples the complex envelope at retarded transmit time",
+		  "[simulation][channel_model][direct][file]")
+{
+	ParamGuard const guard;
+	params::params.reset();
+	params::setC(100.0);
+	params::setOversampleRatio(1);
+	constexpr RealType rate = 32.0;
+	constexpr RealType tone = 3.0;
+	constexpr unsigned sample_count = 64;
+	std::vector<ComplexType> samples(sample_count);
+	for (unsigned i = 0; i < sample_count; ++i)
+	{
+		const RealType phase = 2.0 * PI * tone * static_cast<RealType>(i) / rate;
+		samples[i] = std::polar(1.0, phase);
+	}
+
+	radar::Platform tx_platform("tx-platform");
+	setupPlatform(tx_platform, math::Vec3{0.0, 0.0, 0.0});
+	radar::Platform rx_platform("rx-platform");
+	setupPlatform(rx_platform, math::Vec3{10.0, 0.0, 0.0});
+	antenna::Isotropic antenna("isotropic");
+	auto clock = std::make_shared<timing::Timing>("clock", 42);
+	radar::Transmitter tx(&tx_platform, "tx", radar::OperationMode::CW_MODE);
+	tx.setAntenna(&antenna);
+	tx.setTiming(clock);
+	auto signal = std::make_unique<fers_signal::FileSignal>(fers_signal::FileWaveformKind::Cw);
+	signal->load(samples, sample_count, rate);
+	fers_signal::RadarSignal waveform("file-cw", 4.0, 10.0, 2.0, std::move(signal));
+	tx.setSignal(&waveform);
+	radar::Receiver rx(&rx_platform, "rx", 43, radar::OperationMode::CW_MODE);
+	rx.setAntenna(&antenna);
+	rx.setTiming(clock);
+
+	const auto source = core::makeActiveSource(&tx, 0.0, 5.0);
+	const RealType delay = 10.0 / params::c();
+	const RealType first_local_time = 0.3125;
+	const ComplexType first =
+		simulation::calculateStreamingDirectPathContribution(source, &rx, delay + first_local_time);
+	const ComplexType next =
+		simulation::calculateStreamingDirectPathContribution(source, &rx, delay + first_local_time + 1.0 / rate);
+	const ComplexType after_end =
+		simulation::calculateStreamingDirectPathContribution(source, &rx, delay + first_local_time + 2.0);
+
+	REQUIRE(std::abs(first) > 0.0);
+	REQUIRE_THAT(std::abs(next / first), WithinAbs(1.0, 1e-6));
+	REQUIRE_THAT(std::arg(next / first), WithinAbs(2.0 * PI * tone / rate, 1e-6));
+	REQUIRE(std::abs(after_end) == 0.0);
+	REQUIRE_THAT(source.segment_end, WithinAbs(2.0, 1e-12));
+}
+
 TEST_CASE("FMCW streaming direct path keeps chirp cache per source", "[simulation][channel_model][direct][fmcw]")
 {
 	ParamGuard const guard;

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -26,6 +26,10 @@ by scenario documents.
 - **Target-RCS XML assets** are loaded by `libfers` according to the `target-rcs` structure. The schemas are provided for
   user/tool validation of those standalone assets.
 
+Scenario waveform choices include `<pulsed_from_file>`, `<cw_from_file>`, and `<fmcw_from_file>`. CW and FMCW file
+variants require the pulsed-compatible HDF5 layout with `/I/value` and `/Q/value`; pulsed file input also retains legacy
+CSV support.
+
 During the build process of the `libfers` package, the scenario and antenna-pattern schema files are converted into C
 header files and embedded directly into the library binary. This ensures that the simulator always has access to those
 schema versions for validation without relying on external files. The target-RCS schemas are provided for standalone

--- a/packages/schema/fers-xml.dtd
+++ b/packages/schema/fers-xml.dtd
@@ -47,7 +47,7 @@
                 >
 
         <!-- Waveform definition -->
-        <!ELEMENT waveform (power, carrier_frequency, (pulsed_from_file | cw | fmcw_linear_chirp | fmcw_triangle | stepped_frequency))>
+        <!ELEMENT waveform (power, carrier_frequency, (pulsed_from_file | cw_from_file | fmcw_from_file | cw | fmcw_linear_chirp | fmcw_triangle | stepped_frequency))>
         <!ATTLIST waveform
                 name CDATA #REQUIRED>
 
@@ -60,6 +60,10 @@
         <!-- Waveform types -->
         <!ELEMENT pulsed_from_file EMPTY>
         <!ATTLIST pulsed_from_file filename CDATA #REQUIRED>
+        <!ELEMENT cw_from_file EMPTY>
+        <!ATTLIST cw_from_file filename CDATA #REQUIRED>
+        <!ELEMENT fmcw_from_file EMPTY>
+        <!ATTLIST fmcw_from_file filename CDATA #REQUIRED>
         <!ELEMENT cw EMPTY>
         <!ELEMENT fmcw_linear_chirp (chirp_bandwidth, chirp_duration, chirp_period, start_frequency_offset?, chirp_count?)>
         <!ATTLIST fmcw_linear_chirp direction (up|down) #REQUIRED>

--- a/packages/schema/fers-xml.xsd
+++ b/packages/schema/fers-xml.xsd
@@ -101,6 +101,16 @@
                             <xs:attribute name="filename" type="xs:string" use="required"/>
                         </xs:complexType>
                     </xs:element>
+                    <xs:element name="cw_from_file">
+                        <xs:complexType>
+                            <xs:attribute name="filename" type="xs:string" use="required"/>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="fmcw_from_file">
+                        <xs:complexType>
+                            <xs:attribute name="filename" type="xs:string" use="required"/>
+                        </xs:complexType>
+                    </xs:element>
                     <xs:element name="cw">
                         <xs:complexType/>
                     </xs:element>

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+profile = "minimal"


### PR DESCRIPTION
This pull request adds first-class HDF5 file input for CW and FMCW waveforms across the simulation core, XML and JSON scenario formats, output metadata, FERS-UI authoring flow, documentation, and tests. File loading is now the primary CW/FMCW authoring path, while generated CW tones and analytic FMCW chirps remain available as alternatives.

### Key Changes

**1. Native File-Backed CW and FMCW Support**

* Added `<cw_from_file>` and `<fmcw_from_file>` waveform variants using the existing pulsed-compatible HDF5 layout: real samples in `/I/value` and imaginary samples in `/Q/value`.
* Added explicit file-waveform mode identity so sampled waveforms participate correctly in CW and FMCW transmitter, receiver, and dechirp flows.
* Restricted new CW and FMCW file inputs to HDF5 while retaining existing CSV/HDF5 behavior for pulsed waveforms.
* Preserved parameter-generated `<cw/>`, `<fmcw_linear_chirp>`, and `<fmcw_triangle>` waveforms as optional generated alternatives.

**2. Finite Sampled-Waveform Physics**

* Samples file-backed complex envelopes at retarded transmit time using the simulator's interpolation filter for direct and reflected paths.
* Treats each HDF5 waveform as a finite sampled timeline at the scenario rate, clamps active streaming segments to the file duration, and returns zero before the first sample or after the final sample without implicit wrapping.
* Applies waveform power and RF carrier propagation to the complete sampled complex envelope, preserving arbitrary phase and amplitude modulation from the source file.
* Updated FMCW dechirping to mix against the same finite complex reference samples instead of a phase-only analytic reference, preserving coherence for arbitrary sampled sweeps.

**3. Schema, Serialization, and Output Metadata**

* Extended the DTD and XSD waveform unions with `cw_from_file` and `fmcw_from_file`.
* Added XML and JSON parsing, serialization, round-trip support, relative-path resolution, and waveform-mode compatibility for both variants.
* Added file-backed FMCW output metadata with `waveform_shape: "file"`, sampled duration, and sampled count.
* Avoided reporting inferred analytic chirp direction, bandwidth, period, or emitted chirp counts for arbitrary sampled FMCW files.

**4. FERS-UI Authoring and Display**

* Added CW File and FMCW File authoring choices ahead of generated waveform options, making file loading the primary UI workflow.
* Added HDF5-only file selection and filename validation for CW/FMCW file variants.
* Extended waveform defaults, hydration, serialization, inspector controls, radar-mode compatibility, link visualization, and output metadata display.
* Excluded file-backed FMCW waveforms from analytic chirp constraints that cannot be inferred from arbitrary samples.

**5. Documentation and Regression Coverage**

* Updated the UI guide, usage guide, and XML schema reference with the new elements, shared HDF5 layout, finite playback behavior, and generated-waveform alternatives.
* Added core tests for finite interpolation, zero padding, waveform identity, retarded-time direct-path sampling, file-backed FMCW references, and metadata.
* Added parser, serializer, factory, schema, relative-path, and HDF5 validation coverage, including rejection of legacy CSV input for CW/FMCW.
* Added API runtime coverage that executes both HDF5-backed CW and FMCW scenarios end to end and inspects the emitted receiver data and FMCW metadata.
* Added UI tests for file-first choices, defaults, visible fields, validation, hydration, serialization, and file-backed FMCW behavior.

### Validation

* C++ regression suite: 634/634 tests passed.
* UI regression suite: 111/111 tests passed.
* Focused file-waveform suite: 4 cases and 64 assertions passed.
* HDF5-tagged suite: 19 cases and 140 assertions passed.
* C++ ASan and release builds passed.
* UI production build, lint, and formatting checks passed.