### PR TITLE
test(vita49): remove scheduler timing assumptions

### DIFF
--- a/packages/libfers/tests/serial/test_vita49.cpp
+++ b/packages/libfers/tests/serial/test_vita49.cpp
@@ -920,10 +920,6 @@ TEST_CASE("VITA paced sender preempts a later deadline when an earlier packet ar
 	REQUIRE(recording_raw->sent.size() == 2u);
 	CHECK(recording_raw->sent.at(0).back() == 1u);
 	CHECK(recording_raw->sent.at(1).back() == 2u);
-	CHECK(sender.lateDataPacketCount(1) == 0u);
-	CHECK(sender.lateDataPacketCount(2) == 0u);
-	CHECK(sender.lateContextPacketCount(1) == 0u);
-	CHECK(sender.lateContextPacketCount(2) == 0u);
 }
 
 TEST_CASE("VITA paced sender admits an earlier deadline through saturated backpressure",
@@ -956,10 +952,6 @@ TEST_CASE("VITA paced sender admits an earlier deadline through saturated backpr
 	REQUIRE(recording_raw->sent.size() == 2u);
 	CHECK(recording_raw->sent.at(0).back() == 1u);
 	CHECK(recording_raw->sent.at(1).back() == 2u);
-	CHECK(sender.lateDataPacketCount(1) == 0u);
-	CHECK(sender.lateDataPacketCount(2) == 0u);
-	CHECK(sender.lateContextPacketCount(1) == 0u);
-	CHECK(sender.lateContextPacketCount(2) == 0u);
 }
 
 TEST_CASE("VITA paced sender preserves insertion order for equal deadlines", "[serial][vita49][ordering]")
@@ -1605,11 +1597,6 @@ TEST_CASE("VITA output sink deadline-merges synchronized receiver blocks under s
 	CHECK(data_stream_ids.at(0) == data_stream_ids.at(4));
 	CHECK(data_stream_ids.at(1) == data_stream_ids.at(5));
 	REQUIRE(stats.streams.size() == 2u);
-	CAPTURE(stats.streams.at(0).late_data_packet_count, stats.streams.at(1).late_data_packet_count,
-			stats.streams.at(0).late_context_packet_count, stats.streams.at(1).late_context_packet_count);
-	CHECK(std::ranges::all_of(stats.streams, [](const auto& stream) { return stream.late_data_packet_count == 0u; }));
-	CHECK(
-		std::ranges::all_of(stats.streams, [](const auto& stream) { return stream.late_context_packet_count <= 1u; }));
 	CHECK(std::ranges::all_of(stats.streams, [](const auto& stream) { return stream.packets_dropped == 0u; }));
 }
 


### PR DESCRIPTION
Fixes some environment specific timing assumptions which fail on windows and macos CI.